### PR TITLE
Replaced class_name with _type

### DIFF
--- a/app/assets/javascripts/AdverseEvent.js
+++ b/app/assets/javascripts/AdverseEvent.js
@@ -19,6 +19,7 @@ const AdverseEventSchema = DataElement.extendSchema(DataElement.DataElementSchem
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.120' },
   category: { type: String, default: 'adverse_event' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AdverseEvent' },
 
 });
 

--- a/app/assets/javascripts/AdverseEvent.js
+++ b/app/assets/javascripts/AdverseEvent.js
@@ -19,7 +19,6 @@ const AdverseEventSchema = DataElement.extendSchema(DataElement.DataElementSchem
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.120' },
   category: { type: String, default: 'adverse_event' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'AdverseEvent' },
 
 });
 

--- a/app/assets/javascripts/AllergyIntolerance.js
+++ b/app/assets/javascripts/AllergyIntolerance.js
@@ -19,7 +19,6 @@ const AllergyIntoleranceSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'allergy' },
   qdm_status: { type: String, default: 'intolerance' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'AllergyIntolerance' },
 
 });
 

--- a/app/assets/javascripts/AllergyIntolerance.js
+++ b/app/assets/javascripts/AllergyIntolerance.js
@@ -19,6 +19,7 @@ const AllergyIntoleranceSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'allergy' },
   qdm_status: { type: String, default: 'intolerance' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AllergyIntolerance' },
 
 });
 

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -22,6 +22,7 @@ const AssessmentPerformedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AssessmentPerformed' },
 
 });
 

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -22,7 +22,6 @@ const AssessmentPerformedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'AssessmentPerformed' },
 
 });
 

--- a/app/assets/javascripts/AssessmentRecommended.js
+++ b/app/assets/javascripts/AssessmentRecommended.js
@@ -19,7 +19,6 @@ const AssessmentRecommendedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'AssessmentRecommended' },
 
 });
 

--- a/app/assets/javascripts/AssessmentRecommended.js
+++ b/app/assets/javascripts/AssessmentRecommended.js
@@ -19,6 +19,7 @@ const AssessmentRecommendedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AssessmentRecommended' },
 
 });
 

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -17,6 +17,7 @@ const CareGoalSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.7' },
   category: { type: String, default: 'care_goal' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CareGoal' },
 
 });
 

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -17,7 +17,6 @@ const CareGoalSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.7' },
   category: { type: String, default: 'care_goal' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'CareGoal' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromPatientToProvider.js
+++ b/app/assets/javascripts/CommunicationFromPatientToProvider.js
@@ -18,7 +18,6 @@ const CommunicationFromPatientToProviderSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_patient_to_provider' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'CommunicationFromPatientToProvider' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromPatientToProvider.js
+++ b/app/assets/javascripts/CommunicationFromPatientToProvider.js
@@ -18,6 +18,7 @@ const CommunicationFromPatientToProviderSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_patient_to_provider' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromPatientToProvider' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromProviderToPatient.js
+++ b/app/assets/javascripts/CommunicationFromProviderToPatient.js
@@ -18,7 +18,6 @@ const CommunicationFromProviderToPatientSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_patient' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'CommunicationFromProviderToPatient' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromProviderToPatient.js
+++ b/app/assets/javascripts/CommunicationFromProviderToPatient.js
@@ -18,6 +18,7 @@ const CommunicationFromProviderToPatientSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_patient' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromProviderToPatient' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromProviderToProvider.js
+++ b/app/assets/javascripts/CommunicationFromProviderToProvider.js
@@ -18,6 +18,7 @@ const CommunicationFromProviderToProviderSchema = DataElement.extendSchema(DataE
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_provider' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromProviderToProvider' },
 
 });
 

--- a/app/assets/javascripts/CommunicationFromProviderToProvider.js
+++ b/app/assets/javascripts/CommunicationFromProviderToProvider.js
@@ -18,7 +18,6 @@ const CommunicationFromProviderToProviderSchema = DataElement.extendSchema(DataE
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_provider' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'CommunicationFromProviderToProvider' },
 
 });
 

--- a/app/assets/javascripts/Component.js
+++ b/app/assets/javascripts/Component.js
@@ -14,6 +14,7 @@ const ComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   code: Code,
   result: {},
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Component' },
 
 });
 

--- a/app/assets/javascripts/Component.js
+++ b/app/assets/javascripts/Component.js
@@ -14,7 +14,6 @@ const ComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   code: Code,
   result: {},
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Component' },
 
 });
 

--- a/app/assets/javascripts/DeviceApplied.js
+++ b/app/assets/javascripts/DeviceApplied.js
@@ -21,6 +21,7 @@ const DeviceAppliedSchema = DataElement.extendSchema(DataElement.DataElementSche
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'applied' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceApplied' },
 
 });
 

--- a/app/assets/javascripts/DeviceApplied.js
+++ b/app/assets/javascripts/DeviceApplied.js
@@ -21,7 +21,6 @@ const DeviceAppliedSchema = DataElement.extendSchema(DataElement.DataElementSche
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'applied' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DeviceApplied' },
 
 });
 

--- a/app/assets/javascripts/DeviceOrder.js
+++ b/app/assets/javascripts/DeviceOrder.js
@@ -18,6 +18,7 @@ const DeviceOrderSchema = DataElement.extendSchema(DataElement.DataElementSchema
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceOrder' },
 
 });
 

--- a/app/assets/javascripts/DeviceOrder.js
+++ b/app/assets/javascripts/DeviceOrder.js
@@ -18,7 +18,6 @@ const DeviceOrderSchema = DataElement.extendSchema(DataElement.DataElementSchema
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DeviceOrder' },
 
 });
 

--- a/app/assets/javascripts/DeviceRecommended.js
+++ b/app/assets/javascripts/DeviceRecommended.js
@@ -18,6 +18,7 @@ const DeviceRecommendedSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceRecommended' },
 
 });
 

--- a/app/assets/javascripts/DeviceRecommended.js
+++ b/app/assets/javascripts/DeviceRecommended.js
@@ -18,7 +18,6 @@ const DeviceRecommendedSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DeviceRecommended' },
 
 });
 

--- a/app/assets/javascripts/Diagnosis.js
+++ b/app/assets/javascripts/Diagnosis.js
@@ -19,7 +19,6 @@ const DiagnosisSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Diagnosis' },
 
 });
 

--- a/app/assets/javascripts/Diagnosis.js
+++ b/app/assets/javascripts/Diagnosis.js
@@ -19,6 +19,7 @@ const DiagnosisSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Diagnosis' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyOrder.js
+++ b/app/assets/javascripts/DiagnosticStudyOrder.js
@@ -19,6 +19,7 @@ const DiagnosticStudyOrderSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyOrder' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyOrder.js
+++ b/app/assets/javascripts/DiagnosticStudyOrder.js
@@ -19,7 +19,6 @@ const DiagnosticStudyOrderSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DiagnosticStudyOrder' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -25,6 +25,7 @@ const DiagnosticStudyPerformedSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyPerformed' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -25,7 +25,6 @@ const DiagnosticStudyPerformedSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DiagnosticStudyPerformed' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyRecommended.js
+++ b/app/assets/javascripts/DiagnosticStudyRecommended.js
@@ -19,6 +19,7 @@ const DiagnosticStudyRecommendedSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyRecommended' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyRecommended.js
+++ b/app/assets/javascripts/DiagnosticStudyRecommended.js
@@ -19,7 +19,6 @@ const DiagnosticStudyRecommendedSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'DiagnosticStudyRecommended' },
 
 });
 

--- a/app/assets/javascripts/EncounterOrder.js
+++ b/app/assets/javascripts/EncounterOrder.js
@@ -19,6 +19,7 @@ const EncounterOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterOrder' },
 
 });
 

--- a/app/assets/javascripts/EncounterOrder.js
+++ b/app/assets/javascripts/EncounterOrder.js
@@ -19,7 +19,6 @@ const EncounterOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'EncounterOrder' },
 
 });
 

--- a/app/assets/javascripts/EncounterPerformed.js
+++ b/app/assets/javascripts/EncounterPerformed.js
@@ -24,7 +24,6 @@ const EncounterPerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'EncounterPerformed' },
 
 });
 

