### PR TITLE
Refactored js basetypes to fit the format for schematypes

### DIFF
--- a/app/assets/javascripts/basetypes/Code.js
+++ b/app/assets/javascripts/basetypes/Code.js
@@ -1,30 +1,25 @@
 const mongoose = require('mongoose');
 
-class Code {
-  constructor(code, code_system, descriptor, code_system_oid, version) {
-    this.code = code;
-    this.code_system = code_system;
-    this.descriptor = descriptor;
-    this.code_system_oid = code_system_oid;
-    this.version = version;
-  }
-
-  toBSON() {
-    const code = {};
-    code.code = this.code;
-    code.code_system = this.code_system;
-    code.descriptor = this.descriptor;
-    code.code_system_oid = this.code_system_oid;
-    code.version = this.version;
-    return code;
-  }
+function Code(key, options) {
+  mongoose.SchemaType.call(this, key, options, 'Code');
 }
+Code.prototype = Object.create(mongoose.SchemaType.prototype);
 
-class CodeSchema extends mongoose.SchemaType {
-  static cast(code) {
-    return new Code(code.code, code.code_system, code.descriptor, code.code_system_oid, code.version);
+Code.prototype.cast = (code) => {
+  if (typeof code.code === 'undefined') {
+    throw new Error(`Code: ${code} does not have a code`);
+  } else if (typeof code.code_system === 'undefined') {
+    throw new Error(`Code: ${code} does not have a code_system`);
   }
-}
 
-mongoose.Schema.Types.Code = CodeSchema;
+  const val = { code: code.code, code_system: code.code_system };
+
+  val.descriptor = (typeof code.descriptor !== 'undefined') ? code.descriptor : null;
+  val.code_system_oid = (typeof code.code_system_oid !== 'undefined') ? code.code_system_oid : null;
+  val.version = (typeof code.version !== 'undefined') ? code.version : null;
+
+  return val;
+};
+
+mongoose.Schema.Types.Code = Code;
 module.exports = Code;

--- a/app/assets/javascripts/basetypes/Interval.js
+++ b/app/assets/javascripts/basetypes/Interval.js
@@ -1,28 +1,21 @@
 const mongoose = require('mongoose');
 
-class Interval {
-  constructor(low, high, low_closed, high_closed) {
-    this.low = low;
-    this.high = high;
-    this.low_closed = low_closed;
-    this.high_closed = high_closed;
-  }
-
-  toBSON() {
-    const interval = {};
-    interval.low = this.low;
-    interval.high = this.high;
-    interval.low_closed = this.low_closed;
-    interval.high_closed = this.high_closed;
-    return interval;
-  }
+function Interval(key, options) {
+  mongoose.SchemaType.call(this, key, options, 'Interval');
 }
+Interval.prototype = Object.create(mongoose.SchemaType.prototype);
 
-class IntervalSchema extends mongoose.SchemaType {
-  static cast(interval) {
-    return new Interval(interval.low, interval.high, interval.low_closed, interval.high_closed);
+Interval.prototype.cast = (interval) => {
+  if (typeof interval.low === 'undefined') {
+    throw new Error(`Interval: ${interval} does not have a low value`);
   }
-}
+  const val = { low: interval.low };
 
-mongoose.Schema.Types.Interval = IntervalSchema;
+  val.high = (typeof interval.high !== 'undefined') ? interval.high : null;
+  val.low_closed = (typeof interval.low_closed !== 'undefined') ? interval.low_closed : null;
+  val.high_closed = (typeof interval.high_closed !== 'undefined') ? interval.high_closed : null;
+  return val;
+};
+
+mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;

--- a/app/assets/javascripts/basetypes/Quantity.js
+++ b/app/assets/javascripts/basetypes/Quantity.js
@@ -1,24 +1,19 @@
 const mongoose = require('mongoose');
 
-class Quantity {
-  constructor(value, unit) {
-    this.value = value;
-    this.unit = unit;
-  }
-
-  toBSON() {
-    const quantity = {};
-    quantity.value = this.value;
-    quantity.unit = this.unit;
-    return quantity;
-  }
+function Quantity(key, options) {
+  mongoose.SchemaType.call(this, key, options, 'Quantity');
 }
+Quantity.prototype = Object.create(mongoose.SchemaType.prototype);
 
-class QuantitySchema extends mongoose.SchemaType {
-  static cast(quantity) {
-    return new Quantity(quantity.value, quantity.unit);
+Quantity.prototype.cast = (quantity) => {
+  if (typeof quantity.value === 'undefined') {
+    throw new Error(`Quantity: ${quantity} does not have a value`);
+  } else if (typeof quantity.unit === 'undefined') {
+    throw new Error(`Quantity: ${quantity} does not have a unit`);
   }
-}
 
-mongoose.Schema.Types.Quantity = QuantitySchema;
+  return { value: quantity.value, unit: quantity.unit };
+};
+
+mongoose.Schema.Types.Quantity = Quantity;
 module.exports = Quantity;


### PR DESCRIPTION
The new SchemaTypes for the basetypes in the Javascript models were not properly implemented to successfully import with said basetypes. Now, the models properly instantiate.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
