### PR TITLE
Added measure/valueset fixtures

### DIFF
--- a/spec/fixtures/measures/cms158v6.json
+++ b/spec/fixtures/measures/cms158v6.json
@@ -1,0 +1,5097 @@
+{
+  "_id": {
+    "$oid": "5a57eb37942c6d1e61d33813"
+  },
+  "bundle_id": "5a57e977942c6d1e61d32f14",
+  "category": "Miscellaneous",
+  "cms_id": "CMS158v6",
+  "complexity": {
+    "variables": [
+      {
+        "name": "Patient",
+        "complexity": 1
+      },
+      {
+        "name": "SDE Ethnicity",
+        "complexity": 1
+      },
+      {
+        "name": "SDE Payer",
+        "complexity": 1
+      },
+      {
+        "name": "SDE Race",
+        "complexity": 1
+      },
+      {
+        "name": "SDE Sex",
+        "complexity": 1
+      },
+      {
+        "name": "Most Recent Delivery",
+        "complexity": 1
+      },
+      {
+        "name": "Most Recent Delivery Overlaps Diagnosis",
+        "complexity": 1
+      },
+      {
+        "name": "Denominator Exceptions",
+        "complexity": 1
+      },
+      {
+        "name": "Initial Population",
+        "complexity": 3
+      },
+      {
+        "name": "Numerator",
+        "complexity": 1
+      },
+      {
+        "name": "Denominator",
+        "complexity": 1
+      }
+    ]
+  },
+  "continuous_variable": false,
+  "cql": [
+    "library PregnantwomenthathadHBsAgtesting version '6.0.001'\r\n\r\nusing QDM version '5.3'\r\n\r\nvalueset \"ONC Administrative Sex\": 'urn:oid:2.16.840.1.113762.1.4.1'\r\nvalueset \"Race\": 'urn:oid:2.16.840.1.114222.4.11.836'\r\nvalueset \"Ethnicity\": 'urn:oid:2.16.840.1.114222.4.11.837'\r\nvalueset \"Payer\": 'urn:oid:2.16.840.1.114222.4.11.3591'\r\nvalueset \"Delivery - Diagnosis\": 'urn:oid:2.16.840.1.113883.3.67.1.101.1.278'\r\nvalueset \"Delivery - Procedure\": 'urn:oid:2.16.840.1.113762.1.4.1078.5'\r\nvalueset \"Female\": 'urn:oid:2.16.840.1.113883.3.560.100.2'\r\nvalueset \"HBsAg\": 'urn:oid:2.16.840.1.113883.3.67.1.101.1.279'\r\nvalueset \"Hepatitis B\": 'urn:oid:2.16.840.1.113883.3.67.1.101.1.269'\r\n\r\nparameter \"Measurement Period\" Interval<DateTime>\r\n\r\ncontext Patient\r\n\r\ndefine \"SDE Ethnicity\":\r\n\t[\"Patient Characteristic Ethnicity\": \"Ethnicity\"]\r\n\r\ndefine \"SDE Payer\":\r\n\t[\"Patient Characteristic Payer\": \"Payer\"]\r\n\r\ndefine \"SDE Race\":\r\n\t[\"Patient Characteristic Race\": \"Race\"]\r\n\r\ndefine \"SDE Sex\":\r\n\t[\"Patient Characteristic Sex\": \"ONC Administrative Sex\"]\r\n\r\ndefine \"Most Recent Delivery\":\r\n\tLast([\"Procedure, Performed\": \"Delivery - Procedure\"] DeliveryProcedure\r\n\t\t\twhere DeliveryProcedure.relevantPeriod during \"Measurement Period\"\r\n\t\t\tsort by start of relevantPeriod\r\n\t)\r\n\r\ndefine \"Denominator Exceptions\":\r\n\texists ( [\"Diagnosis\": \"Hepatitis B\"] HepB\r\n\t\t\twith \"Most Recent Delivery Overlaps Diagnosis\" DeliveryOverlapsDiagnosis\r\n\t\t\t\tsuch that HepB.prevalencePeriod starts 365 days or less before start of DeliveryOverlapsDiagnosis.relevantPeriod\r\n\t\t\t\t\tor HepB.prevalencePeriod ends 365 days or less before start of DeliveryOverlapsDiagnosis.relevantPeriod\r\n\t)\r\n\r\ndefine \"Most Recent Delivery Overlaps Diagnosis\":\r\n\t\"Most Recent Delivery\" MostRecentDelivery\r\n\t\twhere exists ( [\"Diagnosis\": \"Delivery - Diagnosis\"] DeliveryDiagnosis\r\n\t\t\t\twhere MostRecentDelivery.relevantPeriod overlaps DeliveryDiagnosis.prevalencePeriod\r\n\t\t)\r\n\r\ndefine \"Initial Population\":\r\n\t\"Most Recent Delivery Overlaps Diagnosis\" is not null\r\n\t\tand AgeInYearsAt(start of \"Measurement Period\")>= 12\r\n\t\tand exists ( [\"Patient Characteristic Sex\": \"Female\"] )\r\n\r\ndefine \"Numerator\":\r\n\texists ( [\"Laboratory Test, Performed\": \"HBsAg\"] LabTest\r\n\t\t\twith \"Most Recent Delivery Overlaps Diagnosis\" DeliveryOverlapsDiagnosis\r\n\t\t\t\tsuch that LabTest.relevantPeriod starts 280 days or less before start of DeliveryOverlapsDiagnosis.relevantPeriod\r\n\t)\r\n\r\ndefine \"Denominator\":\r\n\t\"Initial Population\"\r\n"
+  ],
+  "cql_statement_dependencies": {
+    "PregnantwomenthathadHBsAgtesting": {
+      "Patient": [],
+      "SDE Ethnicity": [],
+      "SDE Payer": [],
+      "SDE Race": [],
+      "SDE Sex": [],
+      "Most Recent Delivery": [],
+      "Most Recent Delivery Overlaps Diagnosis": [
+        {
+          "library_name": "PregnantwomenthathadHBsAgtesting",
+          "statement_name": "Most Recent Delivery"
+        }
+      ],
+      "Denominator Exceptions": [
+        {
+          "library_name": "PregnantwomenthathadHBsAgtesting",
+          "statement_name": "Most Recent Delivery Overlaps Diagnosis"
+        }
+      ],
+      "Initial Population": [
+        {
+          "library_name": "PregnantwomenthathadHBsAgtesting",
+          "statement_name": "Most Recent Delivery Overlaps Diagnosis"
+        }
+      ],
+      "Numerator": [
+        {
+          "library_name": "PregnantwomenthathadHBsAgtesting",
+          "statement_name": "Most Recent Delivery Overlaps Diagnosis"
+        }
+      ],
+      "Denominator": [
+        {
+          "library_name": "PregnantwomenthathadHBsAgtesting",
+          "statement_name": "Initial Population"
+        }
+      ]
+    }
+  },
+  "created_at": "2018-01-11T22:54:47.980Z",
+  "data_criteria": {
+    "Payer_PatientCharacteristicPayer_db378f80_d372_4017_830b_17befc5e45d2": {
+      "title": "Payer",
+      "description": "Patient Characteristic Payer: Payer",
+      "code_list_id": "2.16.840.1.114222.4.11.3591",
+      "property": "payer",
+      "type": "characteristic",
+      "definition": "patient_characteristic_payer",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Payer_PatientCharacteristicPayer_db378f80_d372_4017_830b_17befc5e45d2_source",
+      "variable": false,
+      "inline_code_list": {
+        "Source of Payment Typology": [
+          "1",
+          "11",
+          "111",
+          "112",
+          "113",
+          "119",
+          "12",
+          "121",
+          "122",
+          "123",
+          "129",
+          "13",
+          "14",
+          "19",
+          "191",
+          "2",
+          "21",
+          "211",
+          "212",
+          "213",
+          "219",
+          "22",
+          "23",
+          "24",
+          "25",
+          "26",
+          "29",
+          "291",
+          "3",
+          "31",
+          "311",
+          "3111",
+          "3112",
+          "3113",
+          "3114",
+          "3115",
+          "3116",
+          "3119",
+          "312",
+          "3121",
+          "3122",
+          "3123",
+          "313",
+          "32",
+          "321",
+          "3211",
+          "3212",
+          "32121",
+          "32122",
+          "32123",
+          "32124",
+          "32125",
+          "32126",
+          "322",
+          "3221",
+          "3222",
+          "3223",
+          "3229",
+          "33",
+          "331",
+          "332",
+          "333",
+          "334",
+          "34",
+          "341",
+          "342",
+          "343",
+          "349",
+          "35",
+          "36",
+          "361",
+          "362",
+          "369",
+          "37",
+          "371",
+          "3711",
+          "3712",
+          "3713",
+          "372",
+          "379",
+          "38",
+          "381",
+          "3811",
+          "3812",
+          "3813",
+          "3819",
+          "382",
+          "389",
+          "39",
+          "4",
+          "41",
+          "42",
+          "43",
+          "44",
+          "5",
+          "51",
+          "511",
+          "512",
+          "513",
+          "514",
+          "515",
+          "516",
+          "519",
+          "52",
+          "521",
+          "522",
+          "523",
+          "529",
+          "53",
+          "54",
+          "55",
+          "56",
+          "561",
+          "562",
+          "59",
+          "6",
+          "61",
+          "611",
+          "612",
+          "613",
+          "619",
+          "62",
+          "63",
+          "64",
+          "69",
+          "7",
+          "71",
+          "72",
+          "73",
+          "79",
+          "8",
+          "81",
+          "82",
+          "821",
+          "822",
+          "823",
+          "83",
+          "84",
+          "85",
+          "89",
+          "9",
+          "91",
+          "92",
+          "93",
+          "94",
+          "95",
+          "951",
+          "953",
+          "954",
+          "959",
+          "96",
+          "97",
+          "98",
+          "99",
+          "9999"
+        ]
+      }
+    },
+    "Ethnicity_PatientCharacteristicEthnicity_0a1eb113_68c5_4e81_ba8c_03e4541fd752": {
+      "title": "Ethnicity",
+      "description": "Patient Characteristic Ethnicity: Ethnicity",
+      "code_list_id": "2.16.840.1.114222.4.11.837",
+      "property": "ethnicity",
+      "type": "characteristic",
+      "definition": "patient_characteristic_ethnicity",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Ethnicity_PatientCharacteristicEthnicity_0a1eb113_68c5_4e81_ba8c_03e4541fd752_source",
+      "variable": false,
+      "inline_code_list": {
+        "CDC Race": [
+          "2135-2",
+          "2186-5"
+        ]
+      }
+    },
+    "ONCAdministrativeSex_PatientCharacteristicSex_ca6fb067_270a_43f8_9849_a197b20702a6": {
+      "title": "ONCAdministrativeSex",
+      "description": "Patient Characteristic Sex: ONCAdministrativeSex",
+      "code_list_id": "2.16.840.1.113762.1.4.1",
+      "property": "gender",
+      "type": "characteristic",
+      "definition": "patient_characteristic_gender",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "ONCAdministrativeSex_PatientCharacteristicSex_ca6fb067_270a_43f8_9849_a197b20702a6_source",
+      "variable": false,
+      "value": {
+        "type": "CD",
+        "system": "Administrative Sex",
+        "code": "F"
+      }
+    },
+    "Race_PatientCharacteristicRace_7b1d6697_e04e_4af8_baa8_4abb48e8366c": {
+      "title": "Race",
+      "description": "Patient Characteristic Race: Race",
+      "code_list_id": "2.16.840.1.114222.4.11.836",
+      "property": "race",
+      "type": "characteristic",
+      "definition": "patient_characteristic_race",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Race_PatientCharacteristicRace_7b1d6697_e04e_4af8_baa8_4abb48e8366c_source",
+      "variable": false,
+      "inline_code_list": {
+        "CDC Race": [
+          "1002-5",
+          "2028-9",
+          "2054-5",
+          "2076-8",
+          "2106-3",
+          "2131-1"
+        ]
+      }
+    },
+    "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890": {
+      "title": "Delivery-Procedure",
+      "description": "Procedure, Performed: Delivery-Procedure",
+      "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+      "type": "procedures",
+      "definition": "procedure",
+      "status": "performed",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+      "variable": false
+    },
+    "Female_PatientCharacteristicSex_40280381_3d61_56a7_013e_7f3878ec7633": {
+      "title": "Female",
+      "description": "Patient Characteristic Sex: Female",
+      "code_list_id": "2.16.840.1.113883.3.560.100.2",
+      "property": "gender",
+      "type": "characteristic",
+      "definition": "patient_characteristic_gender",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Female_PatientCharacteristicSex_40280381_3d61_56a7_013e_7f3878ec7633_source",
+      "variable": false,
+      "value": {
+        "type": "CD",
+        "system": "Administrative Sex",
+        "code": "F"
+      }
+    },
+    "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630": {
+      "title": "HBsAg",
+      "description": "Laboratory Test, Performed: HBsAg",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+      "type": "laboratory_tests",
+      "definition": "laboratory_test",
+      "status": "performed",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+      "variable": false
+    },
+    "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434": {
+      "title": "Delivery-Diagnosis",
+      "description": "Diagnosis: Delivery-Diagnosis",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+      "type": "conditions",
+      "definition": "diagnosis",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+      "variable": false
+    },
+    "HepatitisB_Diagnosis_40280381_3d61_56a7_013e_7f3878ec7631": {
+      "title": "HepatitisB",
+      "description": "Diagnosis: HepatitisB",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.269",
+      "type": "conditions",
+      "definition": "diagnosis",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "HepatitisB_Diagnosis_40280381_3d61_56a7_013e_7f3878ec7631_source",
+      "variable": false
+    }
+  },
+  "description": "This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy",
+  "elm": [
+    {
+      "library": {
+        "identifier": {
+          "id": "PregnantwomenthathadHBsAgtesting",
+          "version": "6.0.001"
+        },
+        "schemaIdentifier": {
+          "id": "urn:hl7-org:elm",
+          "version": "r1"
+        },
+        "usings": {
+          "def": [
+            {
+              "localIdentifier": "System",
+              "uri": "urn:hl7-org:elm-types:r1"
+            },
+            {
+              "localId": "1",
+              "locator": "3:1-3:23",
+              "localIdentifier": "QDM",
+              "uri": "urn:healthit-gov:qdm:v5_3",
+              "version": "5.3"
+            }
+          ]
+        },
+        "parameters": {
+          "def": [
+            {
+              "localId": "13",
+              "locator": "17:1-17:49",
+              "name": "Measurement Period",
+              "accessLevel": "Public",
+              "parameterTypeSpecifier": {
+                "localId": "12",
+                "locator": "17:32-17:49",
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "localId": "11",
+                  "locator": "17:41-17:48",
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          ]
+        },
+        "valueSets": {
+          "def": [
+            {
+              "localId": "2",
+              "locator": "6:1-6:68",
+              "name": "ONC Administrative Sex",
+              "id": "2.16.840.1.113762.1.4.1",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "3",
+              "locator": "7:1-7:53",
+              "name": "Race",
+              "id": "2.16.840.1.114222.4.11.836",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "4",
+              "locator": "8:1-8:58",
+              "name": "Ethnicity",
+              "id": "2.16.840.1.114222.4.11.837",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "5",
+              "locator": "9:1-9:55",
+              "name": "Payer",
+              "id": "2.16.840.1.114222.4.11.3591",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "6",
+              "locator": "10:1-10:77",
+              "name": "Delivery - Diagnosis",
+              "id": "2.16.840.1.113883.3.67.1.101.1.278",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "7",
+              "locator": "11:1-11:71",
+              "name": "Delivery - Procedure",
+              "id": "2.16.840.1.113762.1.4.1078.5",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "8",
+              "locator": "12:1-12:58",
+              "name": "Female",
+              "id": "2.16.840.1.113883.3.560.100.2",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "9",
+              "locator": "13:1-13:62",
+              "name": "HBsAg",
+              "id": "2.16.840.1.113883.3.67.1.101.1.279",
+              "accessLevel": "Public"
+            },
+            {
+              "localId": "10",
+              "locator": "14:1-14:68",
+              "name": "Hepatitis B",
+              "id": "2.16.840.1.113883.3.67.1.101.1.269",
+              "accessLevel": "Public"
+            }
+          ]
+        },
+        "statements": {
+          "def": [
+            {
+              "locator": "19:1-19:15",
+              "name": "Patient",
+              "context": "Patient",
+              "expression": {
+                "type": "SingletonFrom",
+                "operand": {
+                  "locator": "19:1-19:15",
+                  "dataType": "{urn:healthit-gov:qdm:v5_3}Patient",
+                  "templateId": "Patient",
+                  "type": "Retrieve"
+                }
+              }
+            },
+            {
+              "localId": "15",
+              "locator": "21:1-22:50",
+              "name": "SDE Ethnicity",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "15",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"SDE Ethnicity\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "14",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "\"Patient Characteristic Ethnicity\"",
+                              ": "
+                            ]
+                          },
+                          {
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Ethnicity\""
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "14",
+                "locator": "22:2-22:50",
+                "dataType": "{urn:healthit-gov:qdm:v5_3}PatientCharacteristicEthnicity",
+                "codeProperty": "code",
+                "type": "Retrieve",
+                "codes": {
+                  "name": "Ethnicity",
+                  "type": "ValueSetRef"
+                }
+              }
+            },
+            {
+              "localId": "17",
+              "locator": "24:1-25:42",
+              "name": "SDE Payer",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "17",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"SDE Payer\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "16",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "\"Patient Characteristic Payer\"",
+                              ": "
+                            ]
+                          },
+                          {
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Payer\""
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "16",
+                "locator": "25:2-25:42",
+                "dataType": "{urn:healthit-gov:qdm:v5_3}PatientCharacteristicPayer",
+                "codeProperty": "code",
+                "type": "Retrieve",
+                "codes": {
+                  "name": "Payer",
+                  "type": "ValueSetRef"
+                }
+              }
+            },
+            {
+              "localId": "19",
+              "locator": "27:1-28:40",
+              "name": "SDE Race",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "19",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"SDE Race\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "18",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "\"Patient Characteristic Race\"",
+                              ": "
+                            ]
+                          },
+                          {
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Race\""
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "18",
+                "locator": "28:2-28:40",
+                "dataType": "{urn:healthit-gov:qdm:v5_3}PatientCharacteristicRace",
+                "codeProperty": "code",
+                "type": "Retrieve",
+                "codes": {
+                  "name": "Race",
+                  "type": "ValueSetRef"
+                }
+              }
+            },
+            {
+              "localId": "21",
+              "locator": "30:1-31:57",
+              "name": "SDE Sex",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "21",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"SDE Sex\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "20",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "\"Patient Characteristic Sex\"",
+                              ": "
+                            ]
+                          },
+                          {
+                            "s": [
+                              {
+                                "value": [
+                                  "\"ONC Administrative Sex\""
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "20",
+                "locator": "31:2-31:57",
+                "dataType": "{urn:healthit-gov:qdm:v5_3}PatientCharacteristicSex",
+                "codeProperty": "code",
+                "type": "Retrieve",
+                "codes": {
+                  "name": "ONC Administrative Sex",
+                  "type": "ValueSetRef"
+                }
+              }
+            },
+            {
+              "localId": "34",
+              "locator": "33:1-37:2",
+              "name": "Most Recent Delivery",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "34",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Most Recent Delivery\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "33",
+                        "s": [
+                          {
+                            "value": [
+                              "Last",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "32",
+                            "s": [
+                              {
+                                "s": [
+                                  {
+                                    "r": "23",
+                                    "s": [
+                                      {
+                                        "r": "22",
+                                        "s": [
+                                          {
+                                            "r": "22",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "[",
+                                                  "\"Procedure, Performed\"",
+                                                  ": "
+                                                ]
+                                              },
+                                              {
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"Delivery - Procedure\""
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "]"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          "DeliveryProcedure"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\t\t\t"
+                                ]
+                              },
+                              {
+                                "r": "27",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "where "
+                                    ]
+                                  },
+                                  {
+                                    "r": "27",
+                                    "s": [
+                                      {
+                                        "r": "25",
+                                        "s": [
+                                          {
+                                            "r": "24",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "DeliveryProcedure"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "25",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "relevantPeriod"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          "during",
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "26",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Measurement Period\""
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\t\t\t"
+                                ]
+                              },
+                              {
+                                "r": "31",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "sort by "
+                                    ]
+                                  },
+                                  {
+                                    "r": "30",
+                                    "s": [
+                                      {
+                                        "r": "29",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "28",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "relevantPeriod"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t)"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "33",
+                "locator": "34:2-37:2",
+                "type": "Last",
+                "source": {
+                  "localId": "32",
+                  "locator": "34:7-36:34",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "23",
+                      "locator": "34:7-34:72",
+                      "alias": "DeliveryProcedure",
+                      "expression": {
+                        "localId": "22",
+                        "locator": "34:7-34:54",
+                        "dataType": "{urn:healthit-gov:qdm:v5_3}PositiveProcedurePerformed",
+                        "templateId": "PositiveProcedurePerformed",
+                        "codeProperty": "code",
+                        "type": "Retrieve",
+                        "codes": {
+                          "name": "Delivery - Procedure",
+                          "type": "ValueSetRef"
+                        }
+                      }
+                    }
+                  ],
+                  "relationship": [],
+                  "where": {
+                    "localId": "27",
+                    "locator": "35:4-35:69",
+                    "type": "IncludedIn",
+                    "operand": [
+                      {
+                        "localId": "25",
+                        "locator": "35:10-35:41",
+                        "path": "relevantPeriod",
+                        "scope": "DeliveryProcedure",
+                        "type": "Property"
+                      },
+                      {
+                        "localId": "26",
+                        "locator": "35:50-35:69",
+                        "name": "Measurement Period",
+                        "type": "ParameterRef"
+                      }
+                    ]
+                  },
+                  "sort": {
+                    "localId": "31",
+                    "locator": "36:4-36:34",
+                    "by": [
+                      {
+                        "localId": "30",
+                        "locator": "36:12-36:34",
+                        "direction": "asc",
+                        "type": "ByExpression",
+                        "expression": {
+                          "localId": "29",
+                          "locator": "36:12-36:34",
+                          "type": "Start",
+                          "operand": {
+                            "localId": "28",
+                            "locator": "36:21-36:34",
+                            "name": "relevantPeriod",
+                            "type": "IdentifierRef"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "localId": "49",
+              "locator": "47:1-51:3",
+              "name": "Most Recent Delivery Overlaps Diagnosis",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "49",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Most Recent Delivery Overlaps Diagnosis\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "48",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "38",
+                                "s": [
+                                  {
+                                    "r": "37",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Most Recent Delivery\""
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "MostRecentDelivery"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "47",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "47",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "exists "
+                                    ]
+                                  },
+                                  {
+                                    "r": "46",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "46",
+                                        "s": [
+                                          {
+                                            "s": [
+                                              {
+                                                "r": "40",
+                                                "s": [
+                                                  {
+                                                    "r": "39",
+                                                    "s": [
+                                                      {
+                                                        "r": "39",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "[",
+                                                              "\"Diagnosis\"",
+                                                              ": "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "\"Delivery - Diagnosis\""
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "]"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "DeliveryDiagnosis"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "45",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "where "
+                                                ]
+                                              },
+                                              {
+                                                "r": "45",
+                                                "s": [
+                                                  {
+                                                    "r": "42",
+                                                    "s": [
+                                                      {
+                                                        "r": "41",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "MostRecentDelivery"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "42",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "relevantPeriod"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "overlaps",
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "44",
+                                                    "s": [
+                                                      {
+                                                        "r": "43",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "DeliveryDiagnosis"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "44",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "prevalencePeriod"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\t\t)"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "48",
+                "locator": "48:2-51:3",
+                "type": "Query",
+                "source": [
+                  {
+                    "localId": "38",
+                    "locator": "48:2-48:42",
+                    "alias": "MostRecentDelivery",
+                    "expression": {
+                      "localId": "37",
+                      "locator": "48:2-48:23",
+                      "name": "Most Recent Delivery",
+                      "type": "ExpressionRef"
+                    }
+                  }
+                ],
+                "relationship": [],
+                "where": {
+                  "localId": "47",
+                  "locator": "49:3-51:3",
+                  "type": "Exists",
+                  "operand": {
+                    "localId": "46",
+                    "locator": "49:16-51:3",
+                    "type": "Query",
+                    "source": [
+                      {
+                        "localId": "40",
+                        "locator": "49:18-49:72",
+                        "alias": "DeliveryDiagnosis",
+                        "expression": {
+                          "localId": "39",
+                          "locator": "49:18-49:54",
+                          "dataType": "{urn:healthit-gov:qdm:v5_3}Diagnosis",
+                          "codeProperty": "code",
+                          "type": "Retrieve",
+                          "codes": {
+                            "name": "Delivery - Diagnosis",
+                            "type": "ValueSetRef"
+                          }
+                        }
+                      }
+                    ],
+                    "relationship": [],
+                    "where": {
+                      "localId": "45",
+                      "locator": "50:5-50:87",
+                      "type": "Overlaps",
+                      "operand": [
+                        {
+                          "localId": "42",
+                          "locator": "50:11-50:43",
+                          "path": "relevantPeriod",
+                          "scope": "MostRecentDelivery",
+                          "type": "Property"
+                        },
+                        {
+                          "localId": "44",
+                          "locator": "50:54-50:87",
+                          "path": "prevalencePeriod",
+                          "scope": "DeliveryDiagnosis",
+                          "type": "Property"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "localId": "70",
+              "locator": "39:1-45:51",
+              "name": "Denominator Exceptions",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "70",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Denominator Exceptions\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "69",
+                        "s": [
+                          {
+                            "value": [
+                              "exists"
+                            ]
+                          },
+                          {
+                            "r": "68",
+                            "s": [
+                              {
+                                "value": [
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "68",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "r": "36",
+                                        "s": [
+                                          {
+                                            "r": "35",
+                                            "s": [
+                                              {
+                                                "r": "35",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "[",
+                                                      "\"Diagnosis\"",
+                                                      ": "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "\"Hepatitis B\""
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "]"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "HepB"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " \n\t\t    "
+                                    ]
+                                  },
+                                  {
+                                    "r": "67",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "with "
+                                        ]
+                                      },
+                                      {
+                                        "r": "51",
+                                        "s": [
+                                          {
+                                            "r": "50",
+                                            "s": [
+                                              {
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"Most Recent Delivery Overlaps Diagnosis\""
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "DeliveryOverlapsDiagnosis"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\t\t        such that "
+                                        ]
+                                      },
+                                      {
+                                        "r": "66",
+                                        "s": [
+                                          {
+                                            "r": "58",
+                                            "s": [
+                                              {
+                                                "r": "53",
+                                                "s": [
+                                                  {
+                                                    "r": "52",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "HepB"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "53",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "prevalencePeriod"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "58",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "starts "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "57",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "365 ",
+                                                          "days"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " or less before"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "56",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "start of\n\t\t        "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "55",
+                                                    "s": [
+                                                      {
+                                                        "r": "54",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "DeliveryOverlapsDiagnosis"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "55",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "relevantPeriod"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " \n\t\t        or "
+                                            ]
+                                          },
+                                          {
+                                            "r": "65",
+                                            "s": [
+                                              {
+                                                "r": "60",
+                                                "s": [
+                                                  {
+                                                    "r": "59",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "HepB"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "60",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "prevalencePeriod"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "65",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ends "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "64",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "365 ",
+                                                          "days"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " or less before"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "63",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "start of\n\t\t        "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "62",
+                                                    "s": [
+                                                      {
+                                                        "r": "61",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "DeliveryOverlapsDiagnosis"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "62",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "relevantPeriod"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "69",
+                "locator": "40:2-45:51",
+                "type": "Exists",
+                "operand": {
+                  "localId": "68",
+                  "locator": "40:8-45:51",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "36",
+                      "locator": "40:9-40:41",
+                      "alias": "HepB",
+                      "expression": {
+                        "localId": "35",
+                        "locator": "40:9-40:36",
+                        "dataType": "{urn:healthit-gov:qdm:v5_3}Diagnosis",
+                        "codeProperty": "code",
+                        "type": "Retrieve",
+                        "codes": {
+                          "name": "Hepatitis B",
+                          "type": "ValueSetRef"
+                        }
+                      }
+                    }
+                  ],
+                  "relationship": [
+                    {
+                      "localId": "67",
+                      "locator": "41:7-45:50",
+                      "alias": "DeliveryOverlapsDiagnosis",
+                      "type": "With",
+                      "expression": {
+                        "localId": "50",
+                        "locator": "41:12-41:52",
+                        "name": "Most Recent Delivery Overlaps Diagnosis",
+                        "type": "ExpressionRef"
+                      },
+                      "suchThat": {
+                        "localId": "66",
+                        "locator": "42:21-45:50",
+                        "type": "Or",
+                        "operand": [
+                          {
+                            "localId": "58",
+                            "locator": "42:21-43:50",
+                            "type": "In",
+                            "operand": [
+                              {
+                                "locator": "42:43-42:48",
+                                "type": "Start",
+                                "operand": {
+                                  "localId": "53",
+                                  "locator": "42:21-42:41",
+                                  "path": "prevalencePeriod",
+                                  "scope": "HepB",
+                                  "type": "Property"
+                                }
+                              },
+                              {
+                                "locator": "42:50-42:65",
+                                "lowClosed": true,
+                                "highClosed": false,
+                                "type": "Interval",
+                                "low": {
+                                  "locator": "42:74-43:50",
+                                  "type": "Subtract",
+                                  "operand": [
+                                    {
+                                      "localId": "56",
+                                      "locator": "42:74-43:50",
+                                      "type": "Start",
+                                      "operand": {
+                                        "localId": "55",
+                                        "locator": "43:11-43:50",
+                                        "path": "relevantPeriod",
+                                        "scope": "DeliveryOverlapsDiagnosis",
+                                        "type": "Property"
+                                      }
+                                    },
+                                    {
+                                      "localId": "57",
+                                      "locator": "42:50-42:57",
+                                      "value": 365,
+                                      "unit": "days",
+                                      "type": "Quantity"
+                                    }
+                                  ]
+                                },
+                                "high": {
+                                  "localId": "56",
+                                  "locator": "42:74-43:50",
+                                  "type": "Start",
+                                  "operand": {
+                                    "localId": "55",
+                                    "locator": "43:11-43:50",
+                                    "path": "relevantPeriod",
+                                    "scope": "DeliveryOverlapsDiagnosis",
+                                    "type": "Property"
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "65",
+                            "locator": "44:14-45:50",
+                            "type": "In",
+                            "operand": [
+                              {
+                                "locator": "44:36-44:39",
+                                "type": "End",
+                                "operand": {
+                                  "localId": "60",
+                                  "locator": "44:14-44:34",
+                                  "path": "prevalencePeriod",
+                                  "scope": "HepB",
+                                  "type": "Property"
+                                }
+                              },
+                              {
+                                "locator": "44:41-44:56",
+                                "lowClosed": true,
+                                "highClosed": false,
+                                "type": "Interval",
+                                "low": {
+                                  "locator": "44:65-45:50",
+                                  "type": "Subtract",
+                                  "operand": [
+                                    {
+                                      "localId": "63",
+                                      "locator": "44:65-45:50",
+                                      "type": "Start",
+                                      "operand": {
+                                        "localId": "62",
+                                        "locator": "45:11-45:50",
+                                        "path": "relevantPeriod",
+                                        "scope": "DeliveryOverlapsDiagnosis",
+                                        "type": "Property"
+                                      }
+                                    },
+                                    {
+                                      "localId": "64",
+                                      "locator": "44:41-44:48",
+                                      "value": 365,
+                                      "unit": "days",
+                                      "type": "Quantity"
+                                    }
+                                  ]
+                                },
+                                "high": {
+                                  "localId": "63",
+                                  "locator": "44:65-45:50",
+                                  "type": "Start",
+                                  "operand": {
+                                    "localId": "62",
+                                    "locator": "45:11-45:50",
+                                    "path": "relevantPeriod",
+                                    "scope": "DeliveryOverlapsDiagnosis",
+                                    "type": "Property"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "localId": "82",
+              "locator": "53:1-56:57",
+              "name": "Initial Population",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "82",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Initial Population\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "81",
+                        "s": [
+                          {
+                            "r": "78",
+                            "s": [
+                              {
+                                "r": "72",
+                                "s": [
+                                  {
+                                    "r": "71",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Most Recent Delivery Overlaps Diagnosis\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\t\tand "
+                                ]
+                              },
+                              {
+                                "r": "77",
+                                "s": [
+                                  {
+                                    "r": "75",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "AgeInYearsAt",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "74",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "73",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "\"Measurement Period\""
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ">=",
+                                      " ",
+                                      "12"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\tand "
+                            ]
+                          },
+                          {
+                            "r": "80",
+                            "s": [
+                              {
+                                "value": [
+                                  "exists "
+                                ]
+                              },
+                              {
+                                "r": "79",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "( "
+                                    ]
+                                  },
+                                  {
+                                    "r": "79",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "\"Patient Characteristic Sex\"",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Female\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " )"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "81",
+                "locator": "54:2-56:57",
+                "type": "And",
+                "operand": [
+                  {
+                    "localId": "78",
+                    "locator": "54:2-55:54",
+                    "type": "And",
+                    "operand": [
+                      {
+                        "localId": "72",
+                        "locator": "54:2-54:54",
+                        "type": "Not",
+                        "operand": {
+                          "locator": "54:2-54:54",
+                          "type": "IsNull",
+                          "operand": {
+                            "localId": "71",
+                            "locator": "54:2-54:42",
+                            "name": "Most Recent Delivery Overlaps Diagnosis",
+                            "type": "ExpressionRef"
+                          }
+                        }
+                      },
+                      {
+                        "localId": "77",
+                        "locator": "55:7-55:54",
+                        "type": "GreaterOrEqual",
+                        "operand": [
+                          {
+                            "localId": "75",
+                            "locator": "55:7-55:49",
+                            "precision": "Year",
+                            "type": "CalculateAgeAt",
+                            "operand": [
+                              {
+                                "path": "birthDatetime",
+                                "type": "Property",
+                                "source": {
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              },
+                              {
+                                "localId": "74",
+                                "locator": "55:20-55:48",
+                                "type": "Start",
+                                "operand": {
+                                  "localId": "73",
+                                  "locator": "55:29-55:48",
+                                  "name": "Measurement Period",
+                                  "type": "ParameterRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "76",
+                            "locator": "55:53-55:54",
+                            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                            "value": "12",
+                            "type": "Literal"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "80",
+                    "locator": "56:7-56:57",
+                    "type": "Exists",
+                    "operand": {
+                      "localId": "79",
+                      "locator": "56:14-56:57",
+                      "dataType": "{urn:healthit-gov:qdm:v5_3}PatientCharacteristicSex",
+                      "codeProperty": "code",
+                      "type": "Retrieve",
+                      "codes": {
+                        "name": "Female",
+                        "type": "ValueSetRef"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "localId": "97",
+              "locator": "58:1-62:2",
+              "name": "Numerator",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "97",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Numerator\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "96",
+                        "s": [
+                          {
+                            "value": [
+                              "exists "
+                            ]
+                          },
+                          {
+                            "r": "95",
+                            "s": [
+                              {
+                                "value": [
+                                  "( "
+                                ]
+                              },
+                              {
+                                "r": "95",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "r": "84",
+                                        "s": [
+                                          {
+                                            "r": "83",
+                                            "s": [
+                                              {
+                                                "r": "83",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "[",
+                                                      "\"Laboratory Test, Performed\"",
+                                                      ": "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "\"HBsAg\""
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "]"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "LabTest"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n\t\t\t"
+                                    ]
+                                  },
+                                  {
+                                    "r": "94",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "with "
+                                        ]
+                                      },
+                                      {
+                                        "r": "86",
+                                        "s": [
+                                          {
+                                            "r": "85",
+                                            "s": [
+                                              {
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"Most Recent Delivery Overlaps Diagnosis\""
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "DeliveryOverlapsDiagnosis"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\t\t\t\tsuch that "
+                                        ]
+                                      },
+                                      {
+                                        "r": "93",
+                                        "s": [
+                                          {
+                                            "r": "88",
+                                            "s": [
+                                              {
+                                                "r": "87",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "LabTest"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "88",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "relevantPeriod"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " "
+                                            ]
+                                          },
+                                          {
+                                            "r": "93",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "starts "
+                                                ]
+                                              },
+                                              {
+                                                "r": "92",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "280 ",
+                                                      "days"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " or less before"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " "
+                                            ]
+                                          },
+                                          {
+                                            "r": "91",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "start of "
+                                                ]
+                                              },
+                                              {
+                                                "r": "90",
+                                                "s": [
+                                                  {
+                                                    "r": "89",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "DeliveryOverlapsDiagnosis"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "90",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "relevantPeriod"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\t)"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "96",
+                "locator": "59:2-62:2",
+                "type": "Exists",
+                "operand": {
+                  "localId": "95",
+                  "locator": "59:9-62:2",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "84",
+                      "locator": "59:11-59:57",
+                      "alias": "LabTest",
+                      "expression": {
+                        "localId": "83",
+                        "locator": "59:11-59:49",
+                        "dataType": "{urn:healthit-gov:qdm:v5_3}PositiveLaboratoryTestPerformed",
+                        "templateId": "PositiveLaboratoryTestPerformed",
+                        "codeProperty": "code",
+                        "type": "Retrieve",
+                        "codes": {
+                          "name": "HBsAg",
+                          "type": "ValueSetRef"
+                        }
+                      }
+                    }
+                  ],
+                  "relationship": [
+                    {
+                      "localId": "94",
+                      "locator": "60:4-61:117",
+                      "alias": "DeliveryOverlapsDiagnosis",
+                      "type": "With",
+                      "expression": {
+                        "localId": "85",
+                        "locator": "60:9-60:49",
+                        "name": "Most Recent Delivery Overlaps Diagnosis",
+                        "type": "ExpressionRef"
+                      },
+                      "suchThat": {
+                        "localId": "93",
+                        "locator": "61:15-61:117",
+                        "type": "In",
+                        "operand": [
+                          {
+                            "locator": "61:38-61:43",
+                            "type": "Start",
+                            "operand": {
+                              "localId": "88",
+                              "locator": "61:15-61:36",
+                              "path": "relevantPeriod",
+                              "scope": "LabTest",
+                              "type": "Property"
+                            }
+                          },
+                          {
+                            "locator": "61:45-61:60",
+                            "lowClosed": true,
+                            "highClosed": false,
+                            "type": "Interval",
+                            "low": {
+                              "locator": "61:69-61:117",
+                              "type": "Subtract",
+                              "operand": [
+                                {
+                                  "localId": "91",
+                                  "locator": "61:69-61:117",
+                                  "type": "Start",
+                                  "operand": {
+                                    "localId": "90",
+                                    "locator": "61:78-61:117",
+                                    "path": "relevantPeriod",
+                                    "scope": "DeliveryOverlapsDiagnosis",
+                                    "type": "Property"
+                                  }
+                                },
+                                {
+                                  "localId": "92",
+                                  "locator": "61:45-61:52",
+                                  "value": 280,
+                                  "unit": "days",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            },
+                            "high": {
+                              "localId": "91",
+                              "locator": "61:69-61:117",
+                              "type": "Start",
+                              "operand": {
+                                "localId": "90",
+                                "locator": "61:78-61:117",
+                                "path": "relevantPeriod",
+                                "scope": "DeliveryOverlapsDiagnosis",
+                                "type": "Property"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "localId": "99",
+              "locator": "64:1-65:21",
+              "name": "Denominator",
+              "context": "Patient",
+              "accessLevel": "Public",
+              "annotation": [
+                {
+                  "type": "Annotation",
+                  "s": {
+                    "r": "99",
+                    "s": [
+                      {
+                        "value": [
+                          "define ",
+                          "\"Denominator\"",
+                          ":\n\t"
+                        ]
+                      },
+                      {
+                        "r": "98",
+                        "s": [
+                          {
+                            "value": [
+                              "\"Initial Population\""
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "expression": {
+                "localId": "98",
+                "locator": "65:2-65:21",
+                "name": "Initial Population",
+                "type": "ExpressionRef"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "elm_annotations": {
+    "PregnantwomenthathadHBsAgtesting": {
+      "statements": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"SDE Ethnicity\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "[\"Patient Characteristic Ethnicity\": "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "\"Ethnicity\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "]"
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "Retrieve",
+                  "ref_id": "14"
+                }
+              ],
+              "ref_id": "15"
+            }
+          ],
+          "define_name": "SDE Ethnicity"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"SDE Payer\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "[\"Patient Characteristic Payer\": "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "\"Payer\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "]"
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "Retrieve",
+                  "ref_id": "16"
+                }
+              ],
+              "ref_id": "17"
+            }
+          ],
+          "define_name": "SDE Payer"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"SDE Race\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "[\"Patient Characteristic Race\": "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "\"Race\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "]"
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "Retrieve",
+                  "ref_id": "18"
+                }
+              ],
+              "ref_id": "19"
+            }
+          ],
+          "define_name": "SDE Race"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"SDE Sex\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "[\"Patient Characteristic Sex\": "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "\"ONC Administrative Sex\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "]"
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "Retrieve",
+                  "ref_id": "20"
+                }
+              ],
+              "ref_id": "21"
+            }
+          ],
+          "define_name": "SDE Sex"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Most Recent Delivery\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "Last("
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "[\"Procedure, Performed\": "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "\"Delivery - Procedure\""
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "]"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "Retrieve",
+                                      "ref_id": "22"
+                                    }
+                                  ],
+                                  "node_type": "Retrieve",
+                                  "ref_id": "22"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": " DeliveryProcedure"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "ref_id": "23"
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "\n      "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "text": "where "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "DeliveryProcedure"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "ref_id": "24"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "relevantPeriod"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "Property",
+                                      "ref_id": "25"
+                                    }
+                                  ],
+                                  "node_type": "Property",
+                                  "ref_id": "25"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": " during "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "\"Measurement Period\""
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "node_type": "ParameterRef",
+                                  "ref_id": "26"
+                                }
+                              ],
+                              "ref_id": "27"
+                            }
+                          ],
+                          "ref_id": "27"
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "\n      "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "text": "sort by "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "start of "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "relevantPeriod"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "IdentifierRef",
+                                      "ref_id": "28"
+                                    }
+                                  ],
+                                  "node_type": "Start",
+                                  "ref_id": "29"
+                                }
+                              ],
+                              "ref_id": "30"
+                            }
+                          ],
+                          "ref_id": "31"
+                        }
+                      ],
+                      "ref_id": "32"
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "\n  )"
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "Last",
+                  "ref_id": "33"
+                }
+              ],
+              "ref_id": "34"
+            }
+          ],
+          "define_name": "Most Recent Delivery"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Most Recent Delivery Overlaps Diagnosis\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "\"Most Recent Delivery\""
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "node_type": "ExpressionRef",
+                              "ref_id": "37"
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": " MostRecentDelivery"
+                                }
+                              ]
+                            }
+                          ],
+                          "ref_id": "38"
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "\n    "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "where "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "text": "exists "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "( "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "[\"Diagnosis\": "
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "children": [
+                                                            {
+                                                              "text": "\"Delivery - Diagnosis\""
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "]"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "node_type": "Retrieve",
+                                                  "ref_id": "39"
+                                                }
+                                              ],
+                                              "node_type": "Retrieve",
+                                              "ref_id": "39"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": " DeliveryDiagnosis"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "ref_id": "40"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "\n        "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "where "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "MostRecentDelivery"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "ref_id": "41"
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "."
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "relevantPeriod"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "node_type": "Property",
+                                                  "ref_id": "42"
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "42"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": " overlaps "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "DeliveryDiagnosis"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "ref_id": "43"
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "."
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "prevalencePeriod"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "node_type": "Property",
+                                                  "ref_id": "44"
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "44"
+                                            }
+                                          ],
+                                          "ref_id": "45"
+                                        }
+                                      ],
+                                      "ref_id": "45"
+                                    }
+                                  ],
+                                  "node_type": "Query",
+                                  "ref_id": "46"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": "\n    )"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "node_type": "Query",
+                              "ref_id": "46"
+                            }
+                          ],
+                          "ref_id": "47"
+                        }
+                      ],
+                      "ref_id": "47"
+                    }
+                  ],
+                  "node_type": "Query",
+                  "ref_id": "48"
+                }
+              ],
+              "ref_id": "49"
+            }
+          ],
+          "define_name": "Most Recent Delivery Overlaps Diagnosis"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Denominator Exceptions\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "exists"
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "("
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "[\"Diagnosis\": "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "\"Hepatitis B\""
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "]"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "Retrieve",
+                                          "ref_id": "35"
+                                        }
+                                      ],
+                                      "node_type": "Retrieve",
+                                      "ref_id": "35"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " HepB"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "ref_id": "36"
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": " \n        "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "with "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "\"Most Recent Delivery Overlaps Diagnosis\""
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "ExpressionRef",
+                                      "ref_id": "50"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " DeliveryOverlapsDiagnosis"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "ref_id": "51"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": "\n            such that "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "HepB"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "ref_id": "52"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "."
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "prevalencePeriod"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "53"
+                                            }
+                                          ],
+                                          "node_type": "Property",
+                                          "ref_id": "53"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": " "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "starts "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "365 days"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "node_type": "Quantity",
+                                              "ref_id": "57"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": " or less before"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "In",
+                                          "ref_id": "58"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": " "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "start of\n            "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "DeliveryOverlapsDiagnosis"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "ref_id": "54"
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "."
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "relevantPeriod"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "node_type": "Property",
+                                                  "ref_id": "55"
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "55"
+                                            }
+                                          ],
+                                          "node_type": "Start",
+                                          "ref_id": "56"
+                                        }
+                                      ],
+                                      "node_type": "In",
+                                      "ref_id": "58"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " \n            or "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "HepB"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "ref_id": "59"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "."
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "prevalencePeriod"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "60"
+                                            }
+                                          ],
+                                          "node_type": "Property",
+                                          "ref_id": "60"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": " "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "ends "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "365 days"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "node_type": "Quantity",
+                                              "ref_id": "64"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": " or less before"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "In",
+                                          "ref_id": "65"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": " "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "start of\n            "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "DeliveryOverlapsDiagnosis"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "ref_id": "61"
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "."
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "children": [
+                                                        {
+                                                          "text": "relevantPeriod"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "node_type": "Property",
+                                                  "ref_id": "62"
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "62"
+                                            }
+                                          ],
+                                          "node_type": "Start",
+                                          "ref_id": "63"
+                                        }
+                                      ],
+                                      "node_type": "In",
+                                      "ref_id": "65"
+                                    }
+                                  ],
+                                  "node_type": "Or",
+                                  "ref_id": "66"
+                                }
+                              ],
+                              "ref_id": "67"
+                            }
+                          ],
+                          "node_type": "Query",
+                          "ref_id": "68"
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": ")"
+                            }
+                          ]
+                        }
+                      ],
+                      "node_type": "Query",
+                      "ref_id": "68"
+                    }
+                  ],
+                  "node_type": "Exists",
+                  "ref_id": "69"
+                }
+              ],
+              "ref_id": "70"
+            }
+          ],
+          "define_name": "Denominator Exceptions"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Initial Population\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "\"Most Recent Delivery Overlaps Diagnosis\""
+                                    }
+                                  ]
+                                }
+                              ],
+                              "node_type": "ExpressionRef",
+                              "ref_id": "71"
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": " is not null"
+                                }
+                              ]
+                            }
+                          ],
+                          "node_type": "Not",
+                          "ref_id": "72"
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "\n    and "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "AgeInYearsAt("
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "start of "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "\"Measurement Period\""
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "ParameterRef",
+                                      "ref_id": "73"
+                                    }
+                                  ],
+                                  "node_type": "Start",
+                                  "ref_id": "74"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": ")"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "node_type": "CalculateAgeAt",
+                              "ref_id": "75"
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": "&gt;= 12"
+                                }
+                              ]
+                            }
+                          ],
+                          "node_type": "GreaterOrEqual",
+                          "ref_id": "77"
+                        }
+                      ],
+                      "node_type": "And",
+                      "ref_id": "78"
+                    },
+                    {
+                      "children": [
+                        {
+                          "text": "\n    and "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "exists "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "text": "( "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "[\"Patient Characteristic Sex\": "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "text": "\"Female\""
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": "]"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "node_type": "Retrieve",
+                              "ref_id": "79"
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": " )"
+                                }
+                              ]
+                            }
+                          ],
+                          "node_type": "Retrieve",
+                          "ref_id": "79"
+                        }
+                      ],
+                      "node_type": "Exists",
+                      "ref_id": "80"
+                    }
+                  ],
+                  "node_type": "And",
+                  "ref_id": "81"
+                }
+              ],
+              "ref_id": "82"
+            }
+          ],
+          "define_name": "Initial Population"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Numerator\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "exists "
+                        }
+                      ]
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "text": "( "
+                            }
+                          ]
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "[\"Laboratory Test, Performed\": "
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "\"HBsAg\""
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "]"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "Retrieve",
+                                          "ref_id": "83"
+                                        }
+                                      ],
+                                      "node_type": "Retrieve",
+                                      "ref_id": "83"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " LabTest"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "ref_id": "84"
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "text": "\n      "
+                                }
+                              ]
+                            },
+                            {
+                              "children": [
+                                {
+                                  "children": [
+                                    {
+                                      "text": "with "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "\"Most Recent Delivery Overlaps Diagnosis\""
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "ExpressionRef",
+                                      "ref_id": "85"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " DeliveryOverlapsDiagnosis"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "ref_id": "86"
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "text": "\n        such that "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "LabTest"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "ref_id": "87"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "."
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "relevantPeriod"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "Property",
+                                          "ref_id": "88"
+                                        }
+                                      ],
+                                      "node_type": "Property",
+                                      "ref_id": "88"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "starts "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "280 days"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "node_type": "Quantity",
+                                          "ref_id": "92"
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "text": " or less before"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "node_type": "In",
+                                      "ref_id": "93"
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "text": " "
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "children": [
+                                        {
+                                          "children": [
+                                            {
+                                              "text": "start of "
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "children": [
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "DeliveryOverlapsDiagnosis"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "ref_id": "89"
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "text": "."
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "children": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "text": "relevantPeriod"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "node_type": "Property",
+                                              "ref_id": "90"
+                                            }
+                                          ],
+                                          "node_type": "Property",
+                                          "ref_id": "90"
+                                        }
+                                      ],
+                                      "node_type": "Start",
+                                      "ref_id": "91"
+                                    }
+                                  ],
+                                  "node_type": "In",
+                                  "ref_id": "93"
+                                }
+                              ],
+                              "ref_id": "94"
+                            }
+                          ],
+                          "node_type": "Query",
+                          "ref_id": "95"
+                        },
+                        {
+                          "children": [
+                            {
+                              "text": "\n  )"
+                            }
+                          ]
+                        }
+                      ],
+                      "node_type": "Query",
+                      "ref_id": "95"
+                    }
+                  ],
+                  "node_type": "Exists",
+                  "ref_id": "96"
+                }
+              ],
+              "ref_id": "97"
+            }
+          ],
+          "define_name": "Numerator"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "define \"Denominator\":\n  "
+                    }
+                  ]
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "text": "\"Initial Population\""
+                        }
+                      ]
+                    }
+                  ],
+                  "node_type": "ExpressionRef",
+                  "ref_id": "98"
+                }
+              ],
+              "ref_id": "99"
+            }
+          ],
+          "define_name": "Denominator"
+        }
+      ],
+      "identifier": {
+        "id": "PregnantwomenthathadHBsAgtesting",
+        "version": "6.0.001"
+      }
+    }
+  },
+  "episode_ids": null,
+  "episode_of_care": false,
+  "hqmf_id": "40280382-5FA6-FE85-015F-B5969D1D0264",
+  "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+  "hqmf_version_number": 0,
+  "id": "5a57eb37942c6d1e61d33813",
+  "main_cql_library": "PregnantwomenthathadHBsAgtesting",
+  "measure_attributes": [
+    {
+      "code": "OTH",
+      "value": "158",
+      "name": "eCQM Identifier (Measure Authoring Tool)",
+      "code_obj": {
+        "type": "CD",
+        "null_flavor": "OTH",
+        "original_text": "eCQM Identifier (Measure Authoring Tool)"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "158",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "OTH",
+      "value": "Not Applicable",
+      "name": "NQF Number",
+      "code_obj": {
+        "type": "CD",
+        "null_flavor": "OTH",
+        "original_text": "NQF Number"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Not Applicable",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "COPY",
+      "value": "This measure is copyrighted by Optum, Inc.  All rights reserved.",
+      "name": "Copyright",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "COPY",
+        "title": "Copyright"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "This measure is copyrighted by Optum, Inc.  All rights reserved.",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "DISC",
+      "value": "The information in this document is subject to change without notice. This documentation contains proprietary information, and is protected by U.S. and international copyright. All rights reserved. No part of this documentation may be reproduced or transmitted in any form or by any means, electronic or mechanical, including photocopying, modifying, or recording, without the prior written permission of Optum, Inc. No part of this documentation may be translated to another program language without the prior written consent of Optum, Inc.\r\n\r\nOptum(R), Symmetry(R), EBM Connect(R), service marks and logos are registered and unregistered trademarks of Optum and its affiliates in the United States and other countries. \r\n\r\nCMS has contracted with Mathematica Policy Research and its subcontractor, Telligen, for the continued maintenance of this electronic measure.\r\n\r\nEBM Connect(R), Release 9.0, 2015.\r\n\r\nDue to technical limitations, registered trademarks are indicated by (R) or [R].",
+      "name": "Disclaimer",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "DISC",
+        "title": "Disclaimer"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "The information in this document is subject to change without notice. This documentation contains proprietary information, and is protected by U.S. and international copyright. All rights reserved. No part of this documentation may be reproduced or transmitted in any form or by any means, electronic or mechanical, including photocopying, modifying, or recording, without the prior written permission of Optum, Inc. No part of this documentation may be translated to another program language without the prior written consent of Optum, Inc.\r\n\r\nOptum(R), Symmetry(R), EBM Connect(R), service marks and logos are registered and unregistered trademarks of Optum and its affiliates in the United States and other countries. \r\n\r\nCMS has contracted with Mathematica Policy Research and its subcontractor, Telligen, for the continued maintenance of this electronic measure.\r\n\r\nEBM Connect(R), Release 9.0, 2015.\r\n\r\nDue to technical limitations, registered trademarks are indicated by (R) or [R].",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "MSRSCORE",
+      "name": "Measure Scoring",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "MSRSCORE",
+        "title": "Measure Scoring"
+      },
+      "value_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.1.11.20367",
+        "code": "PROPOR",
+        "title": "Proportion"
+      }
+    },
+    {
+      "code": "MSRTYPE",
+      "name": "Measure Type",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "MSRTYPE",
+        "title": "Measure Type"
+      },
+      "value_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.1.11.20368",
+        "code": "PROCESS",
+        "title": "PROCESS"
+      }
+    },
+    {
+      "code": "STRAT",
+      "value": "None",
+      "name": "Stratification",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "STRAT",
+        "title": "Stratification"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "MSRADJ",
+      "value": "None",
+      "name": "Risk Adjustment",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "MSRADJ",
+        "title": "Risk Adjustment"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "MSRAGG",
+      "value": "None",
+      "name": "Rate Aggregation",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "MSRAGG",
+        "title": "Rate Aggregation"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "RAT",
+      "value": "The U.S. Preventive Services Task Force (USPSTF) found good evidence that universal prenatal screening for hepatitis B virus (HBV) infection using hepatitis B surface antigen (HBsAg) substantially reduces prenatal transmission of HBV and the subsequent development of chronic HBV infection (USPSTF 2009). The current practice of vaccinating all infants against HBV infection and post-exposure prophylaxis with hepatitis B immune globulin administered at birth to infants of HBV-infected mothers substantially reduces the risk for acquiring HBV infection.",
+      "name": "Rationale",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "RAT",
+        "title": "Rationale"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "The U.S. Preventive Services Task Force (USPSTF) found good evidence that universal prenatal screening for hepatitis B virus (HBV) infection using hepatitis B surface antigen (HBsAg) substantially reduces prenatal transmission of HBV and the subsequent development of chronic HBV infection (USPSTF 2009). The current practice of vaccinating all infants against HBV infection and post-exposure prophylaxis with hepatitis B immune globulin administered at birth to infants of HBV-infected mothers substantially reduces the risk for acquiring HBV infection.",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "CRS",
+      "value": "The U.S. Preventive Services Task Force (USPSTF) strongly recommends screening for hepatitis B virus (HBV) infection in pregnant women at their first prenatal visit (USPSTF 2009). This is a grade A* recommendation from the USPSTF. In addition, the American College of Obstetricians and Gynecologists (ACOG) recommend screening all pregnant women for HBV infection (ACOG 2007).",
+      "name": "Clinical Recommendation Statement",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "CRS",
+        "title": "Clinical Recommendation Statement"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "The U.S. Preventive Services Task Force (USPSTF) strongly recommends screening for hepatitis B virus (HBV) infection in pregnant women at their first prenatal visit (USPSTF 2009). This is a grade A* recommendation from the USPSTF. In addition, the American College of Obstetricians and Gynecologists (ACOG) recommend screening all pregnant women for HBV infection (ACOG 2007).",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "IDUR",
+      "value": "Higher score indicates better quality",
+      "name": "Improvement Notation",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "IDUR",
+        "title": "Improvement Notation"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Higher score indicates better quality",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "REF",
+      "value": "U.S. Preventive Services Task Force. Screening for Hepatitis B Virus Infection in Pregnancy: U.S.Preventive Services Task Force Reaffirmation Recommendation Statement. Ann Int Med 2009;150:869-73.",
+      "name": "Reference",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "REF",
+        "title": "Reference"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "U.S. Preventive Services Task Force. Screening for Hepatitis B Virus Infection in Pregnancy: U.S.Preventive Services Task Force Reaffirmation Recommendation Statement. Ann Int Med 2009;150:869-73.",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "REF",
+      "value": "American College of Obstetricians and Gynecologists. ACOG Practice Bulletin No. 86: Viral hepatitis in pregnancy. Obstet Gynecol 2007;110:941-56.[PMID: 17906043]",
+      "name": "Reference",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "REF",
+        "title": "Reference"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "American College of Obstetricians and Gynecologists. ACOG Practice Bulletin No. 86: Viral hepatitis in pregnancy. Obstet Gynecol 2007;110:941-56.[PMID: 17906043]",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "DEF",
+      "value": "None",
+      "name": "Definition",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "DEF",
+        "title": "Definition"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "GUIDE",
+      "value": "None",
+      "name": "Guidance",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "GUIDE",
+        "title": "Guidance"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "TRANF",
+      "value": "TBD",
+      "name": "Transmission Format",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "TRANF",
+        "title": "Transmission Format"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "TBD",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "IPOP",
+      "value": "All female patients aged 12 and older who had a live birth or delivery during the measurement period",
+      "name": "Initial Population",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "IPOP",
+        "title": "Initial Population"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "All female patients aged 12 and older who had a live birth or delivery during the measurement period",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "DENOM",
+      "value": "Equals Initial Population",
+      "name": "Denominator",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "DENOM",
+        "title": "Denominator"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Equals Initial Population",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "DENEX",
+      "value": "None",
+      "name": "Denominator Exclusions",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "DENEX",
+        "title": "Denominator Exclusions"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "None",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "NUMER",
+      "value": "Patients who were tested for hepatitis B surface antigen (HBsAg) during pregnancy within 280 days prior to delivery",
+      "name": "Numerator",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "NUMER",
+        "title": "Numerator"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Patients who were tested for hepatitis B surface antigen (HBsAg) during pregnancy within 280 days prior to delivery",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "NUMEX",
+      "value": "Not Applicable",
+      "name": "Numerator Exclusions",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "NUMEX",
+        "title": "Numerator Exclusions"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Not Applicable",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "DENEXCEP",
+      "value": "Patients with a diagnosis of hepatitis B that started or ended within 365 days prior to delivery",
+      "name": "Denominator Exceptions",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "DENEXCEP",
+        "title": "Denominator Exceptions"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "Patients with a diagnosis of hepatitis B that started or ended within 365 days prior to delivery",
+        "media_type": "text/plain"
+      }
+    },
+    {
+      "code": "SDE",
+      "value": "For every patient evaluated by this measure also identify payer, race, ethnicity and sex",
+      "name": "Supplemental Data Elements",
+      "code_obj": {
+        "type": "CD",
+        "system": "2.16.840.1.113883.5.4",
+        "code": "SDE",
+        "title": "Supplemental Data Elements"
+      },
+      "value_obj": {
+        "type": "ED",
+        "value": "For every patient evaluated by this measure also identify payer, race, ethnicity and sex",
+        "media_type": "text/plain"
+      }
+    }
+  ],
+  "measure_id": "40280382-5FA6-FE85-015F-B5969D1D0264",
+  "measure_period": {
+    "type": "IVL_TS",
+    "low": {
+      "type": "TS",
+      "value": "201201010000",
+      "inclusive?": true,
+      "derived?": false
+    },
+    "high": {
+      "type": "TS",
+      "value": "201212312359",
+      "inclusive?": true,
+      "derived?": false
+    },
+    "width": {
+      "type": "PQ",
+      "unit": "a",
+      "value": "1",
+      "inclusive?": true,
+      "derived?": false
+    }
+  },
+  "observations": [],
+  "population_criteria": {
+    "IPP": {
+      "conjunction?": true,
+      "type": "IPP",
+      "hqmf_id": "D925905E-7C6A-4DAB-BAED-9BD0D30C17B4",
+      "preconditions": [
+        {
+          "id": 2,
+          "preconditions": [
+            {
+              "id": 1,
+              "reference": "PregnantwomenthathadHBsAgtesting__Initial_Population__4410CA84_4111_4F6F_A4CA_EB665F4558EC"
+            }
+          ],
+          "conjunction_code": "allTrue"
+        }
+      ]
+    },
+    "DENOM": {
+      "conjunction?": true,
+      "type": "DENOM",
+      "hqmf_id": "0D651BD8-1BC2-44DD-B939-D4668CBCF2F8",
+      "preconditions": [
+        {
+          "id": 4,
+          "preconditions": [
+            {
+              "id": 3,
+              "reference": "PregnantwomenthathadHBsAgtesting__Denominator__4410CA84_4111_4F6F_A4CA_EB665F4558EC"
+            }
+          ],
+          "conjunction_code": "allTrue"
+        }
+      ]
+    },
+    "NUMER": {
+      "conjunction?": true,
+      "type": "NUMER",
+      "hqmf_id": "6D406128-ADE1-4B45-826A-5850D297D405",
+      "preconditions": [
+        {
+          "id": 6,
+          "preconditions": [
+            {
+              "id": 5,
+              "reference": "PregnantwomenthathadHBsAgtesting__Numerator__4410CA84_4111_4F6F_A4CA_EB665F4558EC"
+            }
+          ],
+          "conjunction_code": "allTrue"
+        }
+      ]
+    },
+    "DENEXCEP": {
+      "conjunction?": true,
+      "type": "DENEXCEP",
+      "hqmf_id": "CA814520-4C34-40EE-8B75-E4CC17F826E4",
+      "preconditions": [
+        {
+          "id": 8,
+          "preconditions": [
+            {
+              "id": 7,
+              "reference": "PregnantwomenthathadHBsAgtesting__Denominator_Exceptions__4410CA84_4111_4F6F_A4CA_EB665F4558EC"
+            }
+          ],
+          "conjunction_code": "atLeastOneTrue"
+        }
+      ]
+    }
+  },
+  "populations": [
+    {
+      "IPP": "IPP",
+      "DENOM": "DENOM",
+      "NUMER": "NUMER",
+      "DENEXCEP": "DENEXCEP",
+      "id": "PopulationCriteria1",
+      "title": "Population Criteria Section"
+    }
+  ],
+  "populations_cql_map": {
+    "IPP": [
+      "Initial Population"
+    ],
+    "DENOM": [
+      "Denominator"
+    ],
+    "DENEXCEP": [
+      "Denominator Exceptions"
+    ],
+    "NUMER": [
+      "Numerator"
+    ]
+  },
+  "publish_date": null,
+  "published": null,
+  "record_ids": [],
+  "source_data_criteria": {
+    "Payer_PatientCharacteristicPayer_db378f80_d372_4017_830b_17befc5e45d2_source": {
+      "title": "Payer",
+      "description": "Patient Characteristic Payer: Payer",
+      "code_list_id": "2.16.840.1.114222.4.11.3591",
+      "property": "payer",
+      "type": "characteristic",
+      "definition": "patient_characteristic_payer",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Payer_PatientCharacteristicPayer_db378f80_d372_4017_830b_17befc5e45d2_source",
+      "variable": false,
+      "inline_code_list": {
+        "Source of Payment Typology": [
+          "1",
+          "11",
+          "111",
+          "112",
+          "113",
+          "119",
+          "12",
+          "121",
+          "122",
+          "123",
+          "129",
+          "13",
+          "14",
+          "19",
+          "191",
+          "2",
+          "21",
+          "211",
+          "212",
+          "213",
+          "219",
+          "22",
+          "23",
+          "24",
+          "25",
+          "26",
+          "29",
+          "291",
+          "3",
+          "31",
+          "311",
+          "3111",
+          "3112",
+          "3113",
+          "3114",
+          "3115",
+          "3116",
+          "3119",
+          "312",
+          "3121",
+          "3122",
+          "3123",
+          "313",
+          "32",
+          "321",
+          "3211",
+          "3212",
+          "32121",
+          "32122",
+          "32123",
+          "32124",
+          "32125",
+          "32126",
+          "322",
+          "3221",
+          "3222",
+          "3223",
+          "3229",
+          "33",
+          "331",
+          "332",
+          "333",
+          "334",
+          "34",
+          "341",
+          "342",
+          "343",
+          "349",
+          "35",
+          "36",
+          "361",
+          "362",
+          "369",
+          "37",
+          "371",
+          "3711",
+          "3712",
+          "3713",
+          "372",
+          "379",
+          "38",
+          "381",
+          "3811",
+          "3812",
+          "3813",
+          "3819",
+          "382",
+          "389",
+          "39",
+          "4",
+          "41",
+          "42",
+          "43",
+          "44",
+          "5",
+          "51",
+          "511",
+          "512",
+          "513",
+          "514",
+          "515",
+          "516",
+          "519",
+          "52",
+          "521",
+          "522",
+          "523",
+          "529",
+          "53",
+          "54",
+          "55",
+          "56",
+          "561",
+          "562",
+          "59",
+          "6",
+          "61",
+          "611",
+          "612",
+          "613",
+          "619",
+          "62",
+          "63",
+          "64",
+          "69",
+          "7",
+          "71",
+          "72",
+          "73",
+          "79",
+          "8",
+          "81",
+          "82",
+          "821",
+          "822",
+          "823",
+          "83",
+          "84",
+          "85",
+          "89",
+          "9",
+          "91",
+          "92",
+          "93",
+          "94",
+          "95",
+          "951",
+          "953",
+          "954",
+          "959",
+          "96",
+          "97",
+          "98",
+          "99",
+          "9999"
+        ]
+      }
+    },
+    "Ethnicity_PatientCharacteristicEthnicity_0a1eb113_68c5_4e81_ba8c_03e4541fd752_source": {
+      "title": "Ethnicity",
+      "description": "Patient Characteristic Ethnicity: Ethnicity",
+      "code_list_id": "2.16.840.1.114222.4.11.837",
+      "property": "ethnicity",
+      "type": "characteristic",
+      "definition": "patient_characteristic_ethnicity",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Ethnicity_PatientCharacteristicEthnicity_0a1eb113_68c5_4e81_ba8c_03e4541fd752_source",
+      "variable": false,
+      "inline_code_list": {
+        "CDC Race": [
+          "2135-2",
+          "2186-5"
+        ]
+      }
+    },
+    "ONCAdministrativeSex_PatientCharacteristicSex_ca6fb067_270a_43f8_9849_a197b20702a6_source": {
+      "title": "ONCAdministrativeSex",
+      "description": "Patient Characteristic Sex: ONCAdministrativeSex",
+      "code_list_id": "2.16.840.1.113762.1.4.1",
+      "property": "gender",
+      "type": "characteristic",
+      "definition": "patient_characteristic_gender",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "ONCAdministrativeSex_PatientCharacteristicSex_ca6fb067_270a_43f8_9849_a197b20702a6_source",
+      "variable": false,
+      "value": {
+        "type": "CD",
+        "system": "Administrative Sex",
+        "code": "F"
+      }
+    },
+    "Race_PatientCharacteristicRace_7b1d6697_e04e_4af8_baa8_4abb48e8366c_source": {
+      "title": "Race",
+      "description": "Patient Characteristic Race: Race",
+      "code_list_id": "2.16.840.1.114222.4.11.836",
+      "property": "race",
+      "type": "characteristic",
+      "definition": "patient_characteristic_race",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Race_PatientCharacteristicRace_7b1d6697_e04e_4af8_baa8_4abb48e8366c_source",
+      "variable": false,
+      "inline_code_list": {
+        "CDC Race": [
+          "1002-5",
+          "2028-9",
+          "2054-5",
+          "2076-8",
+          "2106-3",
+          "2131-1"
+        ]
+      }
+    },
+    "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source": {
+      "title": "Delivery-Procedure",
+      "description": "Procedure, Performed: Delivery-Procedure",
+      "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+      "type": "procedures",
+      "definition": "procedure",
+      "status": "performed",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+      "variable": false
+    },
+    "Female_PatientCharacteristicSex_40280381_3d61_56a7_013e_7f3878ec7633_source": {
+      "title": "Female",
+      "description": "Patient Characteristic Sex: Female",
+      "code_list_id": "2.16.840.1.113883.3.560.100.2",
+      "property": "gender",
+      "type": "characteristic",
+      "definition": "patient_characteristic_gender",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Female_PatientCharacteristicSex_40280381_3d61_56a7_013e_7f3878ec7633_source",
+      "variable": false,
+      "value": {
+        "type": "CD",
+        "system": "Administrative Sex",
+        "code": "F"
+      }
+    },
+    "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source": {
+      "title": "HBsAg",
+      "description": "Laboratory Test, Performed: HBsAg",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+      "type": "laboratory_tests",
+      "definition": "laboratory_test",
+      "status": "performed",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+      "variable": false
+    },
+    "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source": {
+      "title": "Delivery-Diagnosis",
+      "description": "Diagnosis: Delivery-Diagnosis",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+      "type": "conditions",
+      "definition": "diagnosis",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+      "variable": false
+    },
+    "HepatitisB_Diagnosis_40280381_3d61_56a7_013e_7f3878ec7631_source": {
+      "title": "HepatitisB",
+      "description": "Diagnosis: HepatitisB",
+      "code_list_id": "2.16.840.1.113883.3.67.1.101.1.269",
+      "type": "conditions",
+      "definition": "diagnosis",
+      "hard_status": false,
+      "negation": false,
+      "source_data_criteria": "HepatitisB_Diagnosis_40280381_3d61_56a7_013e_7f3878ec7631_source",
+      "variable": false
+    }
+  },
+  "title": "Pregnant women that had HBsAg testing",
+  "type": "ep",
+  "updated_at": "2018-01-11T22:54:47.980Z",
+  "user_id": "501fdba3044a111b98000001",
+  "value_set_oid_version_objects": [
+    {
+      "oid": "2.16.840.1.113762.1.4.1",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.114222.4.11.836",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.114222.4.11.837",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.114222.4.11.3591",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.113883.3.67.1.101.1.278",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.113762.1.4.1078.5",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.113883.3.560.100.2",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.113883.3.67.1.101.1.279",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    },
+    {
+      "oid": "2.16.840.1.113883.3.67.1.101.1.269",
+      "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+    }
+  ],
+  "value_set_oids": [
+    "2.16.840.1.113762.1.4.1",
+    "2.16.840.1.114222.4.11.836",
+    "2.16.840.1.114222.4.11.837",
+    "2.16.840.1.114222.4.11.3591",
+    "2.16.840.1.113883.3.67.1.101.1.278",
+    "2.16.840.1.113762.1.4.1078.5",
+    "2.16.840.1.113883.3.560.100.2",
+    "2.16.840.1.113883.3.67.1.101.1.279",
+    "2.16.840.1.113883.3.67.1.101.1.269"
+  ],
+  "version": null
+}

--- a/spec/fixtures/valuesets/cms158v6_vs.json
+++ b/spec/fixtures/valuesets/cms158v6_vs.json
@@ -1,0 +1,8735 @@
+[
+  {
+    "_id": "5a12ffbf942c6d740e7d4127",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a12ffbf942c6d740e7d4128",
+        "black_list": false,
+        "code": "F",
+        "code_system": "2.16.840.1.113883.5.1",
+        "code_system_name": "AdministrativeGender",
+        "code_system_version": "HL7V3.0_2016-07",
+        "display_name": "Female",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffbf942c6d740e7d4129",
+        "black_list": false,
+        "code": "M",
+        "code_system": "2.16.840.1.113883.5.1",
+        "code_system_name": "AdministrativeGender",
+        "code_system_version": "HL7V3.0_2016-07",
+        "display_name": "Male",
+        "white_list": false
+      }
+    ],
+    "display_name": "ONC Administrative Sex",
+    "oid": "2.16.840.1.113762.1.4.1",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-84B9D0B5-0CAF-4E41-B345-3492A23C2E9F"
+  },
+  {
+    "_id": "5a12ffc1942c6d740e7d412a",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a12ffc1942c6d740e7d412b",
+        "black_list": false,
+        "code": "1002-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "American Indian or Alaska Native",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d412c",
+        "black_list": false,
+        "code": "2028-9",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Asian",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d412d",
+        "black_list": false,
+        "code": "2054-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Black or African American",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d412e",
+        "black_list": false,
+        "code": "2076-8",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Native Hawaiian or Other Pacific Islander",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d412f",
+        "black_list": false,
+        "code": "2106-3",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "White",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d4130",
+        "black_list": false,
+        "code": "2131-1",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Other Race",
+        "white_list": false
+      }
+    ],
+    "display_name": "Race",
+    "oid": "2.16.840.1.114222.4.11.836",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-84B9D0B5-0CAF-4E41-B345-3492A23C2E9F"
+  },
+  {
+    "_id": "5a12ffc1942c6d740e7d4131",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a12ffc1942c6d740e7d4132",
+        "black_list": false,
+        "code": "2135-2",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Hispanic or Latino",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc1942c6d740e7d4133",
+        "black_list": false,
+        "code": "2186-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Not Hispanic or Latino",
+        "white_list": false
+      }
+    ],
+    "display_name": "Ethnicity",
+    "oid": "2.16.840.1.114222.4.11.837",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-84B9D0B5-0CAF-4E41-B345-3492A23C2E9F"
+  },
+  {
+    "_id": "5a12ffc3942c6d740e7d4134",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a12ffc3942c6d740e7d4135",
+        "black_list": false,
+        "code": "1",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MEDICARE",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4136",
+        "black_list": false,
+        "code": "11",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare (Managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4137",
+        "black_list": false,
+        "code": "111",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4138",
+        "black_list": false,
+        "code": "112",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4139",
+        "black_list": false,
+        "code": "113",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413a",
+        "black_list": false,
+        "code": "119",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413b",
+        "black_list": false,
+        "code": "12",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare (Non-managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413c",
+        "black_list": false,
+        "code": "121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare FFS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413d",
+        "black_list": false,
+        "code": "122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Drug Benefit",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413e",
+        "black_list": false,
+        "code": "123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Medical Savings Account (MSA)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d413f",
+        "black_list": false,
+        "code": "129",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Non-managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4140",
+        "black_list": false,
+        "code": "13",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Hospice",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4141",
+        "black_list": false,
+        "code": "14",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dual Eligibility Medicare/Medicaid Organization",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4142",
+        "black_list": false,
+        "code": "19",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4143",
+        "black_list": false,
+        "code": "191",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4144",
+        "black_list": false,
+        "code": "2",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MEDICAID",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4145",
+        "black_list": false,
+        "code": "21",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid (Managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4146",
+        "black_list": false,
+        "code": "211",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4147",
+        "black_list": false,
+        "code": "212",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4148",
+        "black_list": false,
+        "code": "213",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid PCCM (Primary Care Case Management)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4149",
+        "black_list": false,
+        "code": "219",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414a",
+        "black_list": false,
+        "code": "22",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid (Non-managed Care Plan)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414b",
+        "black_list": false,
+        "code": "23",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid/SCHIP",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414c",
+        "black_list": false,
+        "code": "24",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Applicant",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414d",
+        "black_list": false,
+        "code": "25",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid - Out of State",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414e",
+        "black_list": false,
+        "code": "26",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid -- Long Term Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d414f",
+        "black_list": false,
+        "code": "29",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4150",
+        "black_list": false,
+        "code": "291",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4151",
+        "black_list": false,
+        "code": "3",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "OTHER GOVERNMENT (Federal/State/Local) (excluding Department of Corrections)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4152",
+        "black_list": false,
+        "code": "31",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Defense",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4153",
+        "black_list": false,
+        "code": "311",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE (CHAMPUS)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4154",
+        "black_list": false,
+        "code": "3111",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Prime--HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4155",
+        "black_list": false,
+        "code": "3112",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Extra--PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4156",
+        "black_list": false,
+        "code": "3113",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Standard - Fee For Service",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4157",
+        "black_list": false,
+        "code": "3114",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE For Life--Medicare Supplement",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4158",
+        "black_list": false,
+        "code": "3115",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Reserve Select",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4159",
+        "black_list": false,
+        "code": "3116",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Uniformed Services Family Health Plan (USFHP) -- HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415a",
+        "black_list": false,
+        "code": "3119",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Defense - (other)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415b",
+        "black_list": false,
+        "code": "312",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Military Treatment Facility",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415c",
+        "black_list": false,
+        "code": "3121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Enrolled Prime--HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415d",
+        "black_list": false,
+        "code": "3122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Non-enrolled Space Available",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415e",
+        "black_list": false,
+        "code": "3123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE For Life (TFL)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d415f",
+        "black_list": false,
+        "code": "313",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dental --Stand Alone",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4160",
+        "black_list": false,
+        "code": "32",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Veterans Affairs",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4161",
+        "black_list": false,
+        "code": "321",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Veteran care--Care provided to Veterans",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4162",
+        "black_list": false,
+        "code": "3211",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Direct Care--Care provided in VA facilities",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4163",
+        "black_list": false,
+        "code": "3212",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indirect Care--Care provided outside VA facilities",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4164",
+        "black_list": false,
+        "code": "32121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Fee Basis",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4165",
+        "black_list": false,
+        "code": "32122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Foreign Fee/Foreign Medical Program(FMP)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4166",
+        "black_list": false,
+        "code": "32123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Contract Nursing Home/Community Nursing Home",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4167",
+        "black_list": false,
+        "code": "32124",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State Veterans Home",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4168",
+        "black_list": false,
+        "code": "32125",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Sharing Agreements",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4169",
+        "black_list": false,
+        "code": "32126",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Federal Agency",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416a",
+        "black_list": false,
+        "code": "322",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Non-veteran care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416b",
+        "black_list": false,
+        "code": "3221",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Civilian Health and Medical Program for the VA (CHAMPVA)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416c",
+        "black_list": false,
+        "code": "3222",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Spina Bifida Health Care Program (SB)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416d",
+        "black_list": false,
+        "code": "3223",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Children of Women Vietnam Veterans (CWVV)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416e",
+        "black_list": false,
+        "code": "3229",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other non-veteran care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d416f",
+        "black_list": false,
+        "code": "33",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service or Tribe",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4170",
+        "black_list": false,
+        "code": "331",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service -- Regular",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4171",
+        "black_list": false,
+        "code": "332",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service -- Contract",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4172",
+        "black_list": false,
+        "code": "333",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service - Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4173",
+        "black_list": false,
+        "code": "334",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Tribe - Sponsored Coverage",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4174",
+        "black_list": false,
+        "code": "34",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HRSA Program",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4175",
+        "black_list": false,
+        "code": "341",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Title V (MCH Block Grant)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4176",
+        "black_list": false,
+        "code": "342",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Migrant Health Program",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4177",
+        "black_list": false,
+        "code": "343",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Ryan White Act",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4178",
+        "black_list": false,
+        "code": "349",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4179",
+        "black_list": false,
+        "code": "35",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Black Lung",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417a",
+        "black_list": false,
+        "code": "36",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State Government",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417b",
+        "black_list": false,
+        "code": "361",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State SCHIP program (codes for individual states)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417c",
+        "black_list": false,
+        "code": "362",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Specific state programs (list/ local code)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417d",
+        "black_list": false,
+        "code": "369",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State, not otherwise specified (other state)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417e",
+        "black_list": false,
+        "code": "37",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local Government",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d417f",
+        "black_list": false,
+        "code": "371",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local - Managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4180",
+        "black_list": false,
+        "code": "3711",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4181",
+        "black_list": false,
+        "code": "3712",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4182",
+        "black_list": false,
+        "code": "3713",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4183",
+        "black_list": false,
+        "code": "372",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "FFS/Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4184",
+        "black_list": false,
+        "code": "379",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local, not otherwise specified (other local, county)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4185",
+        "black_list": false,
+        "code": "38",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Government (Federal, State, Local not specified)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4186",
+        "black_list": false,
+        "code": "381",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4187",
+        "black_list": false,
+        "code": "3811",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4188",
+        "black_list": false,
+        "code": "3812",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4189",
+        "black_list": false,
+        "code": "3813",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418a",
+        "black_list": false,
+        "code": "3819",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - not specified managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418b",
+        "black_list": false,
+        "code": "382",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - FFS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418c",
+        "black_list": false,
+        "code": "389",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418d",
+        "black_list": false,
+        "code": "39",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Federal",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418e",
+        "black_list": false,
+        "code": "4",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "DEPARTMENTS OF CORRECTIONS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d418f",
+        "black_list": false,
+        "code": "41",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Federal",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4190",
+        "black_list": false,
+        "code": "42",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections State",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4191",
+        "black_list": false,
+        "code": "43",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Local",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4192",
+        "black_list": false,
+        "code": "44",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Unknown Level",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4193",
+        "black_list": false,
+        "code": "5",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PRIVATE HEALTH INSURANCE",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4194",
+        "black_list": false,
+        "code": "51",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care (Private)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4195",
+        "black_list": false,
+        "code": "511",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4196",
+        "black_list": false,
+        "code": "512",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4197",
+        "black_list": false,
+        "code": "513",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4198",
+        "black_list": false,
+        "code": "514",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Exclusive Provider Organization",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d4199",
+        "black_list": false,
+        "code": "515",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Gatekeeper PPO (GPPO)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419a",
+        "black_list": false,
+        "code": "516",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419b",
+        "black_list": false,
+        "code": "519",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care, Other (non HMO)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419c",
+        "black_list": false,
+        "code": "52",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Private Health Insurance - Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419d",
+        "black_list": false,
+        "code": "521",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419e",
+        "black_list": false,
+        "code": "522",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Self-insured (ERISA) Administrative Services Only (ASO) plan",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d419f",
+        "black_list": false,
+        "code": "523",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare supplemental policy (as second payer)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a0",
+        "black_list": false,
+        "code": "529",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Private health insurance--other commercial Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a1",
+        "black_list": false,
+        "code": "53",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care (private) or private health insurance (indemnity), not otherwise specified",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a2",
+        "black_list": false,
+        "code": "54",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Organized Delivery System",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a3",
+        "black_list": false,
+        "code": "55",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Small Employer Purchasing Group",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a4",
+        "black_list": false,
+        "code": "56",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Specialized Stand Alone Plan",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a5",
+        "black_list": false,
+        "code": "561",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dental",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a6",
+        "black_list": false,
+        "code": "562",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Vision",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a7",
+        "black_list": false,
+        "code": "59",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Private Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a8",
+        "black_list": false,
+        "code": "6",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BLUE CROSS/BLUE SHIELD",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41a9",
+        "black_list": false,
+        "code": "61",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41aa",
+        "black_list": false,
+        "code": "611",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ab",
+        "black_list": false,
+        "code": "612",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ac",
+        "black_list": false,
+        "code": "613",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ad",
+        "black_list": false,
+        "code": "619",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ae",
+        "black_list": false,
+        "code": "62",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41af",
+        "black_list": false,
+        "code": "63",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Out of State",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b0",
+        "black_list": false,
+        "code": "64",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b1",
+        "black_list": false,
+        "code": "69",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b2",
+        "black_list": false,
+        "code": "7",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MANAGED CARE, UNSPECIFIED (to be used only if one can't distinguish public from private)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b3",
+        "black_list": false,
+        "code": "71",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b4",
+        "black_list": false,
+        "code": "72",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b5",
+        "black_list": false,
+        "code": "73",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b6",
+        "black_list": false,
+        "code": "79",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b7",
+        "black_list": false,
+        "code": "8",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "NO PAYMENT from an Organization/Agency/Program/Private Payer Listed",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b8",
+        "black_list": false,
+        "code": "81",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Self-pay",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41b9",
+        "black_list": false,
+        "code": "82",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Charge",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ba",
+        "black_list": false,
+        "code": "821",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Charity",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41bb",
+        "black_list": false,
+        "code": "822",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Professional Courtesy",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41bc",
+        "black_list": false,
+        "code": "823",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Research/Clinical Trial",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41bd",
+        "black_list": false,
+        "code": "83",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Refusal to Pay/Bad Debt",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41be",
+        "black_list": false,
+        "code": "84",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Hill Burton Free Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41bf",
+        "black_list": false,
+        "code": "85",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Research/Donor",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c0",
+        "black_list": false,
+        "code": "89",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Payment, Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c1",
+        "black_list": false,
+        "code": "9",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MISCELLANEOUS/OTHER",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c2",
+        "black_list": false,
+        "code": "91",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Foreign National",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c3",
+        "black_list": false,
+        "code": "92",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other (Non-government)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c4",
+        "black_list": false,
+        "code": "93",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Disability Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c5",
+        "black_list": false,
+        "code": "94",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Long-term Care Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c6",
+        "black_list": false,
+        "code": "95",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Compensation",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c7",
+        "black_list": false,
+        "code": "951",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c8",
+        "black_list": false,
+        "code": "953",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp Fee-for-Service",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41c9",
+        "black_list": false,
+        "code": "954",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp Other Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ca",
+        "black_list": false,
+        "code": "959",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp, Other unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41cb",
+        "black_list": false,
+        "code": "96",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Auto Insurance (includes no fault)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41cc",
+        "black_list": false,
+        "code": "97",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Legal Liability / Liability Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41cd",
+        "black_list": false,
+        "code": "98",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other specified but not otherwise classifiable (includes Hospice - Unspecified plan)",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41ce",
+        "black_list": false,
+        "code": "99",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Typology Code available for payment source",
+        "white_list": false
+      },
+      {
+        "_id": "5a12ffc3942c6d740e7d41cf",
+        "black_list": false,
+        "code": "9999",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Unavailable / No Payer Specified / Blank",
+        "white_list": false
+      }
+    ],
+    "display_name": "Payer",
+    "oid": "2.16.840.1.114222.4.11.3591",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-84B9D0B5-0CAF-4E41-B345-3492A23C2E9F"
+  },
+  {
+    "_id": "5a25964f942c6d5d8ba7b969",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a25964f942c6d5d8ba7b96a",
+        "black_list": false,
+        "code": "F",
+        "code_system": "2.16.840.1.113883.5.1",
+        "code_system_name": "AdministrativeGender",
+        "code_system_version": "HL7V3.0_2016-07",
+        "display_name": "Female",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b96b",
+        "black_list": false,
+        "code": "M",
+        "code_system": "2.16.840.1.113883.5.1",
+        "code_system_name": "AdministrativeGender",
+        "code_system_version": "HL7V3.0_2016-07",
+        "display_name": "Male",
+        "white_list": false
+      }
+    ],
+    "display_name": "ONC Administrative Sex",
+    "oid": "2.16.840.1.113762.1.4.1",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a25964f942c6d5d8ba7b96c",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a25964f942c6d5d8ba7b96d",
+        "black_list": false,
+        "code": "1002-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "American Indian or Alaska Native",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b96e",
+        "black_list": false,
+        "code": "2028-9",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Asian",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b96f",
+        "black_list": false,
+        "code": "2054-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Black or African American",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b970",
+        "black_list": false,
+        "code": "2076-8",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Native Hawaiian or Other Pacific Islander",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b971",
+        "black_list": false,
+        "code": "2106-3",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "White",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b972",
+        "black_list": false,
+        "code": "2131-1",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Other Race",
+        "white_list": false
+      }
+    ],
+    "display_name": "Race",
+    "oid": "2.16.840.1.114222.4.11.836",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a25964f942c6d5d8ba7b973",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a25964f942c6d5d8ba7b974",
+        "black_list": false,
+        "code": "2135-2",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Hispanic or Latino",
+        "white_list": false
+      },
+      {
+        "_id": "5a25964f942c6d5d8ba7b975",
+        "black_list": false,
+        "code": "2186-5",
+        "code_system": "2.16.840.1.113883.6.238",
+        "code_system_name": "CDC Race",
+        "code_system_version": "1.1",
+        "display_name": "Not Hispanic or Latino",
+        "white_list": false
+      }
+    ],
+    "display_name": "Ethnicity",
+    "oid": "2.16.840.1.114222.4.11.837",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259650942c6d5d8ba7b976",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259650942c6d5d8ba7b977",
+        "black_list": false,
+        "code": "1",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MEDICARE",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b978",
+        "black_list": false,
+        "code": "11",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare (Managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b979",
+        "black_list": false,
+        "code": "111",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97a",
+        "black_list": false,
+        "code": "112",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97b",
+        "black_list": false,
+        "code": "113",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97c",
+        "black_list": false,
+        "code": "119",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97d",
+        "black_list": false,
+        "code": "12",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare (Non-managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97e",
+        "black_list": false,
+        "code": "121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare FFS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b97f",
+        "black_list": false,
+        "code": "122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Drug Benefit",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b980",
+        "black_list": false,
+        "code": "123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Medical Savings Account (MSA)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b981",
+        "black_list": false,
+        "code": "129",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Non-managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b982",
+        "black_list": false,
+        "code": "13",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Hospice",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b983",
+        "black_list": false,
+        "code": "14",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dual Eligibility Medicare/Medicaid Organization",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b984",
+        "black_list": false,
+        "code": "19",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b985",
+        "black_list": false,
+        "code": "191",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b986",
+        "black_list": false,
+        "code": "2",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MEDICAID",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b987",
+        "black_list": false,
+        "code": "21",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid (Managed Care)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b988",
+        "black_list": false,
+        "code": "211",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b989",
+        "black_list": false,
+        "code": "212",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98a",
+        "black_list": false,
+        "code": "213",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid PCCM (Primary Care Case Management)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98b",
+        "black_list": false,
+        "code": "219",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Managed Care Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98c",
+        "black_list": false,
+        "code": "22",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid (Non-managed Care Plan)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98d",
+        "black_list": false,
+        "code": "23",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid/SCHIP",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98e",
+        "black_list": false,
+        "code": "24",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Applicant",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b98f",
+        "black_list": false,
+        "code": "25",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid - Out of State",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b990",
+        "black_list": false,
+        "code": "26",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid -- Long Term Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b991",
+        "black_list": false,
+        "code": "29",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b992",
+        "black_list": false,
+        "code": "291",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicaid Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b993",
+        "black_list": false,
+        "code": "3",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "OTHER GOVERNMENT (Federal/State/Local) (excluding Department of Corrections)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b994",
+        "black_list": false,
+        "code": "31",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Defense",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b995",
+        "black_list": false,
+        "code": "311",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE (CHAMPUS)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b996",
+        "black_list": false,
+        "code": "3111",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Prime--HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b997",
+        "black_list": false,
+        "code": "3112",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Extra--PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b998",
+        "black_list": false,
+        "code": "3113",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Standard - Fee For Service",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b999",
+        "black_list": false,
+        "code": "3114",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE For Life--Medicare Supplement",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99a",
+        "black_list": false,
+        "code": "3115",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE Reserve Select",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99b",
+        "black_list": false,
+        "code": "3116",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Uniformed Services Family Health Plan (USFHP) -- HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99c",
+        "black_list": false,
+        "code": "3119",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Defense - (other)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99d",
+        "black_list": false,
+        "code": "312",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Military Treatment Facility",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99e",
+        "black_list": false,
+        "code": "3121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Enrolled Prime--HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b99f",
+        "black_list": false,
+        "code": "3122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Non-enrolled Space Available",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a0",
+        "black_list": false,
+        "code": "3123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "TRICARE For Life (TFL)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a1",
+        "black_list": false,
+        "code": "313",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dental --Stand Alone",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a2",
+        "black_list": false,
+        "code": "32",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Department of Veterans Affairs",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a3",
+        "black_list": false,
+        "code": "321",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Veteran care--Care provided to Veterans",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a4",
+        "black_list": false,
+        "code": "3211",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Direct Care--Care provided in VA facilities",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a5",
+        "black_list": false,
+        "code": "3212",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indirect Care--Care provided outside VA facilities",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a6",
+        "black_list": false,
+        "code": "32121",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Fee Basis",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a7",
+        "black_list": false,
+        "code": "32122",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Foreign Fee/Foreign Medical Program(FMP)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a8",
+        "black_list": false,
+        "code": "32123",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Contract Nursing Home/Community Nursing Home",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9a9",
+        "black_list": false,
+        "code": "32124",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State Veterans Home",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9aa",
+        "black_list": false,
+        "code": "32125",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Sharing Agreements",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ab",
+        "black_list": false,
+        "code": "32126",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Federal Agency",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ac",
+        "black_list": false,
+        "code": "322",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Non-veteran care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ad",
+        "black_list": false,
+        "code": "3221",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Civilian Health and Medical Program for the VA (CHAMPVA)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ae",
+        "black_list": false,
+        "code": "3222",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Spina Bifida Health Care Program (SB)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9af",
+        "black_list": false,
+        "code": "3223",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Children of Women Vietnam Veterans (CWVV)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b0",
+        "black_list": false,
+        "code": "3229",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other non-veteran care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b1",
+        "black_list": false,
+        "code": "33",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service or Tribe",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b2",
+        "black_list": false,
+        "code": "331",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service -- Regular",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b3",
+        "black_list": false,
+        "code": "332",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service -- Contract",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b4",
+        "black_list": false,
+        "code": "333",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Health Service - Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b5",
+        "black_list": false,
+        "code": "334",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Indian Tribe - Sponsored Coverage",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b6",
+        "black_list": false,
+        "code": "34",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HRSA Program",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b7",
+        "black_list": false,
+        "code": "341",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Title V (MCH Block Grant)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b8",
+        "black_list": false,
+        "code": "342",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Migrant Health Program",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9b9",
+        "black_list": false,
+        "code": "343",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Ryan White Act",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ba",
+        "black_list": false,
+        "code": "349",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9bb",
+        "black_list": false,
+        "code": "35",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Black Lung",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9bc",
+        "black_list": false,
+        "code": "36",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State Government",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9bd",
+        "black_list": false,
+        "code": "361",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State SCHIP program (codes for individual states)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9be",
+        "black_list": false,
+        "code": "362",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Specific state programs (list/ local code)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9bf",
+        "black_list": false,
+        "code": "369",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "State, not otherwise specified (other state)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c0",
+        "black_list": false,
+        "code": "37",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local Government",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c1",
+        "black_list": false,
+        "code": "371",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local - Managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c2",
+        "black_list": false,
+        "code": "3711",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c3",
+        "black_list": false,
+        "code": "3712",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c4",
+        "black_list": false,
+        "code": "3713",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c5",
+        "black_list": false,
+        "code": "372",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "FFS/Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c6",
+        "black_list": false,
+        "code": "379",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Local, not otherwise specified (other local, county)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c7",
+        "black_list": false,
+        "code": "38",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Government (Federal, State, Local not specified)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c8",
+        "black_list": false,
+        "code": "381",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9c9",
+        "black_list": false,
+        "code": "3811",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ca",
+        "black_list": false,
+        "code": "3812",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9cb",
+        "black_list": false,
+        "code": "3813",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9cc",
+        "black_list": false,
+        "code": "3819",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - not specified managed care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9cd",
+        "black_list": false,
+        "code": "382",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - FFS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ce",
+        "black_list": false,
+        "code": "389",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Federal, State, Local not specified - Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9cf",
+        "black_list": false,
+        "code": "39",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Federal",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d0",
+        "black_list": false,
+        "code": "4",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "DEPARTMENTS OF CORRECTIONS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d1",
+        "black_list": false,
+        "code": "41",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Federal",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d2",
+        "black_list": false,
+        "code": "42",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections State",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d3",
+        "black_list": false,
+        "code": "43",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Local",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d4",
+        "black_list": false,
+        "code": "44",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Corrections Unknown Level",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d5",
+        "black_list": false,
+        "code": "5",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PRIVATE HEALTH INSURANCE",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d6",
+        "black_list": false,
+        "code": "51",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care (Private)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d7",
+        "black_list": false,
+        "code": "511",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d8",
+        "black_list": false,
+        "code": "512",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9d9",
+        "black_list": false,
+        "code": "513",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9da",
+        "black_list": false,
+        "code": "514",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Exclusive Provider Organization",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9db",
+        "black_list": false,
+        "code": "515",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Gatekeeper PPO (GPPO)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9dc",
+        "black_list": false,
+        "code": "516",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Managed Care - Pharmacy Benefit Manager",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9dd",
+        "black_list": false,
+        "code": "519",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care, Other (non HMO)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9de",
+        "black_list": false,
+        "code": "52",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Private Health Insurance - Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9df",
+        "black_list": false,
+        "code": "521",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Commercial Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e0",
+        "black_list": false,
+        "code": "522",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Self-insured (ERISA) Administrative Services Only (ASO) plan",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e1",
+        "black_list": false,
+        "code": "523",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Medicare supplemental policy (as second payer)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e2",
+        "black_list": false,
+        "code": "529",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Private health insurance--other commercial Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e3",
+        "black_list": false,
+        "code": "53",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Managed Care (private) or private health insurance (indemnity), not otherwise specified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e4",
+        "black_list": false,
+        "code": "54",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Organized Delivery System",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e5",
+        "black_list": false,
+        "code": "55",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Small Employer Purchasing Group",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e6",
+        "black_list": false,
+        "code": "56",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Specialized Stand Alone Plan",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e7",
+        "black_list": false,
+        "code": "561",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Dental",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e8",
+        "black_list": false,
+        "code": "562",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Vision",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9e9",
+        "black_list": false,
+        "code": "59",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Private Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ea",
+        "black_list": false,
+        "code": "6",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BLUE CROSS/BLUE SHIELD",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9eb",
+        "black_list": false,
+        "code": "61",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ec",
+        "black_list": false,
+        "code": "611",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ed",
+        "black_list": false,
+        "code": "612",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ee",
+        "black_list": false,
+        "code": "613",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ef",
+        "black_list": false,
+        "code": "619",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Managed Care -- Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f0",
+        "black_list": false,
+        "code": "62",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC Indemnity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f1",
+        "black_list": false,
+        "code": "63",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Out of State",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f2",
+        "black_list": false,
+        "code": "64",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f3",
+        "black_list": false,
+        "code": "69",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "BC (Indemnity or Managed Care) - Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f4",
+        "black_list": false,
+        "code": "7",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MANAGED CARE, UNSPECIFIED (to be used only if one can't distinguish public from private)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f5",
+        "black_list": false,
+        "code": "71",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f6",
+        "black_list": false,
+        "code": "72",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "PPO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f7",
+        "black_list": false,
+        "code": "73",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "POS",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f8",
+        "black_list": false,
+        "code": "79",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9f9",
+        "black_list": false,
+        "code": "8",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "NO PAYMENT from an Organization/Agency/Program/Private Payer Listed",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9fa",
+        "black_list": false,
+        "code": "81",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Self-pay",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9fb",
+        "black_list": false,
+        "code": "82",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Charge",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9fc",
+        "black_list": false,
+        "code": "821",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Charity",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9fd",
+        "black_list": false,
+        "code": "822",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Professional Courtesy",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9fe",
+        "black_list": false,
+        "code": "823",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Research/Clinical Trial",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7b9ff",
+        "black_list": false,
+        "code": "83",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Refusal to Pay/Bad Debt",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba00",
+        "black_list": false,
+        "code": "84",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Hill Burton Free Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba01",
+        "black_list": false,
+        "code": "85",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Research/Donor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba02",
+        "black_list": false,
+        "code": "89",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Payment, Other",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba03",
+        "black_list": false,
+        "code": "9",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "MISCELLANEOUS/OTHER",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba04",
+        "black_list": false,
+        "code": "91",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Foreign National",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba05",
+        "black_list": false,
+        "code": "92",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other (Non-government)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba06",
+        "black_list": false,
+        "code": "93",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Disability Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba07",
+        "black_list": false,
+        "code": "94",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Long-term Care Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba08",
+        "black_list": false,
+        "code": "95",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Compensation",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba09",
+        "black_list": false,
+        "code": "951",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp HMO",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0a",
+        "black_list": false,
+        "code": "953",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp Fee-for-Service",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0b",
+        "black_list": false,
+        "code": "954",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp Other Managed Care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0c",
+        "black_list": false,
+        "code": "959",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Worker's Comp, Other unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0d",
+        "black_list": false,
+        "code": "96",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Auto Insurance (includes no fault)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0e",
+        "black_list": false,
+        "code": "97",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Legal Liability / Liability Insurance",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba0f",
+        "black_list": false,
+        "code": "98",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Other specified but not otherwise classifiable (includes Hospice - Unspecified plan)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba10",
+        "black_list": false,
+        "code": "99",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "No Typology Code available for payment source",
+        "white_list": false
+      },
+      {
+        "_id": "5a259650942c6d5d8ba7ba11",
+        "black_list": false,
+        "code": "9999",
+        "code_system": "2.16.840.1.113883.3.221.5",
+        "code_system_name": "Source of Payment Typology",
+        "code_system_version": "6.0",
+        "display_name": "Unavailable / No Payer Specified / Blank",
+        "white_list": false
+      }
+    ],
+    "display_name": "Payer",
+    "oid": "2.16.840.1.114222.4.11.3591",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259651942c6d5d8ba7ba12",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259652942c6d5d8ba7ba13",
+        "black_list": false,
+        "code": "102879009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Post-term delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba14",
+        "black_list": false,
+        "code": "106007006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Maternal AND/OR fetal condition affecting labor AND/OR delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba15",
+        "black_list": false,
+        "code": "10950002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vulval hematoma during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba16",
+        "black_list": false,
+        "code": "128077009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Trauma to vagina during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba17",
+        "black_list": false,
+        "code": "14331002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Failed vacuum extraction delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba18",
+        "black_list": false,
+        "code": "16574001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Cardiac arrest after obstetrical surgery AND/OR other procedure including delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba19",
+        "black_list": false,
+        "code": "169961004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Normal birth (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1a",
+        "black_list": false,
+        "code": "198617006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery of viable fetus in abdominal pregnancy (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1b",
+        "black_list": false,
+        "code": "199063009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Post-term pregnancy - delivered (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1c",
+        "black_list": false,
+        "code": "199314001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Normal delivery but ante- or post- natal conditions present (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1d",
+        "black_list": false,
+        "code": "199934009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Fourth degree perineal tear during delivery - delivered (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1e",
+        "black_list": false,
+        "code": "199935005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Fourth degree perineal tear during delivery with postnatal problem (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba1f",
+        "black_list": false,
+        "code": "200130005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps delivery - delivered (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba20",
+        "black_list": false,
+        "code": "200133007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by combination of forceps and vacuum extractor (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba21",
+        "black_list": false,
+        "code": "200138003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vacuum extractor delivery - delivered (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba22",
+        "black_list": false,
+        "code": "200142000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech extraction - delivered (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba23",
+        "black_list": false,
+        "code": "200146002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Cesarean delivery - delivered (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba24",
+        "black_list": false,
+        "code": "200148001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by elective cesarean section (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba25",
+        "black_list": false,
+        "code": "200149009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by emergency cesarean section (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba26",
+        "black_list": false,
+        "code": "200150009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by cesarean hysterectomy (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba27",
+        "black_list": false,
+        "code": "206121009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Fetal or neonatal effect of forceps delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba28",
+        "black_list": false,
+        "code": "206123007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Fetal or neonatal effect of cesarean section (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba29",
+        "black_list": false,
+        "code": "21987001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delayed delivery of second of multiple births (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2a",
+        "black_list": false,
+        "code": "22846003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatorenal syndrome following delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2b",
+        "black_list": false,
+        "code": "237313003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vaginal delivery following previous cesarean section (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2c",
+        "black_list": false,
+        "code": "237321009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delayed delivery of triplet (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2d",
+        "black_list": false,
+        "code": "237325000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Head entrapment during breech delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2e",
+        "black_list": false,
+        "code": "23885003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Inversion of uterus during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba2f",
+        "black_list": false,
+        "code": "24258008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Damage to pelvic joints AND/OR ligaments during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba30",
+        "black_list": false,
+        "code": "271368004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivered by low forceps delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba31",
+        "black_list": false,
+        "code": "271369007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivered by mid-cavity forceps delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba32",
+        "black_list": false,
+        "code": "271373005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Deliveries by spontaneous breech delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba33",
+        "black_list": false,
+        "code": "274127000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Abnormal delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba34",
+        "black_list": false,
+        "code": "274128005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Brow delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba35",
+        "black_list": false,
+        "code": "274129002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Face delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba36",
+        "black_list": false,
+        "code": "288209009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Normal delivery - occipitoanterior (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba37",
+        "black_list": false,
+        "code": "289259007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vaginal delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba38",
+        "black_list": false,
+        "code": "302254004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivered by cesarean delivery following previous cesarean delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba39",
+        "black_list": false,
+        "code": "309469004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Spontaneous vertex delivery (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3a",
+        "black_list": false,
+        "code": "35347003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delayed delivery after artificial rupture of membranes (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3b",
+        "black_list": false,
+        "code": "42599006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Trauma from instrument during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3c",
+        "black_list": false,
+        "code": "46502006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hematoma of vagina during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3d",
+        "black_list": false,
+        "code": "4787007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Fetal or neonatal effect of breech delivery and extraction (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3e",
+        "black_list": false,
+        "code": "48782003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery normal (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba3f",
+        "black_list": false,
+        "code": "48888007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Placenta previa found before labor AND delivery by cesarean section without hemorrhage (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba40",
+        "black_list": false,
+        "code": "49815007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Damage to coccyx during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba41",
+        "black_list": false,
+        "code": "5740008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Pelvic hematoma during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba42",
+        "black_list": false,
+        "code": "61007003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Separation of symphysis pubis during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba43",
+        "black_list": false,
+        "code": "64646001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Failed forceps delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba44",
+        "black_list": false,
+        "code": "64954002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Avulsion of inner symphyseal cartilage during delivery (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba45",
+        "black_list": false,
+        "code": "O10.22",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pre-existing hypertensive chronic kidney disease complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba46",
+        "black_list": false,
+        "code": "O10.32",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pre-existing hypertensive heart and chronic kidney disease complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba47",
+        "black_list": false,
+        "code": "O10.42",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pre-existing secondary hypertension complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba48",
+        "black_list": false,
+        "code": "O10.92",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified pre-existing hypertension complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba49",
+        "black_list": false,
+        "code": "O15.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Eclampsia complicating labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4a",
+        "black_list": false,
+        "code": "O24.02",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pre-existing type 1 diabetes mellitus, in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4b",
+        "black_list": false,
+        "code": "O24.12",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pre-existing type 2 diabetes mellitus, in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4c",
+        "black_list": false,
+        "code": "O24.32",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified pre-existing diabetes mellitus in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4d",
+        "black_list": false,
+        "code": "O24.420",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gestational diabetes mellitus in childbirth, diet controlled",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4e",
+        "black_list": false,
+        "code": "O24.424",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gestational diabetes mellitus in childbirth, insulin controlled",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba4f",
+        "black_list": false,
+        "code": "O24.425",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gestational diabetes mellitus in childbirth, controlled by oral hypoglycemic drugs",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba50",
+        "black_list": false,
+        "code": "O24.429",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gestational diabetes mellitus in childbirth, unspecified control",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba51",
+        "black_list": false,
+        "code": "O24.435",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gestational diabetes mellitus in puerperium, controlled by oral hypoglycemic drugs",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba52",
+        "black_list": false,
+        "code": "O24.82",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other pre-existing diabetes mellitus in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba53",
+        "black_list": false,
+        "code": "O24.92",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified diabetes mellitus in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba54",
+        "black_list": false,
+        "code": "O25.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Malnutrition in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba55",
+        "black_list": false,
+        "code": "O26.62",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Liver and biliary tract disorders in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba56",
+        "black_list": false,
+        "code": "O26.72",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Subluxation of symphysis (pubis) in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba57",
+        "black_list": false,
+        "code": "O41.8X25",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other specified disorders of amniotic fluid and membranes, second trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba58",
+        "black_list": false,
+        "code": "O60.10X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba59",
+        "black_list": false,
+        "code": "O60.10X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5a",
+        "black_list": false,
+        "code": "O60.10X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5b",
+        "black_list": false,
+        "code": "O60.10X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5c",
+        "black_list": false,
+        "code": "O60.10X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5d",
+        "black_list": false,
+        "code": "O60.10X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5e",
+        "black_list": false,
+        "code": "O60.10X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor with preterm delivery, unspecified trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba5f",
+        "black_list": false,
+        "code": "O60.12X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba60",
+        "black_list": false,
+        "code": "O60.12X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba61",
+        "black_list": false,
+        "code": "O60.12X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba62",
+        "black_list": false,
+        "code": "O60.12X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba63",
+        "black_list": false,
+        "code": "O60.12X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba64",
+        "black_list": false,
+        "code": "O60.12X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba65",
+        "black_list": false,
+        "code": "O60.12X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery second trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba66",
+        "black_list": false,
+        "code": "O60.13X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba67",
+        "black_list": false,
+        "code": "O60.13X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba68",
+        "black_list": false,
+        "code": "O60.13X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba69",
+        "black_list": false,
+        "code": "O60.13X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6a",
+        "black_list": false,
+        "code": "O60.13X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6b",
+        "black_list": false,
+        "code": "O60.13X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6c",
+        "black_list": false,
+        "code": "O60.13X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor second trimester with preterm delivery third trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6d",
+        "black_list": false,
+        "code": "O60.14X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6e",
+        "black_list": false,
+        "code": "O60.14X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba6f",
+        "black_list": false,
+        "code": "O60.14X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba70",
+        "black_list": false,
+        "code": "O60.14X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba71",
+        "black_list": false,
+        "code": "O60.14X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba72",
+        "black_list": false,
+        "code": "O60.14X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba73",
+        "black_list": false,
+        "code": "O60.14X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Preterm labor third trimester with preterm delivery third trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba74",
+        "black_list": false,
+        "code": "O60.20X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba75",
+        "black_list": false,
+        "code": "O60.20X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba76",
+        "black_list": false,
+        "code": "O60.20X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba77",
+        "black_list": false,
+        "code": "O60.20X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba78",
+        "black_list": false,
+        "code": "O60.20X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba79",
+        "black_list": false,
+        "code": "O60.20X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7a",
+        "black_list": false,
+        "code": "O60.20X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, unspecified trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7b",
+        "black_list": false,
+        "code": "O60.22X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7c",
+        "black_list": false,
+        "code": "O60.22X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7d",
+        "black_list": false,
+        "code": "O60.22X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7e",
+        "black_list": false,
+        "code": "O60.22X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba7f",
+        "black_list": false,
+        "code": "O60.22X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba80",
+        "black_list": false,
+        "code": "O60.22X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba81",
+        "black_list": false,
+        "code": "O60.22X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, second trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba82",
+        "black_list": false,
+        "code": "O60.23X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba83",
+        "black_list": false,
+        "code": "O60.23X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba84",
+        "black_list": false,
+        "code": "O60.23X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba85",
+        "black_list": false,
+        "code": "O60.23X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba86",
+        "black_list": false,
+        "code": "O60.23X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba87",
+        "black_list": false,
+        "code": "O60.23X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba88",
+        "black_list": false,
+        "code": "O60.23X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Term delivery with preterm labor, third trimester, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba89",
+        "black_list": false,
+        "code": "O61.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed medical induction of labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8a",
+        "black_list": false,
+        "code": "O61.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed instrumental induction of labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8b",
+        "black_list": false,
+        "code": "O61.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other failed induction of labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8c",
+        "black_list": false,
+        "code": "O61.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed induction of labor, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8d",
+        "black_list": false,
+        "code": "O62.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Primary inadequate contractions",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8e",
+        "black_list": false,
+        "code": "O62.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Secondary uterine inertia",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba8f",
+        "black_list": false,
+        "code": "O62.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other uterine inertia",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba90",
+        "black_list": false,
+        "code": "O62.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Precipitate labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba91",
+        "black_list": false,
+        "code": "O62.4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Hypertonic, incoordinate, and prolonged uterine contractions",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba92",
+        "black_list": false,
+        "code": "O62.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other abnormalities of forces of labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba93",
+        "black_list": false,
+        "code": "O62.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Abnormality of forces of labor, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba94",
+        "black_list": false,
+        "code": "O63.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Prolonged first stage (of labor)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba95",
+        "black_list": false,
+        "code": "O63.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Prolonged second stage (of labor)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba96",
+        "black_list": false,
+        "code": "O63.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Delayed delivery of second twin, triplet, etc.",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba97",
+        "black_list": false,
+        "code": "O63.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Long labor, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba98",
+        "black_list": false,
+        "code": "O64.0XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba99",
+        "black_list": false,
+        "code": "O64.0XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9a",
+        "black_list": false,
+        "code": "O64.0XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9b",
+        "black_list": false,
+        "code": "O64.0XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9c",
+        "black_list": false,
+        "code": "O64.0XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9d",
+        "black_list": false,
+        "code": "O64.0XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9e",
+        "black_list": false,
+        "code": "O64.0XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to incomplete rotation of fetal head, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7ba9f",
+        "black_list": false,
+        "code": "O64.1XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa0",
+        "black_list": false,
+        "code": "O64.1XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa1",
+        "black_list": false,
+        "code": "O64.1XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa2",
+        "black_list": false,
+        "code": "O64.1XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa3",
+        "black_list": false,
+        "code": "O64.1XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa4",
+        "black_list": false,
+        "code": "O64.1XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa5",
+        "black_list": false,
+        "code": "O64.1XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to breech presentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa6",
+        "black_list": false,
+        "code": "O64.2XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa7",
+        "black_list": false,
+        "code": "O64.2XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa8",
+        "black_list": false,
+        "code": "O64.2XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baa9",
+        "black_list": false,
+        "code": "O64.2XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baaa",
+        "black_list": false,
+        "code": "O64.2XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baab",
+        "black_list": false,
+        "code": "O64.2XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baac",
+        "black_list": false,
+        "code": "O64.2XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to face presentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baad",
+        "black_list": false,
+        "code": "O64.3XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baae",
+        "black_list": false,
+        "code": "O64.3XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baaf",
+        "black_list": false,
+        "code": "O64.3XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab0",
+        "black_list": false,
+        "code": "O64.3XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab1",
+        "black_list": false,
+        "code": "O64.3XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab2",
+        "black_list": false,
+        "code": "O64.3XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab3",
+        "black_list": false,
+        "code": "O64.3XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to brow presentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab4",
+        "black_list": false,
+        "code": "O64.4XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab5",
+        "black_list": false,
+        "code": "O64.4XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab6",
+        "black_list": false,
+        "code": "O64.4XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab7",
+        "black_list": false,
+        "code": "O64.4XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab8",
+        "black_list": false,
+        "code": "O64.4XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bab9",
+        "black_list": false,
+        "code": "O64.4XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baba",
+        "black_list": false,
+        "code": "O64.4XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder presentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7babb",
+        "black_list": false,
+        "code": "O64.5XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7babc",
+        "black_list": false,
+        "code": "O64.5XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7babd",
+        "black_list": false,
+        "code": "O64.5XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7babe",
+        "black_list": false,
+        "code": "O64.5XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7babf",
+        "black_list": false,
+        "code": "O64.5XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac0",
+        "black_list": false,
+        "code": "O64.5XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac1",
+        "black_list": false,
+        "code": "O64.5XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to compound presentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac2",
+        "black_list": false,
+        "code": "O64.8XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac3",
+        "black_list": false,
+        "code": "O64.8XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac4",
+        "black_list": false,
+        "code": "O64.8XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac5",
+        "black_list": false,
+        "code": "O64.8XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac6",
+        "black_list": false,
+        "code": "O64.8XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac7",
+        "black_list": false,
+        "code": "O64.8XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac8",
+        "black_list": false,
+        "code": "O64.8XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other malposition and malpresentation, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bac9",
+        "black_list": false,
+        "code": "O64.9XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baca",
+        "black_list": false,
+        "code": "O64.9XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bacb",
+        "black_list": false,
+        "code": "O64.9XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bacc",
+        "black_list": false,
+        "code": "O64.9XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bacd",
+        "black_list": false,
+        "code": "O64.9XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bace",
+        "black_list": false,
+        "code": "O64.9XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bacf",
+        "black_list": false,
+        "code": "O64.9XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to malposition and malpresentation, unspecified, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad0",
+        "black_list": false,
+        "code": "O65.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to deformed pelvis",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad1",
+        "black_list": false,
+        "code": "O65.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to generally contracted pelvis",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad2",
+        "black_list": false,
+        "code": "O65.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to pelvic inlet contraction",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad3",
+        "black_list": false,
+        "code": "O65.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to pelvic outlet and mid-cavity contraction",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad4",
+        "black_list": false,
+        "code": "O65.4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to fetopelvic disproportion, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad5",
+        "black_list": false,
+        "code": "O65.5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to abnormality of maternal pelvic organs",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad6",
+        "black_list": false,
+        "code": "O65.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other maternal pelvic abnormalities",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad7",
+        "black_list": false,
+        "code": "O65.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to maternal pelvic abnormality, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad8",
+        "black_list": false,
+        "code": "O66.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to shoulder dystocia",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bad9",
+        "black_list": false,
+        "code": "O66.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to locked twins",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bada",
+        "black_list": false,
+        "code": "O66.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to unusually large fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7badb",
+        "black_list": false,
+        "code": "O66.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other abnormalities of fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7badc",
+        "black_list": false,
+        "code": "O66.40",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed trial of labor, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7badd",
+        "black_list": false,
+        "code": "O66.41",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed attempted vaginal birth after previous cesarean delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bade",
+        "black_list": false,
+        "code": "O66.5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Attempted application of vacuum extractor and forceps",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7badf",
+        "black_list": false,
+        "code": "O66.6",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor due to other multiple fetuses",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae0",
+        "black_list": false,
+        "code": "O66.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other specified obstructed labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae1",
+        "black_list": false,
+        "code": "O66.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obstructed labor, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae2",
+        "black_list": false,
+        "code": "O68",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by abnormality of fetal acid-base balance",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae3",
+        "black_list": false,
+        "code": "O69.0XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae4",
+        "black_list": false,
+        "code": "O69.0XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae5",
+        "black_list": false,
+        "code": "O69.0XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae6",
+        "black_list": false,
+        "code": "O69.0XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae7",
+        "black_list": false,
+        "code": "O69.0XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae8",
+        "black_list": false,
+        "code": "O69.0XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bae9",
+        "black_list": false,
+        "code": "O69.0XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by prolapse of cord, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baea",
+        "black_list": false,
+        "code": "O69.1XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baeb",
+        "black_list": false,
+        "code": "O69.1XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baec",
+        "black_list": false,
+        "code": "O69.1XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baed",
+        "black_list": false,
+        "code": "O69.1XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baee",
+        "black_list": false,
+        "code": "O69.1XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baef",
+        "black_list": false,
+        "code": "O69.1XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf0",
+        "black_list": false,
+        "code": "O69.1XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, with compression, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf1",
+        "black_list": false,
+        "code": "O69.2XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf2",
+        "black_list": false,
+        "code": "O69.2XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf3",
+        "black_list": false,
+        "code": "O69.2XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf4",
+        "black_list": false,
+        "code": "O69.2XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf5",
+        "black_list": false,
+        "code": "O69.2XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf6",
+        "black_list": false,
+        "code": "O69.2XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf7",
+        "black_list": false,
+        "code": "O69.2XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, with compression, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf8",
+        "black_list": false,
+        "code": "O69.3XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baf9",
+        "black_list": false,
+        "code": "O69.3XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bafa",
+        "black_list": false,
+        "code": "O69.3XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bafb",
+        "black_list": false,
+        "code": "O69.3XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bafc",
+        "black_list": false,
+        "code": "O69.3XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bafd",
+        "black_list": false,
+        "code": "O69.3XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bafe",
+        "black_list": false,
+        "code": "O69.3XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by short cord, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7baff",
+        "black_list": false,
+        "code": "O69.4XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb00",
+        "black_list": false,
+        "code": "O69.4XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb01",
+        "black_list": false,
+        "code": "O69.4XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb02",
+        "black_list": false,
+        "code": "O69.4XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb03",
+        "black_list": false,
+        "code": "O69.4XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb04",
+        "black_list": false,
+        "code": "O69.4XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb05",
+        "black_list": false,
+        "code": "O69.4XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vasa previa, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb06",
+        "black_list": false,
+        "code": "O69.5XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb07",
+        "black_list": false,
+        "code": "O69.5XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb08",
+        "black_list": false,
+        "code": "O69.5XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb09",
+        "black_list": false,
+        "code": "O69.5XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0a",
+        "black_list": false,
+        "code": "O69.5XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0b",
+        "black_list": false,
+        "code": "O69.5XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0c",
+        "black_list": false,
+        "code": "O69.5XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by vascular lesion of cord, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0d",
+        "black_list": false,
+        "code": "O69.81X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0e",
+        "black_list": false,
+        "code": "O69.81X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb0f",
+        "black_list": false,
+        "code": "O69.81X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb10",
+        "black_list": false,
+        "code": "O69.81X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb11",
+        "black_list": false,
+        "code": "O69.81X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb12",
+        "black_list": false,
+        "code": "O69.81X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb13",
+        "black_list": false,
+        "code": "O69.81X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord around neck, without compression, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb14",
+        "black_list": false,
+        "code": "O69.82X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb15",
+        "black_list": false,
+        "code": "O69.82X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb16",
+        "black_list": false,
+        "code": "O69.82X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb17",
+        "black_list": false,
+        "code": "O69.82X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb18",
+        "black_list": false,
+        "code": "O69.82X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb19",
+        "black_list": false,
+        "code": "O69.82X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1a",
+        "black_list": false,
+        "code": "O69.82X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord entanglement, without compression, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1b",
+        "black_list": false,
+        "code": "O69.89X0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1c",
+        "black_list": false,
+        "code": "O69.89X1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1d",
+        "black_list": false,
+        "code": "O69.89X2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1e",
+        "black_list": false,
+        "code": "O69.89X3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb1f",
+        "black_list": false,
+        "code": "O69.89X4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb20",
+        "black_list": false,
+        "code": "O69.89X5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb21",
+        "black_list": false,
+        "code": "O69.89X9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other cord complications, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb22",
+        "black_list": false,
+        "code": "O69.9XX0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, not applicable or unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb23",
+        "black_list": false,
+        "code": "O69.9XX1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, fetus 1",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb24",
+        "black_list": false,
+        "code": "O69.9XX2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, fetus 2",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb25",
+        "black_list": false,
+        "code": "O69.9XX3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, fetus 3",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb26",
+        "black_list": false,
+        "code": "O69.9XX4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, fetus 4",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb27",
+        "black_list": false,
+        "code": "O69.9XX5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, fetus 5",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb28",
+        "black_list": false,
+        "code": "O69.9XX9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by cord complication, unspecified, other fetus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb29",
+        "black_list": false,
+        "code": "O70.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "First degree perineal laceration during delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2a",
+        "black_list": false,
+        "code": "O70.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Second degree perineal laceration during delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2b",
+        "black_list": false,
+        "code": "O70.20",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Third degree perineal laceration during delivery, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2c",
+        "black_list": false,
+        "code": "O70.21",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Third degree perineal laceration during delivery, IIIa",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2d",
+        "black_list": false,
+        "code": "O70.22",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Third degree perineal laceration during delivery, IIIb",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2e",
+        "black_list": false,
+        "code": "O70.23",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Third degree perineal laceration during delivery, IIIc",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb2f",
+        "black_list": false,
+        "code": "O70.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Fourth degree perineal laceration during delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb30",
+        "black_list": false,
+        "code": "O70.4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Anal sphincter tear complicating delivery, not associated with third degree laceration",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb31",
+        "black_list": false,
+        "code": "O70.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Perineal laceration during delivery, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb32",
+        "black_list": false,
+        "code": "O71.00",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Rupture of uterus before onset of labor, unspecified trimester",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb33",
+        "black_list": false,
+        "code": "O71.02",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Rupture of uterus before onset of labor, second trimester",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb34",
+        "black_list": false,
+        "code": "O71.03",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Rupture of uterus before onset of labor, third trimester",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb35",
+        "black_list": false,
+        "code": "O71.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Rupture of uterus during labor",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb36",
+        "black_list": false,
+        "code": "O71.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Postpartum inversion of uterus",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb37",
+        "black_list": false,
+        "code": "O74.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other pulmonary complications of anesthesia during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb38",
+        "black_list": false,
+        "code": "O74.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Cardiac complications of anesthesia during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb39",
+        "black_list": false,
+        "code": "O74.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Central nervous system complications of anesthesia during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3a",
+        "black_list": false,
+        "code": "O74.4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Toxic reaction to local anesthesia during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3b",
+        "black_list": false,
+        "code": "O74.7",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Failed or difficult intubation for anesthesia during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3c",
+        "black_list": false,
+        "code": "O74.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Complication of anesthesia during labor and delivery, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3d",
+        "black_list": false,
+        "code": "O75.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Maternal distress during labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3e",
+        "black_list": false,
+        "code": "O75.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Shock during or following labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb3f",
+        "black_list": false,
+        "code": "O75.5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Delayed delivery after artificial rupture of membranes",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb40",
+        "black_list": false,
+        "code": "O75.81",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Maternal exhaustion complicating labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb41",
+        "black_list": false,
+        "code": "O75.82",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Onset (spontaneous) of labor after 37 completed weeks of gestation but before 39 completed weeks gestation, with delivery by (planned) cesarean section",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb42",
+        "black_list": false,
+        "code": "O75.89",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other specified complications of labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb43",
+        "black_list": false,
+        "code": "O75.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Complication of labor and delivery, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb44",
+        "black_list": false,
+        "code": "O76",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Abnormality in fetal heart rate and rhythm complicating labor and delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb45",
+        "black_list": false,
+        "code": "O77.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by meconium in amniotic fluid",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb46",
+        "black_list": false,
+        "code": "O77.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by other evidence of fetal stress",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb47",
+        "black_list": false,
+        "code": "O77.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Labor and delivery complicated by fetal stress, unspecified",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb48",
+        "black_list": false,
+        "code": "O80",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Encounter for full-term uncomplicated delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb49",
+        "black_list": false,
+        "code": "O82",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Encounter for cesarean delivery without indication",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4a",
+        "black_list": false,
+        "code": "O88.02",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Air embolism in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4b",
+        "black_list": false,
+        "code": "O88.12",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Amniotic fluid embolism in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4c",
+        "black_list": false,
+        "code": "O88.22",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Thromboembolism in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4d",
+        "black_list": false,
+        "code": "O88.32",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Pyemic and septic embolism in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4e",
+        "black_list": false,
+        "code": "O88.82",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other embolism in childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb4f",
+        "black_list": false,
+        "code": "O98.02",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Tuberculosis complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb50",
+        "black_list": false,
+        "code": "O98.12",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Syphilis complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb51",
+        "black_list": false,
+        "code": "O98.22",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Gonorrhea complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb52",
+        "black_list": false,
+        "code": "O98.32",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other infections with a predominantly sexual mode of transmission complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb53",
+        "black_list": false,
+        "code": "O98.42",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Viral hepatitis complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb54",
+        "black_list": false,
+        "code": "O98.52",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other viral diseases complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb55",
+        "black_list": false,
+        "code": "O98.62",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Protozoal diseases complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb56",
+        "black_list": false,
+        "code": "O98.72",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Human immunodeficiency virus [HIV] disease complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb57",
+        "black_list": false,
+        "code": "O98.82",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other maternal infectious and parasitic diseases complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb58",
+        "black_list": false,
+        "code": "O98.92",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified maternal infectious and parasitic disease complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb59",
+        "black_list": false,
+        "code": "O99.02",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Anemia complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5a",
+        "black_list": false,
+        "code": "O99.12",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other diseases of the blood and blood-forming organs and certain disorders involving the immune mechanism complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5b",
+        "black_list": false,
+        "code": "O99.214",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Obesity complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5c",
+        "black_list": false,
+        "code": "O99.284",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Endocrine, nutritional and metabolic diseases complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5d",
+        "black_list": false,
+        "code": "O99.314",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Alcohol use complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5e",
+        "black_list": false,
+        "code": "O99.324",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Drug use complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb5f",
+        "black_list": false,
+        "code": "O99.334",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Smoking (tobacco) complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb60",
+        "black_list": false,
+        "code": "O99.344",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other mental disorders complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb61",
+        "black_list": false,
+        "code": "O99.354",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Diseases of the nervous system complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb62",
+        "black_list": false,
+        "code": "O99.42",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Diseases of the circulatory system complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb63",
+        "black_list": false,
+        "code": "O99.52",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Diseases of the respiratory system complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb64",
+        "black_list": false,
+        "code": "O99.62",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Diseases of the digestive system complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb65",
+        "black_list": false,
+        "code": "O99.72",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Diseases of the skin and subcutaneous tissue complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb66",
+        "black_list": false,
+        "code": "O99.814",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Abnormal glucose complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb67",
+        "black_list": false,
+        "code": "O99.824",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Streptococcus B carrier state complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb68",
+        "black_list": false,
+        "code": "O99.834",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other infection carrier state complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb69",
+        "black_list": false,
+        "code": "O99.844",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Bariatric surgery status complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6a",
+        "black_list": false,
+        "code": "O9A.12",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Malignant neoplasm complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6b",
+        "black_list": false,
+        "code": "O9A.22",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Injury, poisoning and certain other consequences of external causes complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6c",
+        "black_list": false,
+        "code": "O9A.32",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Physical abuse complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6d",
+        "black_list": false,
+        "code": "O9A.42",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Sexual abuse complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6e",
+        "black_list": false,
+        "code": "O9A.52",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Psychological abuse complicating childbirth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb6f",
+        "black_list": false,
+        "code": "Z37.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Single live birth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb70",
+        "black_list": false,
+        "code": "Z37.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twins, both liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb71",
+        "black_list": false,
+        "code": "Z37.3",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twins, one liveborn and one stillborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb72",
+        "black_list": false,
+        "code": "Z37.50",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Multiple births, unspecified, all liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb73",
+        "black_list": false,
+        "code": "Z37.51",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Triplets, all liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb74",
+        "black_list": false,
+        "code": "Z37.52",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quadruplets, all liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb75",
+        "black_list": false,
+        "code": "Z37.54",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Sextuplets, all liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb76",
+        "black_list": false,
+        "code": "Z37.59",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple births, all liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb77",
+        "black_list": false,
+        "code": "Z37.61",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Triplets, some liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb78",
+        "black_list": false,
+        "code": "Z37.62",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quadruplets, some liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb79",
+        "black_list": false,
+        "code": "Z37.63",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quintuplets, some liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7a",
+        "black_list": false,
+        "code": "Z37.64",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Sextuplets, some liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7b",
+        "black_list": false,
+        "code": "Z37.69",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple births, some liveborn",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7c",
+        "black_list": false,
+        "code": "Z38.00",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Single liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7d",
+        "black_list": false,
+        "code": "Z38.01",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Single liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7e",
+        "black_list": false,
+        "code": "Z38.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Single liveborn infant, born outside hospital",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb7f",
+        "black_list": false,
+        "code": "Z38.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Single liveborn infant, unspecified as to place of birth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb80",
+        "black_list": false,
+        "code": "Z38.30",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twin liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb81",
+        "black_list": false,
+        "code": "Z38.31",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twin liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb82",
+        "black_list": false,
+        "code": "Z38.4",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twin liveborn infant, born outside hospital",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb83",
+        "black_list": false,
+        "code": "Z38.5",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Twin liveborn infant, unspecified as to place of birth",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb84",
+        "black_list": false,
+        "code": "Z38.61",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Triplet liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb85",
+        "black_list": false,
+        "code": "Z38.62",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Triplet liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb86",
+        "black_list": false,
+        "code": "Z38.63",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quadruplet liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb87",
+        "black_list": false,
+        "code": "Z38.64",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quadruplet liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb88",
+        "black_list": false,
+        "code": "Z38.65",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quintuplet liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb89",
+        "black_list": false,
+        "code": "Z38.66",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Quintuplet liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb8a",
+        "black_list": false,
+        "code": "Z38.68",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple liveborn infant, delivered vaginally",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb8b",
+        "black_list": false,
+        "code": "Z38.69",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple liveborn infant, delivered by cesarean",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb8c",
+        "black_list": false,
+        "code": "Z38.7",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple liveborn infant, born outside hospital",
+        "white_list": false
+      },
+      {
+        "_id": "5a259652942c6d5d8ba7bb8d",
+        "black_list": false,
+        "code": "Z38.8",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Other multiple liveborn infant, unspecified as to place of birth",
+        "white_list": false
+      }
+    ],
+    "display_name": "Delivery - Diagnosis",
+    "oid": "2.16.840.1.113883.3.67.1.101.1.278",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259653942c6d5d8ba7bb8e",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259653942c6d5d8ba7bb8f",
+        "black_list": false,
+        "code": "10745001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery of transverse presentation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb90",
+        "black_list": false,
+        "code": "10D00Z0",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Classical, Open Approach",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb91",
+        "black_list": false,
+        "code": "10D00Z1",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Low Cervical, Open Approach",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb92",
+        "black_list": false,
+        "code": "10D00Z2",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Extraperitoneal, Open Approach",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb93",
+        "black_list": false,
+        "code": "10D07Z3",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Low Forceps, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb94",
+        "black_list": false,
+        "code": "10D07Z4",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Mid Forceps, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb95",
+        "black_list": false,
+        "code": "10D07Z5",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, High Forceps, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb96",
+        "black_list": false,
+        "code": "10D07Z6",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Vacuum, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb97",
+        "black_list": false,
+        "code": "10D07Z7",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Internal Version, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb98",
+        "black_list": false,
+        "code": "10D07Z8",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Other, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb99",
+        "black_list": false,
+        "code": "10D17Z9",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Manual Extraction of Products of Conception, Retained, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9a",
+        "black_list": false,
+        "code": "10D17ZZ",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Retained, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9b",
+        "black_list": false,
+        "code": "10D18Z9",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Manual Extraction of Products of Conception, Retained, Via Natural or Artificial Opening Endoscopic",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9c",
+        "black_list": false,
+        "code": "10D18ZZ",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Retained, Via Natural or Artificial Opening Endoscopic",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9d",
+        "black_list": false,
+        "code": "10D27ZZ",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Ectopic, Via Natural or Artificial Opening",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9e",
+        "black_list": false,
+        "code": "10D28ZZ",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Extraction of Products of Conception, Ectopic, Via Natural or Artificial Opening Endoscopic",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bb9f",
+        "black_list": false,
+        "code": "10E0XZZ",
+        "code_system": "2.16.840.1.113883.6.4",
+        "code_system_name": "ICD-10-PCS",
+        "code_system_version": "2018",
+        "display_name": "Delivery of Products of Conception, External Approach",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba0",
+        "black_list": false,
+        "code": "11466000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba1",
+        "black_list": false,
+        "code": "14119008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Braxton Hicks obstetrical version with extraction (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba2",
+        "black_list": false,
+        "code": "15413009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "High forceps delivery with episiotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba3",
+        "black_list": false,
+        "code": "16819009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery of face presentation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba4",
+        "black_list": false,
+        "code": "177128002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Induction and delivery procedures (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba5",
+        "black_list": false,
+        "code": "177141003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Elective cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba6",
+        "black_list": false,
+        "code": "177142005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Elective upper segment cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba7",
+        "black_list": false,
+        "code": "177143000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Elective lower segment cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba8",
+        "black_list": false,
+        "code": "177152009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech extraction delivery with version (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bba9",
+        "black_list": false,
+        "code": "177157003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Spontaneous breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbaa",
+        "black_list": false,
+        "code": "177158008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Assisted breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbab",
+        "black_list": false,
+        "code": "177161009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps cephalic delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbac",
+        "black_list": false,
+        "code": "177162002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "High forceps cephalic delivery with rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbad",
+        "black_list": false,
+        "code": "177164001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Midforceps cephalic delivery with rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbae",
+        "black_list": false,
+        "code": "177167008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Barton forceps cephalic delivery with rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbaf",
+        "black_list": false,
+        "code": "177168003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "DeLee forceps cephalic delivery with rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb0",
+        "black_list": false,
+        "code": "177170007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Piper forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb1",
+        "black_list": false,
+        "code": "177173009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "High vacuum delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb2",
+        "black_list": false,
+        "code": "177174003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Low vacuum delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb3",
+        "black_list": false,
+        "code": "177175002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vacuum delivery before full dilation of cervix (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb4",
+        "black_list": false,
+        "code": "177176001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Trial of vacuum delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb5",
+        "black_list": false,
+        "code": "177179008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Cephalic vaginal delivery with abnormal presentation of head at delivery without instrument (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb6",
+        "black_list": false,
+        "code": "177180006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Manipulative cephalic vaginal delivery with abnormal presentation of head at delivery without instrument (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb7",
+        "black_list": false,
+        "code": "177181005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Non-manipulative cephalic vaginal delivery with abnormal presentation of head at delivery without instrument (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb8",
+        "black_list": false,
+        "code": "177184002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Normal delivery procedure (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbb9",
+        "black_list": false,
+        "code": "177203002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Manual removal of products of conception from delivered uterus (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbba",
+        "black_list": false,
+        "code": "17860005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Low forceps delivery with episiotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbbb",
+        "black_list": false,
+        "code": "18625004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Low forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbbc",
+        "black_list": false,
+        "code": "19390001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Partial breech delivery with forceps to aftercoming head (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbbd",
+        "black_list": false,
+        "code": "22633006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vaginal delivery, medical personnel present (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbbe",
+        "black_list": false,
+        "code": "236973005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery procedure (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbbf",
+        "black_list": false,
+        "code": "236974004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Instrumental delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc0",
+        "black_list": false,
+        "code": "236975003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Nonrotational forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc1",
+        "black_list": false,
+        "code": "236976002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Outlet forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc2",
+        "black_list": false,
+        "code": "236977006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps delivery, face to pubes (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc3",
+        "black_list": false,
+        "code": "236978001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps delivery to the aftercoming head (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc4",
+        "black_list": false,
+        "code": "236985002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Emergency lower segment cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc5",
+        "black_list": false,
+        "code": "236986001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Emergency upper segment cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc6",
+        "black_list": false,
+        "code": "236989008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Abdominal delivery for shoulder dystocia (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc7",
+        "black_list": false,
+        "code": "237311001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc8",
+        "black_list": false,
+        "code": "25296001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by Scanzoni maneuver (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbc9",
+        "black_list": false,
+        "code": "25828002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Mid forceps delivery with episiotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbca",
+        "black_list": false,
+        "code": "26313002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by vacuum extraction with episiotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbcb",
+        "black_list": false,
+        "code": "265639000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Midforceps delivery without rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbcc",
+        "black_list": false,
+        "code": "274130007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Emergency cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbcd",
+        "black_list": false,
+        "code": "275168001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Neville-Barnes forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbce",
+        "black_list": false,
+        "code": "275169009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Simpson's forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbcf",
+        "black_list": false,
+        "code": "287976008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech/instrumental delivery operations (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd0",
+        "black_list": false,
+        "code": "29613008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by double application of forceps (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd1",
+        "black_list": false,
+        "code": "302382009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech extraction with internal podalic version (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd2",
+        "black_list": false,
+        "code": "302383004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd3",
+        "black_list": false,
+        "code": "30476003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Barton's forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd4",
+        "black_list": false,
+        "code": "306727001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech presentation, delivery, no version (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd5",
+        "black_list": false,
+        "code": "359940006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Partial breech extraction (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd6",
+        "black_list": false,
+        "code": "359943008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Partial breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd7",
+        "black_list": false,
+        "code": "384729004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery of vertex presentation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd8",
+        "black_list": false,
+        "code": "38479009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Frank breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbd9",
+        "black_list": false,
+        "code": "386622003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Duhrssen's incisions of cervix to assist delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbda",
+        "black_list": false,
+        "code": "387711001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Pubiotomy to assist delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbdb",
+        "black_list": false,
+        "code": "398307005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Low cervical cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbdc",
+        "black_list": false,
+        "code": "40219000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by Malstrom's extraction with episiotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbdd",
+        "black_list": false,
+        "code": "416055001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Total breech extraction (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbde",
+        "black_list": false,
+        "code": "417121007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Breech extraction (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbdf",
+        "black_list": false,
+        "code": "45718005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vaginal delivery with forceps including postpartum care (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe0",
+        "black_list": false,
+        "code": "54973000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Total breech delivery with forceps to aftercoming head (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe1",
+        "black_list": false,
+        "code": "5556001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Manually assisted spontaneous delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe2",
+        "black_list": false,
+        "code": "57271003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Extraperitoneal cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe3",
+        "black_list": false,
+        "code": "59400",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Routine obstetric care including antepartum care, vaginal delivery (with or without episiotomy, and/or forceps) and postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe4",
+        "black_list": false,
+        "code": "59409",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Vaginal delivery only (with or without episiotomy and/or forceps)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe5",
+        "black_list": false,
+        "code": "59410",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Vaginal delivery only (with or without episiotomy and/or forceps); including postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe6",
+        "black_list": false,
+        "code": "59510",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Routine obstetric care including antepartum care, cesarean delivery, and postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe7",
+        "black_list": false,
+        "code": "59514",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Cesarean delivery only",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe8",
+        "black_list": false,
+        "code": "59515",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Cesarean delivery only; including postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbe9",
+        "black_list": false,
+        "code": "59610",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Routine obstetric care including antepartum care, vaginal delivery (with or without episiotomy, and/or forceps) and postpartum care, after previous cesarean delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbea",
+        "black_list": false,
+        "code": "59612",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Vaginal delivery only, after previous cesarean delivery (with or without episiotomy and/or forceps)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbeb",
+        "black_list": false,
+        "code": "59614",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Vaginal delivery only, after previous cesarean delivery (with or without episiotomy and/or forceps); including postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbec",
+        "black_list": false,
+        "code": "59618",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Routine obstetric care including antepartum care, cesarean delivery, and postpartum care, following attempted vaginal delivery after previous cesarean delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbed",
+        "black_list": false,
+        "code": "59620",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Cesarean delivery only, following attempted vaginal delivery after previous cesarean delivery",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbee",
+        "black_list": false,
+        "code": "59622",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Cesarean delivery only, following attempted vaginal delivery after previous cesarean delivery; including postpartum care",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbef",
+        "black_list": false,
+        "code": "61586001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by vacuum extraction (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf0",
+        "black_list": false,
+        "code": "62508004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Mid forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf1",
+        "black_list": false,
+        "code": "69162008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Cleidotomy (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf2",
+        "black_list": false,
+        "code": "69422002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Trial forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf3",
+        "black_list": false,
+        "code": "71166009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Forceps delivery with rotation of fetal head (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf4",
+        "black_list": false,
+        "code": "72492007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Footling breech delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf5",
+        "black_list": false,
+        "code": "84195007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Classical cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf6",
+        "black_list": false,
+        "code": "85403009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery, medical personnel present (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf7",
+        "black_list": false,
+        "code": "89053004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Vaginal cesarean section (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf8",
+        "black_list": false,
+        "code": "89346004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by Kielland rotation (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbf9",
+        "black_list": false,
+        "code": "89849000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "High forceps delivery (procedure)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259653942c6d5d8ba7bbfa",
+        "black_list": false,
+        "code": "90438006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Delivery by Malstrom's extraction (procedure)",
+        "white_list": false
+      }
+    ],
+    "display_name": "Delivery - Procedure",
+    "oid": "2.16.840.1.113762.1.4.1078.5",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259653942c6d5d8ba7bbfb",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259653942c6d5d8ba7bbfc",
+        "black_list": false,
+        "code": "F",
+        "code_system": "2.16.840.1.113883.5.1",
+        "code_system_name": "AdministrativeGender",
+        "code_system_version": "HL7V3.0_2016-07",
+        "display_name": "Female",
+        "white_list": false
+      }
+    ],
+    "display_name": "Female",
+    "oid": "2.16.840.1.113883.3.560.100.2",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259654942c6d5d8ba7bbfd",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259654942c6d5d8ba7bbfe",
+        "black_list": false,
+        "code": "5195-3",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Presence] in Serum",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bbff",
+        "black_list": false,
+        "code": "5196-1",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc00",
+        "black_list": false,
+        "code": "5197-9",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Presence] in Serum by Radioimmunoassay (RIA)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc01",
+        "black_list": false,
+        "code": "58452-4",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Units/volume] in Serum",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc02",
+        "black_list": false,
+        "code": "63557-3",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Units/volume] in Serum or Plasma by Immunoassay",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc03",
+        "black_list": false,
+        "code": "65633-0",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Confirmatory method",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc04",
+        "black_list": false,
+        "code": "70154-0",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag in Serum or Plasma by Confirmatory method",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc05",
+        "black_list": false,
+        "code": "7905-3",
+        "code_system": "2.16.840.1.113883.6.1",
+        "code_system_name": "LOINC",
+        "code_system_version": "2.58",
+        "display_name": "Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Neutralization test",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc06",
+        "black_list": false,
+        "code": "80055",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Obstetric panel This panel must include the following: Blood count, complete (CBC), automated and automated differential WBC count (85025 or 85027 and 85004) OR Blood count, complete (CBC), automated (85027) and appropriate manual differential WBC count (85007 or 85009) Hepatitis B surface antigen (HBsAg) (87340) Antibody, rubella (86762) Syphilis test, non-treponemal antibody; qualitative (eg, VDRL, RPR, ART) (86592) Antibody screen, RBC, each serum technique (86850) Blood typing, ABO (86900) AND Blood typing, Rh (D) (86901)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259654942c6d5d8ba7bc07",
+        "black_list": false,
+        "code": "87340",
+        "code_system": "2.16.840.1.113883.6.12",
+        "code_system_name": "CPT",
+        "code_system_version": "2017",
+        "display_name": "Infectious agent antigen detection by immunoassay technique, (eg, enzyme immunoassay [EIA], enzyme-linked immunosorbent assay [ELISA], immunochemiluminometric assay [IMCA]) qualitative or semiquantitative, multiple-step method; hepatitis B surface antigen (HBsAg)",
+        "white_list": false
+      }
+    ],
+    "display_name": "HBsAg",
+    "oid": "2.16.840.1.113883.3.67.1.101.1.279",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  },
+  {
+    "_id": "5a259655942c6d5d8ba7bc08",
+    "bundle_id": "5a12f58e942c6d6acb8e8b4d",
+    "categories": null,
+    "concepts": [
+      {
+        "_id": "5a259655942c6d5d8ba7bc09",
+        "black_list": false,
+        "code": "1116000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic aggressive type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0a",
+        "black_list": false,
+        "code": "111891008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Viral hepatitis B without hepatic coma (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0b",
+        "black_list": false,
+        "code": "13265006",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Acute fulminating type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0c",
+        "black_list": false,
+        "code": "186624004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Acute hepatitis B with delta agent (coinfection) with hepatic coma (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0d",
+        "black_list": false,
+        "code": "186626002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Acute hepatitis B with delta-agent (coinfection) without hepatic coma (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0e",
+        "black_list": false,
+        "code": "186639003",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic viral hepatitis B without delta-agent (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc0f",
+        "black_list": false,
+        "code": "235864009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Acute hepatitis B with hepatitis D (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc10",
+        "black_list": false,
+        "code": "235865005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatitis D superinfection of hepatitis B carrier (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc11",
+        "black_list": false,
+        "code": "235869004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic viral hepatitis B with hepatitis D (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc12",
+        "black_list": false,
+        "code": "235871004",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatitis B carrier (finding)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc13",
+        "black_list": false,
+        "code": "26206000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatic coma due to viral hepatitis B (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc14",
+        "black_list": false,
+        "code": "38662009",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic persistent type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc15",
+        "black_list": false,
+        "code": "424099008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatic coma due to acute hepatitis B (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc16",
+        "black_list": false,
+        "code": "424340000",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatic coma due to chronic hepatitis B (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc17",
+        "black_list": false,
+        "code": "442134007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatitis B associated with Human immunodeficiency virus infection (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc18",
+        "black_list": false,
+        "code": "442374005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Hepatitis B and hepatitis C (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc19",
+        "black_list": false,
+        "code": "446698005",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Reactivation of hepatitis B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1a",
+        "black_list": false,
+        "code": "50167007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic active type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1b",
+        "black_list": false,
+        "code": "53425008",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Anicteric type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1c",
+        "black_list": false,
+        "code": "60498001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Congenital viral hepatitis B infection (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1d",
+        "black_list": false,
+        "code": "61977001",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Chronic type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1e",
+        "black_list": false,
+        "code": "66071002",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Viral hepatitis type B (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc1f",
+        "black_list": false,
+        "code": "76795007",
+        "code_system": "2.16.840.1.113883.6.96",
+        "code_system_name": "SNOMED-CT",
+        "code_system_version": "2017-03",
+        "display_name": "Acute type B viral hepatitis (disorder)",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc20",
+        "black_list": false,
+        "code": "B16.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Acute hepatitis B with delta-agent with hepatic coma",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc21",
+        "black_list": false,
+        "code": "B16.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Acute hepatitis B with delta-agent without hepatic coma",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc22",
+        "black_list": false,
+        "code": "B16.2",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Acute hepatitis B without delta-agent with hepatic coma",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc23",
+        "black_list": false,
+        "code": "B16.9",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Acute hepatitis B without delta-agent and without hepatic coma",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc24",
+        "black_list": false,
+        "code": "B18.0",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Chronic viral hepatitis B with delta-agent",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc25",
+        "black_list": false,
+        "code": "B18.1",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Chronic viral hepatitis B without delta-agent",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc26",
+        "black_list": false,
+        "code": "B19.10",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified viral hepatitis B without hepatic coma",
+        "white_list": false
+      },
+      {
+        "_id": "5a259655942c6d5d8ba7bc27",
+        "black_list": false,
+        "code": "B19.11",
+        "code_system": "2.16.840.1.113883.6.90",
+        "code_system_name": "ICD-10-CM",
+        "code_system_version": "2018",
+        "display_name": "Unspecified viral hepatitis B with hepatic coma",
+        "white_list": false
+      }
+    ],
+    "display_name": "Hepatitis B",
+    "oid": "2.16.840.1.113883.3.67.1.101.1.269",
+    "user_id": "5a12f58c942c6d6acb8e8b4c",
+    "version": "Draft-3BBFC929-50C8-44B8-8D34-82BE75C08A70"
+  }
+]


### PR DESCRIPTION
This Pull Request adds actual, calculable, measure and valueset objects to `cqm-models`. 

@ssayer which code systems did we not want to put into the repo? I can edit those out of the valueset. Or, alternately, I can replace all the `Concept`s with fake ones, but then we'll have to make sure to use the fake ones in any patients we use.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/TACO-27
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist` N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A (don't think it's needed for a fixture update)
 
**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