--- a/app/assets/javascripts/EncounterPerformed.js
+++ b/app/assets/javascripts/EncounterPerformed.js
@@ -24,6 +24,7 @@ const EncounterPerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterPerformed' },
 
 });
 

--- a/app/assets/javascripts/EncounterRecommended.js
+++ b/app/assets/javascripts/EncounterRecommended.js
@@ -19,6 +19,7 @@ const EncounterRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterRecommended' },
 
 });
 

--- a/app/assets/javascripts/EncounterRecommended.js
+++ b/app/assets/javascripts/EncounterRecommended.js
@@ -19,7 +19,6 @@ const EncounterRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'EncounterRecommended' },
 
 });
 

--- a/app/assets/javascripts/FacilityLocation.js
+++ b/app/assets/javascripts/FacilityLocation.js
@@ -14,6 +14,7 @@ const FacilityLocationSchema = DataElement.extendSchema(DataElement.DataElementS
   code: Code,
   location_period: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'FacilityLocation' },
 
 });
 

--- a/app/assets/javascripts/FacilityLocation.js
+++ b/app/assets/javascripts/FacilityLocation.js
@@ -14,7 +14,6 @@ const FacilityLocationSchema = DataElement.extendSchema(DataElement.DataElementS
   code: Code,
   location_period: Interval,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'FacilityLocation' },
 
 });
 

--- a/app/assets/javascripts/FamilyHistory.js
+++ b/app/assets/javascripts/FamilyHistory.js
@@ -17,6 +17,7 @@ const FamilyHistorySchema = DataElement.extendSchema(DataElement.DataElementSche
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   category: { type: String, default: 'family_history' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'FamilyHistory' },
 
 });
 

--- a/app/assets/javascripts/FamilyHistory.js
+++ b/app/assets/javascripts/FamilyHistory.js
@@ -17,7 +17,6 @@ const FamilyHistorySchema = DataElement.extendSchema(DataElement.DataElementSche
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   category: { type: String, default: 'family_history' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'FamilyHistory' },
 
 });
 

--- a/app/assets/javascripts/Id.js
+++ b/app/assets/javascripts/Id.js
@@ -14,7 +14,6 @@ const IdSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   naming_system: String,
   value: String,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Id' },
 
 });
 

--- a/app/assets/javascripts/Id.js
+++ b/app/assets/javascripts/Id.js
@@ -14,6 +14,7 @@ const IdSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   naming_system: String,
   value: String,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Id' },
 
 });
 

--- a/app/assets/javascripts/ImmunizationAdministered.js
+++ b/app/assets/javascripts/ImmunizationAdministered.js
@@ -22,7 +22,6 @@ const ImmunizationAdministeredSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ImmunizationAdministered' },
 
 });
 

--- a/app/assets/javascripts/ImmunizationAdministered.js
+++ b/app/assets/javascripts/ImmunizationAdministered.js
@@ -22,6 +22,7 @@ const ImmunizationAdministeredSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ImmunizationAdministered' },
 
 });
 

--- a/app/assets/javascripts/ImmunizationOrder.js
+++ b/app/assets/javascripts/ImmunizationOrder.js
@@ -22,6 +22,7 @@ const ImmunizationOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ImmunizationOrder' },
 
 });
 

--- a/app/assets/javascripts/ImmunizationOrder.js
+++ b/app/assets/javascripts/ImmunizationOrder.js
@@ -22,7 +22,6 @@ const ImmunizationOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ImmunizationOrder' },
 
 });
 

--- a/app/assets/javascripts/InterventionOrder.js
+++ b/app/assets/javascripts/InterventionOrder.js
@@ -18,7 +18,6 @@ const InterventionOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'InterventionOrder' },
 
 });
 

--- a/app/assets/javascripts/InterventionOrder.js
+++ b/app/assets/javascripts/InterventionOrder.js
@@ -18,6 +18,7 @@ const InterventionOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionOrder' },
 
 });
 

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -21,7 +21,6 @@ const InterventionPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'InterventionPerformed' },
 
 });
 

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -21,6 +21,7 @@ const InterventionPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionPerformed' },
 
 });
 

--- a/app/assets/javascripts/InterventionRecommended.js
+++ b/app/assets/javascripts/InterventionRecommended.js
@@ -18,7 +18,6 @@ const InterventionRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'InterventionRecommended' },
 
 });
 

--- a/app/assets/javascripts/InterventionRecommended.js
+++ b/app/assets/javascripts/InterventionRecommended.js
@@ -18,6 +18,7 @@ const InterventionRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionRecommended' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestOrder.js
+++ b/app/assets/javascripts/LaboratoryTestOrder.js
@@ -19,6 +19,7 @@ const LaboratoryTestOrderSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestOrder' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestOrder.js
+++ b/app/assets/javascripts/LaboratoryTestOrder.js
@@ -19,7 +19,6 @@ const LaboratoryTestOrderSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'LaboratoryTestOrder' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -25,6 +25,7 @@ const LaboratoryTestPerformedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestPerformed' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -25,7 +25,6 @@ const LaboratoryTestPerformedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'LaboratoryTestPerformed' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestRecommended.js
+++ b/app/assets/javascripts/LaboratoryTestRecommended.js
@@ -19,7 +19,6 @@ const LaboratoryTestRecommendedSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'LaboratoryTestRecommended' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestRecommended.js
+++ b/app/assets/javascripts/LaboratoryTestRecommended.js
@@ -19,6 +19,7 @@ const LaboratoryTestRecommendedSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestRecommended' },
 
 });
 

--- a/app/assets/javascripts/MedicationActive.js
+++ b/app/assets/javascripts/MedicationActive.js
@@ -20,7 +20,6 @@ const MedicationActiveSchema = DataElement.extendSchema(DataElement.DataElementS
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'active' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'MedicationActive' },
 
 });
 

--- a/app/assets/javascripts/MedicationActive.js
+++ b/app/assets/javascripts/MedicationActive.js
@@ -20,6 +20,7 @@ const MedicationActiveSchema = DataElement.extendSchema(DataElement.DataElementS
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'active' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationActive' },
 
 });
 

--- a/app/assets/javascripts/MedicationAdministered.js
+++ b/app/assets/javascripts/MedicationAdministered.js
@@ -23,6 +23,7 @@ const MedicationAdministeredSchema = DataElement.extendSchema(DataElement.DataEl
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationAdministered' },
 
 });
 

--- a/app/assets/javascripts/MedicationAdministered.js
+++ b/app/assets/javascripts/MedicationAdministered.js
@@ -23,7 +23,6 @@ const MedicationAdministeredSchema = DataElement.extendSchema(DataElement.DataEl
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'MedicationAdministered' },
 
 });
 

--- a/app/assets/javascripts/MedicationDischarge.js
+++ b/app/assets/javascripts/MedicationDischarge.js
@@ -22,6 +22,7 @@ const MedicationDischargeSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'discharge' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationDischarge' },
 
 });
 

--- a/app/assets/javascripts/MedicationDischarge.js
+++ b/app/assets/javascripts/MedicationDischarge.js
@@ -22,7 +22,6 @@ const MedicationDischargeSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'discharge' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'MedicationDischarge' },
 
 });
 

--- a/app/assets/javascripts/MedicationDispensed.js
+++ b/app/assets/javascripts/MedicationDispensed.js
@@ -23,7 +23,6 @@ const MedicationDispensedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'dispensed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'MedicationDispensed' },
 
 });
 

--- a/app/assets/javascripts/MedicationDispensed.js
+++ b/app/assets/javascripts/MedicationDispensed.js
@@ -23,6 +23,7 @@ const MedicationDispensedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'dispensed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationDispensed' },
 
 });
 

--- a/app/assets/javascripts/MedicationOrder.js
+++ b/app/assets/javascripts/MedicationOrder.js
@@ -26,7 +26,6 @@ const MedicationOrderSchema = DataElement.extendSchema(DataElement.DataElementSc
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'MedicationOrder' },
 
 });
 

--- a/app/assets/javascripts/MedicationOrder.js
+++ b/app/assets/javascripts/MedicationOrder.js
@@ -26,6 +26,7 @@ const MedicationOrderSchema = DataElement.extendSchema(DataElement.DataElementSc
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationOrder' },
 
 });
 

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -13,6 +13,7 @@ const [Number, String, Date] = [
 const ParticipationSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   participation_period: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Participation' },
 
 });
 

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -13,7 +13,6 @@ const [Number, String, Date] = [
 const ParticipationSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   participation_period: Interval,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Participation' },
 
 });
 

