### PR TITLE
Add a 'browser' field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "cqm-models",
   "version": "0.0.1",
   "description": "",
-  "main": "/dist/index.js",
+  "main": "./app/assets/javascripts/index.js",
+  "browser": "./dist/index.js",
   "repository": "https://github.com/projecttacoma/cqm-models.git",
   "homepage": "https://github.com/projectcypress/cqm-models#readme",
   "contributors": [


### PR DESCRIPTION
This tells client-side code where to find the browser-specific entrypoint into the lib, while nodeJS can use the actual module.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/TACO-35
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A

**Reviewer 1:** Louis Ades

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
