### PR TITLE
Add .vscode/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-error.log
 .rspec_status
 .DS_Store
 .byebug_history
+
+# Editor-specific files
+.vscode/


### PR DESCRIPTION
The `.vscode/` folder wasn't ignore'd by the `.gitignore`, so it could be added if someone used a command like `git add .`. This fixes that by adding the folder to the `.gitignore`.
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed N/A
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist` N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A

**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