--- a/app/assets/javascripts/Patient.js
+++ b/app/assets/javascripts/Patient.js
@@ -13,7 +13,6 @@ const [Number, String, Date] = [
 const PatientSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   birth_datetime: Date,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Patient' },
   given_names: [String],
   family_name: String,
   bundle_id: String,

--- a/app/assets/javascripts/Patient.js
+++ b/app/assets/javascripts/Patient.js
@@ -13,6 +13,7 @@ const [Number, String, Date] = [
 const PatientSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   birth_datetime: Date,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Patient' },
   given_names: [String],
   family_name: String,
   bundle_id: String,

--- a/app/assets/javascripts/PatientCareExperience.js
+++ b/app/assets/javascripts/PatientCareExperience.js
@@ -15,7 +15,6 @@ const PatientCareExperienceSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.52' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCareExperience' },
 
 });
 

--- a/app/assets/javascripts/PatientCareExperience.js
+++ b/app/assets/javascripts/PatientCareExperience.js
@@ -15,6 +15,7 @@ const PatientCareExperienceSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.52' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCareExperience' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristic.js
+++ b/app/assets/javascripts/PatientCharacteristic.js
@@ -15,6 +15,7 @@ const PatientCharacteristicSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.53' },
   category: { type: String, default: 'patient_characteristic' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristic.js
+++ b/app/assets/javascripts/PatientCharacteristic.js
@@ -15,7 +15,6 @@ const PatientCharacteristicSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.53' },
   category: { type: String, default: 'patient_characteristic' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicBirthdate.js
+++ b/app/assets/javascripts/PatientCharacteristicBirthdate.js
@@ -16,6 +16,7 @@ const PatientCharacteristicBirthdateSchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'birthdate' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicBirthdate' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicBirthdate.js
+++ b/app/assets/javascripts/PatientCharacteristicBirthdate.js
@@ -16,7 +16,6 @@ const PatientCharacteristicBirthdateSchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'birthdate' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicBirthdate' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
+++ b/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
@@ -18,6 +18,7 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElement.extendSc
   category: { type: String, default: 'condition' },
   qdm_status: { type: String, default: 'clinical_trial_participant' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
+++ b/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
@@ -18,7 +18,6 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElement.extendSc
   category: { type: String, default: 'condition' },
   qdm_status: { type: String, default: 'clinical_trial_participant' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicEthnicity.js
+++ b/app/assets/javascripts/PatientCharacteristicEthnicity.js
@@ -15,6 +15,7 @@ const PatientCharacteristicEthnicitySchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'ethnicity' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicEthnicity' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicEthnicity.js
+++ b/app/assets/javascripts/PatientCharacteristicEthnicity.js
@@ -15,7 +15,6 @@ const PatientCharacteristicEthnicitySchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'ethnicity' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicEthnicity' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicExpired.js
+++ b/app/assets/javascripts/PatientCharacteristicExpired.js
@@ -16,6 +16,7 @@ const PatientCharacteristicExpiredSchema = DataElement.extendSchema(DataElement.
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.57' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicExpired' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicExpired.js
+++ b/app/assets/javascripts/PatientCharacteristicExpired.js
@@ -16,7 +16,6 @@ const PatientCharacteristicExpiredSchema = DataElement.extendSchema(DataElement.
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.57' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicExpired' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicPayer.js
+++ b/app/assets/javascripts/PatientCharacteristicPayer.js
@@ -16,6 +16,7 @@ const PatientCharacteristicPayerSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'payer' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicPayer' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicPayer.js
+++ b/app/assets/javascripts/PatientCharacteristicPayer.js
@@ -16,7 +16,6 @@ const PatientCharacteristicPayerSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'payer' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicPayer' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicRace.js
+++ b/app/assets/javascripts/PatientCharacteristicRace.js
@@ -15,7 +15,6 @@ const PatientCharacteristicRaceSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'race' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicRace' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicRace.js
+++ b/app/assets/javascripts/PatientCharacteristicRace.js
@@ -15,6 +15,7 @@ const PatientCharacteristicRaceSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'race' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicRace' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicSex.js
+++ b/app/assets/javascripts/PatientCharacteristicSex.js
@@ -12,6 +12,7 @@ const [Number, String, Date] = [
 
 const PatientCharacteristicSexSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicSex' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicSex.js
+++ b/app/assets/javascripts/PatientCharacteristicSex.js
@@ -12,7 +12,6 @@ const [Number, String, Date] = [
 
 const PatientCharacteristicSexSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PatientCharacteristicSex' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamOrder.js
+++ b/app/assets/javascripts/PhysicalExamOrder.js
@@ -20,6 +20,7 @@ const PhysicalExamOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamOrder' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamOrder.js
+++ b/app/assets/javascripts/PhysicalExamOrder.js
@@ -20,7 +20,6 @@ const PhysicalExamOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PhysicalExamOrder' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -23,7 +23,6 @@ const PhysicalExamPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PhysicalExamPerformed' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -23,6 +23,7 @@ const PhysicalExamPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamPerformed' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamRecommended.js
+++ b/app/assets/javascripts/PhysicalExamRecommended.js
@@ -20,7 +20,6 @@ const PhysicalExamRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'PhysicalExamRecommended' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamRecommended.js
+++ b/app/assets/javascripts/PhysicalExamRecommended.js
@@ -20,6 +20,7 @@ const PhysicalExamRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamRecommended' },
 
 });
 

--- a/app/assets/javascripts/ProcedureOrder.js
+++ b/app/assets/javascripts/ProcedureOrder.js
@@ -22,7 +22,6 @@ const ProcedureOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ProcedureOrder' },
 
 });
 

--- a/app/assets/javascripts/ProcedureOrder.js
+++ b/app/assets/javascripts/ProcedureOrder.js
@@ -22,6 +22,7 @@ const ProcedureOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedureOrder' },
 
 });
 

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -27,6 +27,7 @@ const ProcedurePerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedurePerformed' },
 
 });
 

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -27,7 +27,6 @@ const ProcedurePerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ProcedurePerformed' },
 
 });
 

--- a/app/assets/javascripts/ProcedureRecommended.js
+++ b/app/assets/javascripts/ProcedureRecommended.js
@@ -22,6 +22,7 @@ const ProcedureRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedureRecommended' },
 
 });
 

--- a/app/assets/javascripts/ProcedureRecommended.js
+++ b/app/assets/javascripts/ProcedureRecommended.js
@@ -22,7 +22,6 @@ const ProcedureRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ProcedureRecommended' },
 
 });
 

--- a/app/assets/javascripts/ProviderCareExperience.js
+++ b/app/assets/javascripts/ProviderCareExperience.js
@@ -15,6 +15,7 @@ const ProviderCareExperienceSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.70' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProviderCareExperience' },
 
 });
 

--- a/app/assets/javascripts/ProviderCareExperience.js
+++ b/app/assets/javascripts/ProviderCareExperience.js
@@ -15,7 +15,6 @@ const ProviderCareExperienceSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.70' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ProviderCareExperience' },
 
 });
 

--- a/app/assets/javascripts/ProviderCharacteristic.js
+++ b/app/assets/javascripts/ProviderCharacteristic.js
@@ -15,7 +15,6 @@ const ProviderCharacteristicSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.71' },
   category: { type: String, default: 'provider_characteristic' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ProviderCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/ProviderCharacteristic.js
+++ b/app/assets/javascripts/ProviderCharacteristic.js
@@ -15,6 +15,7 @@ const ProviderCharacteristicSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.71' },
   category: { type: String, default: 'provider_characteristic' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProviderCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/Ratio.js
+++ b/app/assets/javascripts/Ratio.js
@@ -14,7 +14,6 @@ const RatioSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   numerator: Quantity,
   denominator: Quantity,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Ratio' },
 
 });
 

--- a/app/assets/javascripts/Ratio.js
+++ b/app/assets/javascripts/Ratio.js
@@ -14,6 +14,7 @@ const RatioSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   numerator: Quantity,
   denominator: Quantity,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Ratio' },
 
 });
 

--- a/app/assets/javascripts/ResultComponent.js
+++ b/app/assets/javascripts/ResultComponent.js
@@ -13,7 +13,6 @@ const [Number, String, Date] = [
 const ResultComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   reference_range: Interval,
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'ResultComponent' },
 
 });
 

--- a/app/assets/javascripts/ResultComponent.js
+++ b/app/assets/javascripts/ResultComponent.js
@@ -13,6 +13,7 @@ const [Number, String, Date] = [
 const ResultComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   reference_range: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ResultComponent' },
 
 });
 

--- a/app/assets/javascripts/SubstanceAdministered.js
+++ b/app/assets/javascripts/SubstanceAdministered.js
@@ -22,7 +22,6 @@ const SubstanceAdministeredSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'SubstanceAdministered' },
 
 });
 

--- a/app/assets/javascripts/SubstanceAdministered.js
+++ b/app/assets/javascripts/SubstanceAdministered.js
@@ -22,6 +22,7 @@ const SubstanceAdministeredSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceAdministered' },
 
 });
 

--- a/app/assets/javascripts/SubstanceOrder.js
+++ b/app/assets/javascripts/SubstanceOrder.js
@@ -24,6 +24,7 @@ const SubstanceOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceOrder' },
 
 });
 

--- a/app/assets/javascripts/SubstanceOrder.js
+++ b/app/assets/javascripts/SubstanceOrder.js
@@ -24,7 +24,6 @@ const SubstanceOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'SubstanceOrder' },
 
 });
 

--- a/app/assets/javascripts/SubstanceRecommended.js
+++ b/app/assets/javascripts/SubstanceRecommended.js
@@ -24,6 +24,7 @@ const SubstanceRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceRecommended' },
 
 });
 

--- a/app/assets/javascripts/SubstanceRecommended.js
+++ b/app/assets/javascripts/SubstanceRecommended.js
@@ -24,7 +24,6 @@ const SubstanceRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'SubstanceRecommended' },
 
 });
 

--- a/app/assets/javascripts/Symptom.js
+++ b/app/assets/javascripts/Symptom.js
@@ -17,7 +17,6 @@ const SymptomSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   category: { type: String, default: 'symptom' },
   qdm_version: { type: String, default: '5.3' },
-  class_name: { type: String, default: 'Symptom' },
 
 });
 

--- a/app/assets/javascripts/Symptom.js
+++ b/app/assets/javascripts/Symptom.js
@@ -17,6 +17,7 @@ const SymptomSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   category: { type: String, default: 'symptom' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Symptom' },
 
 });
 

--- a/app/models/qdm/adverse_event.rb
+++ b/app/models/qdm/adverse_event.rb
@@ -11,6 +11,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.120'
     field :category, type: String, default: 'adverse_event'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'AdverseEvent'
   end
 end

--- a/app/models/qdm/allergy_intolerance.rb
+++ b/app/models/qdm/allergy_intolerance.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'allergy'
     field :qdm_status, type: String, default: 'intolerance'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'AllergyIntolerance'
   end
 end

--- a/app/models/qdm/assessment_performed.rb
+++ b/app/models/qdm/assessment_performed.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'assessment'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'AssessmentPerformed'
   end
 end

--- a/app/models/qdm/assessment_recommended.rb
+++ b/app/models/qdm/assessment_recommended.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'assessment'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'AssessmentRecommended'
   end
 end

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -33,5 +33,10 @@ module QDM
     def id
       _id
     end
+
+    # Include '_type' in any JSON output. This is necessary for deserialization.
+    def to_json(options = nil)
+      serializable_hash(methods: :_type).to_json(options)
+    end
   end
 end

--- a/app/models/qdm/care_goal.rb
+++ b/app/models/qdm/care_goal.rb
@@ -9,6 +9,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.7'
     field :category, type: String, default: 'care_goal'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'CareGoal'
   end
 end

--- a/app/models/qdm/communication_from_patient_to_provider.rb
+++ b/app/models/qdm/communication_from_patient_to_provider.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'communication'
     field :qdm_status, type: String, default: 'from_patient_to_provider'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'CommunicationFromPatientToProvider'
   end
 end

--- a/app/models/qdm/communication_from_provider_to_patient.rb
+++ b/app/models/qdm/communication_from_provider_to_patient.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'communication'
     field :qdm_status, type: String, default: 'from_provider_to_patient'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'CommunicationFromProviderToPatient'
   end
 end

--- a/app/models/qdm/communication_from_provider_to_provider.rb
+++ b/app/models/qdm/communication_from_provider_to_provider.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'communication'
     field :qdm_status, type: String, default: 'from_provider_to_provider'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'CommunicationFromProviderToProvider'
   end
 end

--- a/app/models/qdm/component.rb
+++ b/app/models/qdm/component.rb
@@ -6,6 +6,5 @@ module QDM
     field :code, type: QDM::Code
     field :result
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Component'
   end
 end

--- a/app/models/qdm/device_applied.rb
+++ b/app/models/qdm/device_applied.rb
@@ -13,6 +13,5 @@ module QDM
     field :category, type: String, default: 'device'
     field :qdm_status, type: String, default: 'applied'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DeviceApplied'
   end
 end

--- a/app/models/qdm/device_order.rb
+++ b/app/models/qdm/device_order.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'device'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DeviceOrder'
   end
 end

--- a/app/models/qdm/device_recommended.rb
+++ b/app/models/qdm/device_recommended.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'device'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DeviceRecommended'
   end
 end

--- a/app/models/qdm/diagnosis.rb
+++ b/app/models/qdm/diagnosis.rb
@@ -11,6 +11,5 @@ module QDM
     field :qrda_oid, type: String, default: '2.16.840.1.113883.10.20.24.3.135'
     field :category, type: String, default: 'condition'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Diagnosis'
   end
 end

--- a/app/models/qdm/diagnostic_study_order.rb
+++ b/app/models/qdm/diagnostic_study_order.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'diagnostic_study'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DiagnosticStudyOrder'
   end
 end

--- a/app/models/qdm/diagnostic_study_performed.rb
+++ b/app/models/qdm/diagnostic_study_performed.rb
@@ -17,6 +17,5 @@ module QDM
     field :category, type: String, default: 'diagnostic_study'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DiagnosticStudyPerformed'
   end
 end

--- a/app/models/qdm/diagnostic_study_recommended.rb
+++ b/app/models/qdm/diagnostic_study_recommended.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'diagnostic_study'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'DiagnosticStudyRecommended'
   end
 end

--- a/app/models/qdm/encounter_order.rb
+++ b/app/models/qdm/encounter_order.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'encounter'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'EncounterOrder'
   end
 end

--- a/app/models/qdm/encounter_performed.rb
+++ b/app/models/qdm/encounter_performed.rb
@@ -16,6 +16,5 @@ module QDM
     field :category, type: String, default: 'encounter'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'EncounterPerformed'
   end
 end

--- a/app/models/qdm/encounter_recommended.rb
+++ b/app/models/qdm/encounter_recommended.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'encounter'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'EncounterRecommended'
   end
 end

--- a/app/models/qdm/facility_location.rb
+++ b/app/models/qdm/facility_location.rb
@@ -6,6 +6,5 @@ module QDM
     field :code, type: QDM::Code
     field :location_period, type: QDM::Interval
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'FacilityLocation'
   end
 end

--- a/app/models/qdm/family_history.rb
+++ b/app/models/qdm/family_history.rb
@@ -9,6 +9,5 @@ module QDM
     field :qrda_oid, type: String, default: '2.16.840.1.113883.10.20.24.3.12'
     field :category, type: String, default: 'family_history'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'FamilyHistory'
   end
 end

--- a/app/models/qdm/id.rb
+++ b/app/models/qdm/id.rb
@@ -6,6 +6,5 @@ module QDM
     field :naming_system, type: String
     field :value, type: String
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Id'
   end
 end

--- a/app/models/qdm/immunization_administered.rb
+++ b/app/models/qdm/immunization_administered.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'immunization'
     field :qdm_status, type: String, default: 'administered'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ImmunizationAdministered'
   end
 end

--- a/app/models/qdm/immunization_order.rb
+++ b/app/models/qdm/immunization_order.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'immunization'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ImmunizationOrder'
   end
 end

--- a/app/models/qdm/intervention_order.rb
+++ b/app/models/qdm/intervention_order.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'intervention'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'InterventionOrder'
   end
 end

--- a/app/models/qdm/intervention_performed.rb
+++ b/app/models/qdm/intervention_performed.rb
@@ -13,6 +13,5 @@ module QDM
     field :category, type: String, default: 'intervention'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'InterventionPerformed'
   end
 end

--- a/app/models/qdm/intervention_recommended.rb
+++ b/app/models/qdm/intervention_recommended.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'intervention'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'InterventionRecommended'
   end
 end

--- a/app/models/qdm/laboratory_test_order.rb
+++ b/app/models/qdm/laboratory_test_order.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'laboratory_test'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'LaboratoryTestOrder'
   end
 end

--- a/app/models/qdm/laboratory_test_performed.rb
+++ b/app/models/qdm/laboratory_test_performed.rb
@@ -17,6 +17,5 @@ module QDM
     field :category, type: String, default: 'laboratory_test'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'LaboratoryTestPerformed'
   end
 end

--- a/app/models/qdm/laboratory_test_recommended.rb
+++ b/app/models/qdm/laboratory_test_recommended.rb
@@ -11,6 +11,5 @@ module QDM
     field :category, type: String, default: 'laboratory_test'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'LaboratoryTestRecommended'
   end
 end

--- a/app/models/qdm/medication_active.rb
+++ b/app/models/qdm/medication_active.rb
@@ -12,6 +12,5 @@ module QDM
     field :category, type: String, default: 'medication'
     field :qdm_status, type: String, default: 'active'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'MedicationActive'
   end
 end

--- a/app/models/qdm/medication_administered.rb
+++ b/app/models/qdm/medication_administered.rb
@@ -15,6 +15,5 @@ module QDM
     field :category, type: String, default: 'medication'
     field :qdm_status, type: String, default: 'administered'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'MedicationAdministered'
   end
 end

--- a/app/models/qdm/medication_discharge.rb
+++ b/app/models/qdm/medication_discharge.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'medication'
     field :qdm_status, type: String, default: 'discharge'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'MedicationDischarge'
   end
 end

--- a/app/models/qdm/medication_dispensed.rb
+++ b/app/models/qdm/medication_dispensed.rb
@@ -15,6 +15,5 @@ module QDM
     field :category, type: String, default: 'medication'
     field :qdm_status, type: String, default: 'dispensed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'MedicationDispensed'
   end
 end

--- a/app/models/qdm/medication_order.rb
+++ b/app/models/qdm/medication_order.rb
@@ -18,6 +18,5 @@ module QDM
     field :category, type: String, default: 'medication'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'MedicationOrder'
   end
 end

--- a/app/models/qdm/participation.rb
+++ b/app/models/qdm/participation.rb
@@ -5,6 +5,5 @@ module QDM
     embedded_in :patient
     field :participation_period, type: QDM::Interval
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Participation'
   end
 end

--- a/app/models/qdm/patient.rb
+++ b/app/models/qdm/patient.rb
@@ -4,7 +4,6 @@ module QDM
     include Mongoid::Document
     field :birth_datetime, type: DateTime
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Patient'
     field :given_names, type: Array
     field :family_name, type: String
     field :bundle_id, type: String

--- a/app/models/qdm/patient_care_experience.rb
+++ b/app/models/qdm/patient_care_experience.rb
@@ -7,6 +7,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.52'
     field :category, type: String, default: 'care_experience'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCareExperience'
   end
 end

--- a/app/models/qdm/patient_characteristic.rb
+++ b/app/models/qdm/patient_characteristic.rb
@@ -7,6 +7,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.53'
     field :category, type: String, default: 'patient_characteristic'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristic'
   end
 end

--- a/app/models/qdm/patient_characteristic_birthdate.rb
+++ b/app/models/qdm/patient_characteristic_birthdate.rb
@@ -8,6 +8,5 @@ module QDM
     field :category, type: String, default: 'patient_characteristic'
     field :qdm_status, type: String, default: 'birthdate'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicBirthdate'
   end
 end

--- a/app/models/qdm/patient_characteristic_clinical_trial_participant.rb
+++ b/app/models/qdm/patient_characteristic_clinical_trial_participant.rb
@@ -10,6 +10,5 @@ module QDM
     field :category, type: String, default: 'condition'
     field :qdm_status, type: String, default: 'clinical_trial_participant'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicClinicalTrialParticipant'
   end
 end

--- a/app/models/qdm/patient_characteristic_ethnicity.rb
+++ b/app/models/qdm/patient_characteristic_ethnicity.rb
@@ -7,6 +7,5 @@ module QDM
     field :category, type: String, default: 'patient_characteristic'
     field :qdm_status, type: String, default: 'ethnicity'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicEthnicity'
   end
 end

--- a/app/models/qdm/patient_characteristic_expired.rb
+++ b/app/models/qdm/patient_characteristic_expired.rb
@@ -8,6 +8,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.57'
     field :category, type: String, default: 'condition'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicExpired'
   end
 end

--- a/app/models/qdm/patient_characteristic_payer.rb
+++ b/app/models/qdm/patient_characteristic_payer.rb
@@ -8,6 +8,5 @@ module QDM
     field :category, type: String, default: 'patient_characteristic'
     field :qdm_status, type: String, default: 'payer'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicPayer'
   end
 end

--- a/app/models/qdm/patient_characteristic_race.rb
+++ b/app/models/qdm/patient_characteristic_race.rb
@@ -7,6 +7,5 @@ module QDM
     field :category, type: String, default: 'patient_characteristic'
     field :qdm_status, type: String, default: 'race'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicRace'
   end
 end

--- a/app/models/qdm/patient_characteristic_sex.rb
+++ b/app/models/qdm/patient_characteristic_sex.rb
@@ -4,6 +4,5 @@ module QDM
     include Mongoid::Document
     embedded_in :patient
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PatientCharacteristicSex'
   end
 end

--- a/app/models/qdm/physical_exam_order.rb
+++ b/app/models/qdm/physical_exam_order.rb
@@ -12,6 +12,5 @@ module QDM
     field :category, type: String, default: 'physical_exam'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PhysicalExamOrder'
   end
 end

--- a/app/models/qdm/physical_exam_performed.rb
+++ b/app/models/qdm/physical_exam_performed.rb
@@ -15,6 +15,5 @@ module QDM
     field :category, type: String, default: 'physical_exam'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PhysicalExamPerformed'
   end
 end

--- a/app/models/qdm/physical_exam_recommended.rb
+++ b/app/models/qdm/physical_exam_recommended.rb
@@ -12,6 +12,5 @@ module QDM
     field :category, type: String, default: 'physical_exam'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'PhysicalExamRecommended'
   end
 end

--- a/app/models/qdm/procedure_order.rb
+++ b/app/models/qdm/procedure_order.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'procedure'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ProcedureOrder'
   end
 end

--- a/app/models/qdm/procedure_performed.rb
+++ b/app/models/qdm/procedure_performed.rb
@@ -19,6 +19,5 @@ module QDM
     field :category, type: String, default: 'procedure'
     field :qdm_status, type: String, default: 'performed'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ProcedurePerformed'
   end
 end

--- a/app/models/qdm/procedure_recommended.rb
+++ b/app/models/qdm/procedure_recommended.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'procedure'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ProcedureRecommended'
   end
 end

--- a/app/models/qdm/provider_care_experience.rb
+++ b/app/models/qdm/provider_care_experience.rb
@@ -7,6 +7,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.70'
     field :category, type: String, default: 'care_experience'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ProviderCareExperience'
   end
 end

--- a/app/models/qdm/provider_characteristic.rb
+++ b/app/models/qdm/provider_characteristic.rb
@@ -7,6 +7,5 @@ module QDM
     field :hqmf_oid, type: String, default: '2.16.840.1.113883.10.20.28.3.71'
     field :category, type: String, default: 'provider_characteristic'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ProviderCharacteristic'
   end
 end

--- a/app/models/qdm/ratio.rb
+++ b/app/models/qdm/ratio.rb
@@ -6,6 +6,5 @@ module QDM
     field :numerator, type: QDM::Quantity
     field :denominator, type: QDM::Quantity
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Ratio'
   end
 end

--- a/app/models/qdm/result_component.rb
+++ b/app/models/qdm/result_component.rb
@@ -5,6 +5,5 @@ module QDM
     embedded_in :patient
     field :reference_range, type: QDM::Interval
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'ResultComponent'
   end
 end

--- a/app/models/qdm/substance_administered.rb
+++ b/app/models/qdm/substance_administered.rb
@@ -14,6 +14,5 @@ module QDM
     field :category, type: String, default: 'substance'
     field :qdm_status, type: String, default: 'administered'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'SubstanceAdministered'
   end
 end

--- a/app/models/qdm/substance_order.rb
+++ b/app/models/qdm/substance_order.rb
@@ -16,6 +16,5 @@ module QDM
     field :category, type: String, default: 'substance'
     field :qdm_status, type: String, default: 'order'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'SubstanceOrder'
   end
 end

--- a/app/models/qdm/substance_recommended.rb
+++ b/app/models/qdm/substance_recommended.rb
@@ -16,6 +16,5 @@ module QDM
     field :category, type: String, default: 'substance'
     field :qdm_status, type: String, default: 'recommended'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'SubstanceRecommended'
   end
 end

--- a/app/models/qdm/symptom.rb
+++ b/app/models/qdm/symptom.rb
@@ -9,6 +9,5 @@ module QDM
     field :qrda_oid, type: String, default: '2.16.840.1.113883.10.20.24.3.136'
     field :category, type: String, default: 'symptom'
     field :qdm_version, type: String, default: '5.3'
-    field :class_name, type: String, default: 'Symptom'
   end
 end

--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '0.3.0'
+  spec.version       = '0.4.0'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'cqm-models'

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,7 @@ const AdverseEventSchema = DataElement.extendSchema(DataElement.DataElementSchem
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.120' },
   category: { type: String, default: 'adverse_event' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AdverseEvent' },
 
 });
 
@@ -48,6 +49,7 @@ const AllergyIntoleranceSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'allergy' },
   qdm_status: { type: String, default: 'intolerance' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AllergyIntolerance' },
 
 });
 
@@ -79,6 +81,7 @@ const AssessmentPerformedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AssessmentPerformed' },
 
 });
 
@@ -107,6 +110,7 @@ const AssessmentRecommendedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'assessment' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'AssessmentRecommended' },
 
 });
 
@@ -133,6 +137,7 @@ const CareGoalSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.7' },
   category: { type: String, default: 'care_goal' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CareGoal' },
 
 });
 
@@ -160,6 +165,7 @@ const CommunicationFromPatientToProviderSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_patient_to_provider' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromPatientToProvider' },
 
 });
 
@@ -187,6 +193,7 @@ const CommunicationFromProviderToPatientSchema = DataElement.extendSchema(DataEl
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_patient' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromProviderToPatient' },
 
 });
 
@@ -214,6 +221,7 @@ const CommunicationFromProviderToProviderSchema = DataElement.extendSchema(DataE
   category: { type: String, default: 'communication' },
   qdm_status: { type: String, default: 'from_provider_to_provider' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'CommunicationFromProviderToProvider' },
 
 });
 
@@ -237,6 +245,7 @@ const ComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   code: Code,
   result: {},
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Component' },
 
 });
 
@@ -283,6 +292,7 @@ const DeviceAppliedSchema = DataElement.extendSchema(DataElement.DataElementSche
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'applied' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceApplied' },
 
 });
 
@@ -310,6 +320,7 @@ const DeviceOrderSchema = DataElement.extendSchema(DataElement.DataElementSchema
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceOrder' },
 
 });
 
@@ -337,6 +348,7 @@ const DeviceRecommendedSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'device' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DeviceRecommended' },
 
 });
 
@@ -365,6 +377,7 @@ const DiagnosisSchema = DataElement.extendSchema(DataElement.DataElementSchema, 
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Diagnosis' },
 
 });
 
@@ -393,6 +406,7 @@ const DiagnosticStudyOrderSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyOrder' },
 
 });
 
@@ -427,6 +441,7 @@ const DiagnosticStudyPerformedSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyPerformed' },
 
 });
 
@@ -455,6 +470,7 @@ const DiagnosticStudyRecommendedSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'diagnostic_study' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'DiagnosticStudyRecommended' },
 
 });
 
@@ -483,6 +499,7 @@ const EncounterOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterOrder' },
 
 });
 
@@ -516,6 +533,7 @@ const EncounterPerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterPerformed' },
 
 });
 
@@ -544,6 +562,7 @@ const EncounterRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'encounter' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'EncounterRecommended' },
 
 });
 
@@ -567,6 +586,7 @@ const FacilityLocationSchema = DataElement.extendSchema(DataElement.DataElementS
   code: Code,
   location_period: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'FacilityLocation' },
 
 });
 
@@ -593,6 +613,7 @@ const FamilyHistorySchema = DataElement.extendSchema(DataElement.DataElementSche
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   category: { type: String, default: 'family_history' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'FamilyHistory' },
 
 });
 
@@ -616,6 +637,7 @@ const IdSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   naming_system: String,
   value: String,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Id' },
 
 });
 
@@ -647,6 +669,7 @@ const ImmunizationAdministeredSchema = DataElement.extendSchema(DataElement.Data
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ImmunizationAdministered' },
 
 });
 
@@ -678,6 +701,7 @@ const ImmunizationOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'immunization' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ImmunizationOrder' },
 
 });
 
@@ -705,6 +729,7 @@ const InterventionOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionOrder' },
 
 });
 
@@ -735,6 +760,7 @@ const InterventionPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionPerformed' },
 
 });
 
@@ -762,6 +788,7 @@ const InterventionRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'intervention' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'InterventionRecommended' },
 
 });
 
@@ -790,6 +817,7 @@ const LaboratoryTestOrderSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestOrder' },
 
 });
 
@@ -824,6 +852,7 @@ const LaboratoryTestPerformedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestPerformed' },
 
 });
 
@@ -852,6 +881,7 @@ const LaboratoryTestRecommendedSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'laboratory_test' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'LaboratoryTestRecommended' },
 
 });
 
@@ -929,19 +959,7 @@ const MeasureSchema = mongoose.Schema(
   }
 );
 
-MeasureSchema.virtual('IPP').get(() => 'IPP');
-MeasureSchema.virtual('DENOM').get(() => 'DENOM');
-MeasureSchema.virtual('NUMER').get(() => 'NUMER');
-MeasureSchema.virtual('NUMEX').get(() => 'NUMEX');
-MeasureSchema.virtual('DENEXCEP').get(() => 'DENEXCEP');
-MeasureSchema.virtual('DENEX').get(() => 'DENEX');
-MeasureSchema.virtual('MSRPOPL').get(() => 'MSRPOPL');
-MeasureSchema.virtual('OBSERV').get(() => 'OBSERV');
-MeasureSchema.virtual('MSRPOPLEX').get(() => 'MSRPOPLEX');
-
-MeasureSchema.virtual('STRAT').get(() => 'STRAT');
-
-MeasureSchema.virtual('ALL_POPULATION_CODES').get(() => [this.STRAT, this.IPP, this.DENOM, this.DENEX, this.NUMER, this.NUMEX, this.DENEXCEP, this.MSRPOPL, this.OBSERV, this.MSRPOPLEX]);
+MeasureSchema.virtual('ALL_POPULATION_CODES').get(() => ['STRAT', 'IPP', 'DENOM', 'DENEX', 'NUMER', 'NUMEX', 'DENEXCEP', 'MSRPOPL', 'OBSERV', 'MSRPOPLEX']);
 
 MeasureSchema.virtual('cqlSkipStatements').get(() => ['SDE Ethnicity', 'SDE Payer', 'SDE Race', 'SDE Sex']);
 
@@ -993,6 +1011,7 @@ const MedicationActiveSchema = DataElement.extendSchema(DataElement.DataElementS
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'active' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationActive' },
 
 });
 
@@ -1025,6 +1044,7 @@ const MedicationAdministeredSchema = DataElement.extendSchema(DataElement.DataEl
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationAdministered' },
 
 });
 
@@ -1056,6 +1076,7 @@ const MedicationDischargeSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'discharge' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationDischarge' },
 
 });
 
@@ -1088,6 +1109,7 @@ const MedicationDispensedSchema = DataElement.extendSchema(DataElement.DataEleme
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'dispensed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationDispensed' },
 
 });
 
@@ -1123,6 +1145,7 @@ const MedicationOrderSchema = DataElement.extendSchema(DataElement.DataElementSc
   category: { type: String, default: 'medication' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'MedicationOrder' },
 
 });
 
@@ -1145,6 +1168,7 @@ const [Number, String, Date] = [
 const ParticipationSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   participation_period: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Participation' },
 
 });
 
@@ -1167,6 +1191,7 @@ const [Number, String, Date] = [
 const PatientSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   birth_datetime: Date,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Patient' },
   given_names: [String],
   family_name: String,
   bundle_id: String,
@@ -1337,6 +1362,7 @@ const PatientCareExperienceSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.52' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCareExperience' },
 
 });
 
@@ -1361,6 +1387,7 @@ const PatientCharacteristicSchema = DataElement.extendSchema(DataElement.DataEle
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.53' },
   category: { type: String, default: 'patient_characteristic' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristic' },
 
 });
 
@@ -1386,6 +1413,7 @@ const PatientCharacteristicBirthdateSchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'birthdate' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicBirthdate' },
 
 });
 
@@ -1413,6 +1441,7 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElement.extendSc
   category: { type: String, default: 'condition' },
   qdm_status: { type: String, default: 'clinical_trial_participant' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
 
 });
 
@@ -1437,6 +1466,7 @@ const PatientCharacteristicEthnicitySchema = DataElement.extendSchema(DataElemen
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'ethnicity' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicEthnicity' },
 
 });
 
@@ -1462,6 +1492,7 @@ const PatientCharacteristicExpiredSchema = DataElement.extendSchema(DataElement.
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.57' },
   category: { type: String, default: 'condition' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicExpired' },
 
 });
 
@@ -1487,6 +1518,7 @@ const PatientCharacteristicPayerSchema = DataElement.extendSchema(DataElement.Da
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'payer' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicPayer' },
 
 });
 
@@ -1511,6 +1543,7 @@ const PatientCharacteristicRaceSchema = DataElement.extendSchema(DataElement.Dat
   category: { type: String, default: 'patient_characteristic' },
   qdm_status: { type: String, default: 'race' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicRace' },
 
 });
 
@@ -1532,6 +1565,7 @@ const [Number, String, Date] = [
 
 const PatientCharacteristicSexSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PatientCharacteristicSex' },
 
 });
 
@@ -1561,6 +1595,7 @@ const PhysicalExamOrderSchema = DataElement.extendSchema(DataElement.DataElement
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamOrder' },
 
 });
 
@@ -1593,6 +1628,7 @@ const PhysicalExamPerformedSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamPerformed' },
 
 });
 
@@ -1622,6 +1658,7 @@ const PhysicalExamRecommendedSchema = DataElement.extendSchema(DataElement.DataE
   category: { type: String, default: 'physical_exam' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'PhysicalExamRecommended' },
 
 });
 
@@ -1653,6 +1690,7 @@ const ProcedureOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedureOrder' },
 
 });
 
@@ -1689,6 +1727,7 @@ const ProcedurePerformedSchema = DataElement.extendSchema(DataElement.DataElemen
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'performed' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedurePerformed' },
 
 });
 
@@ -1720,6 +1759,7 @@ const ProcedureRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'procedure' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProcedureRecommended' },
 
 });
 
@@ -1744,6 +1784,7 @@ const ProviderCareExperienceSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.70' },
   category: { type: String, default: 'care_experience' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProviderCareExperience' },
 
 });
 
@@ -1768,6 +1809,7 @@ const ProviderCharacteristicSchema = DataElement.extendSchema(DataElement.DataEl
   hqmf_oid: { type: String, default: '2.16.840.1.113883.10.20.28.3.71' },
   category: { type: String, default: 'provider_characteristic' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ProviderCharacteristic' },
 
 });
 
@@ -1791,6 +1833,7 @@ const RatioSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   numerator: Quantity,
   denominator: Quantity,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Ratio' },
 
 });
 
@@ -1843,6 +1886,7 @@ const [Number, String, Date] = [
 const ResultComponentSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   reference_range: Interval,
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'ResultComponent' },
 
 });
 
@@ -1874,6 +1918,7 @@ const SubstanceAdministeredSchema = DataElement.extendSchema(DataElement.DataEle
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'administered' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceAdministered' },
 
 });
 
@@ -1907,6 +1952,7 @@ const SubstanceOrderSchema = DataElement.extendSchema(DataElement.DataElementSch
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'order' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceOrder' },
 
 });
 
@@ -1940,6 +1986,7 @@ const SubstanceRecommendedSchema = DataElement.extendSchema(DataElement.DataElem
   category: { type: String, default: 'substance' },
   qdm_status: { type: String, default: 'recommended' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'SubstanceRecommended' },
 
 });
 
@@ -1966,6 +2013,7 @@ const SymptomSchema = DataElement.extendSchema(DataElement.DataElementSchema, {
   qrda_oid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   category: { type: String, default: 'symptom' },
   qdm_version: { type: String, default: '5.3' },
+  _type: { type: String, default: 'Symptom' },
 
 });
 
@@ -2048,6 +2096,7 @@ function extendSchema(TSchema, definition, options) {
 
 const DataElementSchema = new Schema({
   data_element_codes: { type: [Code] },
+  description: { type: String },
 });
 
 // Returns the attribute requested on the data element.
@@ -2077,22 +2126,26 @@ module.exports.extendSchema = extendSchema;
 const mongoose = require('mongoose');
 
 class Interval {
-  constructor(lt, gt) {
-    this.lt = lt;
-    this.gt = gt;
+  constructor(low, high, low_closed, high_closed) {
+    this.low = low;
+    this.high = high;
+    this.low_closed = low_closed;
+    this.high_closed = high_closed;
   }
 
   toBSON() {
     const interval = {};
-    interval.lt = this.lt;
-    interval.gt = this.gt;
+    interval.low = this.low;
+    interval.high = this.high;
+    interval.low_closed = this.low_closed;
+    interval.high_closed = this.high_closed;
     return interval;
   }
 }
 
 class IntervalSchema extends mongoose.SchemaType {
   static cast(interval) {
-    return new Interval(interval.lt, interval.gt);
+    return new Interval(interval.low, interval.high, interval.low_closed, interval.high_closed);
   }
 }
 
@@ -32846,7 +32899,7 @@ HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
 },{"hash.js":182,"minimalistic-assert":205,"minimalistic-crypto-utils":206}],195:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
-  var eLen = (nBytes * 8) - mLen - 1
+  var eLen = nBytes * 8 - mLen - 1
   var eMax = (1 << eLen) - 1
   var eBias = eMax >> 1
   var nBits = -7
@@ -32859,12 +32912,12 @@ exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   e = s & ((1 << (-nBits)) - 1)
   s >>= (-nBits)
   nBits += eLen
-  for (; nBits > 0; e = (e * 256) + buffer[offset + i], i += d, nBits -= 8) {}
+  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
 
   m = e & ((1 << (-nBits)) - 1)
   e >>= (-nBits)
   nBits += mLen
-  for (; nBits > 0; m = (m * 256) + buffer[offset + i], i += d, nBits -= 8) {}
+  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
 
   if (e === 0) {
     e = 1 - eBias
@@ -32879,7 +32932,7 @@ exports.read = function (buffer, offset, isLE, mLen, nBytes) {
 
 exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   var e, m, c
-  var eLen = (nBytes * 8) - mLen - 1
+  var eLen = nBytes * 8 - mLen - 1
   var eMax = (1 << eLen) - 1
   var eBias = eMax >> 1
   var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
@@ -32912,7 +32965,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
       m = 0
       e = eMax
     } else if (e + eBias >= 1) {
-      m = ((value * c) - 1) * Math.pow(2, mLen)
+      m = (value * c - 1) * Math.pow(2, mLen)
       e = e + eBias
     } else {
       m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
@@ -92521,7 +92574,7 @@ module.exports = require('./lib/_stream_duplex.js');
 
 /*<replacement>*/
 
-var pna = require('process-nextick-args');
+var processNextTick = require('process-nextick-args').nextTick;
 /*</replacement>*/
 
 /*<replacement>*/
@@ -92575,7 +92628,7 @@ function onend() {
 
   // no more data can be written.
   // But allow more writes to happen in this tick.
-  pna.nextTick(onEndNT, this);
+  processNextTick(onEndNT, this);
 }
 
 function onEndNT(self) {
@@ -92607,7 +92660,7 @@ Duplex.prototype._destroy = function (err, cb) {
   this.push(null);
   this.end();
 
-  pna.nextTick(cb, err);
+  processNextTick(cb, err);
 };
 
 function forEach(xs, f) {
@@ -92690,7 +92743,7 @@ PassThrough.prototype._transform = function (chunk, encoding, cb) {
 
 /*<replacement>*/
 
-var pna = require('process-nextick-args');
+var processNextTick = require('process-nextick-args').nextTick;
 /*</replacement>*/
 
 module.exports = Readable;
@@ -93162,7 +93215,7 @@ function emitReadable(stream) {
   if (!state.emittedReadable) {
     debug('emitReadable', state.flowing);
     state.emittedReadable = true;
-    if (state.sync) pna.nextTick(emitReadable_, stream);else emitReadable_(stream);
+    if (state.sync) processNextTick(emitReadable_, stream);else emitReadable_(stream);
   }
 }
 
@@ -93181,7 +93234,7 @@ function emitReadable_(stream) {
 function maybeReadMore(stream, state) {
   if (!state.readingMore) {
     state.readingMore = true;
-    pna.nextTick(maybeReadMore_, stream, state);
+    processNextTick(maybeReadMore_, stream, state);
   }
 }
 
@@ -93226,7 +93279,7 @@ Readable.prototype.pipe = function (dest, pipeOpts) {
   var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
 
   var endFn = doEnd ? onend : unpipe;
-  if (state.endEmitted) pna.nextTick(endFn);else src.once('end', endFn);
+  if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
 
   dest.on('unpipe', onunpipe);
   function onunpipe(readable, unpipeInfo) {
@@ -93416,7 +93469,7 @@ Readable.prototype.on = function (ev, fn) {
       state.readableListening = state.needReadable = true;
       state.emittedReadable = false;
       if (!state.reading) {
-        pna.nextTick(nReadingNextTick, this);
+        processNextTick(nReadingNextTick, this);
       } else if (state.length) {
         emitReadable(this);
       }
@@ -93447,7 +93500,7 @@ Readable.prototype.resume = function () {
 function resume(stream, state) {
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
-    pna.nextTick(resume_, stream, state);
+    processNextTick(resume_, stream, state);
   }
 }
 
@@ -93655,7 +93708,7 @@ function endReadable(stream) {
 
   if (!state.endEmitted) {
     state.ended = true;
-    pna.nextTick(endReadableNT, state, stream);
+    processNextTick(endReadableNT, state, stream);
   }
 }
 
@@ -93927,7 +93980,7 @@ function done(stream, er, data) {
 
 /*<replacement>*/
 
-var pna = require('process-nextick-args');
+var processNextTick = require('process-nextick-args').nextTick;
 /*</replacement>*/
 
 module.exports = Writable;
@@ -93954,7 +94007,7 @@ function CorkedRequest(state) {
 /* </replacement> */
 
 /*<replacement>*/
-var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : pna.nextTick;
+var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
 /*</replacement>*/
 
 /*<replacement>*/
@@ -94188,7 +94241,7 @@ function writeAfterEnd(stream, cb) {
   var er = new Error('write after end');
   // TODO: defer error events consistently everywhere, not just the cb
   stream.emit('error', er);
-  pna.nextTick(cb, er);
+  processNextTick(cb, er);
 }
 
 // Checks that a user-supplied chunk is valid, especially for the particular
@@ -94205,7 +94258,7 @@ function validChunk(stream, state, chunk, cb) {
   }
   if (er) {
     stream.emit('error', er);
-    pna.nextTick(cb, er);
+    processNextTick(cb, er);
     valid = false;
   }
   return valid;
@@ -94325,10 +94378,10 @@ function onwriteError(stream, state, sync, er, cb) {
   if (sync) {
     // defer the callback if we are being called synchronously
     // to avoid piling up things on the stack
-    pna.nextTick(cb, er);
+    processNextTick(cb, er);
     // this can emit finish, and it will always happen
     // after error
-    pna.nextTick(finishMaybe, stream, state);
+    processNextTick(finishMaybe, stream, state);
     stream._writableState.errorEmitted = true;
     stream.emit('error', er);
   } else {
@@ -94503,7 +94556,7 @@ function prefinish(stream, state) {
     if (typeof stream._final === 'function') {
       state.pendingcb++;
       state.finalCalled = true;
-      pna.nextTick(callFinal, stream, state);
+      processNextTick(callFinal, stream, state);
     } else {
       state.prefinished = true;
       stream.emit('prefinish');
@@ -94527,7 +94580,7 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished) pna.nextTick(cb);else stream.once('finish', cb);
+    if (state.finished) processNextTick(cb);else stream.once('finish', cb);
   }
   state.ended = true;
   stream.writable = false;
@@ -94661,7 +94714,7 @@ if (util && util.inspect && util.inspect.custom) {
 
 /*<replacement>*/
 
-var pna = require('process-nextick-args');
+var processNextTick = require('process-nextick-args').nextTick;
 /*</replacement>*/
 
 // undocumented cb() API, needed for core, not for public API
@@ -94675,7 +94728,7 @@ function destroy(err, cb) {
     if (cb) {
       cb(err);
     } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
-      pna.nextTick(emitErrorNT, this, err);
+      processNextTick(emitErrorNT, this, err);
     }
     return this;
   }
@@ -94694,7 +94747,7 @@ function destroy(err, cb) {
 
   this._destroy(err || null, function (err) {
     if (!cb && err) {
-      pna.nextTick(emitErrorNT, _this, err);
+      processNextTick(emitErrorNT, _this, err);
       if (_this._writableState) {
         _this._writableState.errorEmitted = true;
       }

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -159,7 +159,8 @@ extra_fields_js = [
   { name: 'qrda_oid', type: 'System.String' },
   { name: 'category', type: 'System.String' },
   { name: 'qdm_status', type: 'System.String' },
-  { name: 'qdm_version', type: 'System.String' }
+  { name: 'qdm_version', type: 'System.String' },
+  { name: '_type', type: 'System.String' }
 ]
 datatypes.each do |datatype, attributes|
   attrs_with_extras = attributes + extra_fields_js
@@ -265,6 +266,9 @@ files = Dir.glob(js_models_path + '*.js').each do |file_name|
   else
     contents.gsub!(/  qdm_status: String,\n/, '') # Don't include this field
   end
+
+  # Add class
+  contents.gsub!(/  _type: String,\n/, "  _type: { type: String, default: '#{dc_name.camelize}' },\n")
 
   File.open(file_name, 'w') { |file| file.puts contents }
 end

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -131,8 +131,7 @@ extra_fields_rb = [
   'qrda_oid:String',
   'category:String',
   'qdm_status:String',
-  'qdm_version:String',
-  'class_name:String'
+  'qdm_version:String'
 ]
 base_module = 'QDM::'
 base_module = 'Test::QDM::' if IS_TEST
@@ -160,8 +159,7 @@ extra_fields_js = [
   { name: 'qrda_oid', type: 'System.String' },
   { name: 'category', type: 'System.String' },
   { name: 'qdm_status', type: 'System.String' },
-  { name: 'qdm_version', type: 'System.String' },
-  { name: 'class_name', type: 'System.String' }
+  { name: 'qdm_version', type: 'System.String' }
 ]
 datatypes.each do |datatype, attributes|
   attrs_with_extras = attributes + extra_fields_js
@@ -224,9 +222,6 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
     contents.gsub!(/  field :qdm_status, type: String\n/, '') # Don't include this field
   end
 
-  # Add class
-  contents.gsub!(/  field :class_name, type: String\n/, "  field :class_name, type: String, default: '#{dc_name.camelize}'\n")
-
   File.open(file_name, 'w') { |file| file.puts contents }
 end
 
@@ -270,9 +265,6 @@ files = Dir.glob(js_models_path + '*.js').each do |file_name|
   else
     contents.gsub!(/  qdm_status: String,\n/, '') # Don't include this field
   end
-
-  # Add class
-  contents.gsub!(/  class_name: String,\n/, "  class_name: { type: String, default: '#{dc_name.camelize}' },\n")
 
   File.open(file_name, 'w') { |file| file.puts contents }
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "app/assets/javascripts/index.js",
   "browser": {


### PR DESCRIPTION
Replaced the `class_name` field with the existing mongo `_type`. When the models are serialized, the JSON now includes `_type`, which makes deserialization work.

---

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Reviewer 1:**

Name: @ljades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
