### PR TITLE
Results object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Naming/UncommunicativeMethodParamName:
 Naming/VariableName:
   Enabled: false
 
+Style/DateTime:
+  Enabled: false
+
 # Only disabled until the cyclomatic complexity method in measure.rb (ported from bonnie-bundler) is rewritten
 Lint/NestedMethodDefinition:
   Enabled: false

--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -1,0 +1,46 @@
+const mongoose = require('mongoose');
+
+const [mNumber, mString, Mixed, ObjectId] = [
+  mongoose.Schema.Types.Number,
+  mongoose.Schema.Types.String,
+  mongoose.Schema.Types.Mixed,
+  mongoose.Schema.Types.ObjectId,
+];
+
+const IndividualResultSchema = mongoose.Schema(
+  {
+    // Population Attributes
+    STRAT: mNumber,
+    IPP: mNumber,
+    DENOM: mNumber,
+    NUMER: mNumber,
+    NUMEX: mNumber,
+    DENEX: mNumber,
+    DENEXCEP: mNumber,
+    MSRPOPL: mNumber,
+    OBSERV: mNumber,
+    MSRPOPLEX: mNumber,
+
+    // Result Attributes
+    clause_results: Mixed,
+    episode_results: Mixed,
+    population_relevance: Mixed,
+    statement_relevance: Mixed,
+    statement_results: Mixed,
+
+    // Calculation State attributes
+    state: mString,
+
+    // Relations to other model classes
+    measure: { type: ObjectId, ref: 'Measure' },
+    patient: { type: ObjectId, ref: 'Patient' },
+
+  },
+  // Options
+  {
+    timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' }, // These are the Mongoid conventions for timestamps
+  }
+);
+
+module.exports.IndividualResultSchema = IndividualResultSchema;
+module.exports.IndividualResult = mongoose.model('individual_result', IndividualResultSchema);

--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -26,6 +26,11 @@ const IndividualResultSchema = mongoose.Schema(
     episode_results: Mixed,
     statement_results: Mixed,
 
+    // This field is for application specific information only. If both Bonnie and
+    // Cypress use a common field, it should be made a field on this model,
+    // and not put into extendedData.
+    extendedData: {},
+
     // Calculation State attributes
     state: {
       type: String,

--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -24,12 +24,14 @@ const IndividualResultSchema = mongoose.Schema(
     // Result Attributes
     clause_results: Mixed,
     episode_results: Mixed,
-    population_relevance: Mixed,
-    statement_relevance: Mixed,
     statement_results: Mixed,
 
     // Calculation State attributes
-    state: String,
+    state: {
+      type: String,
+      enum: ['queued', 'running', 'complete', 'cancelled', 'failed'],
+      default: 'queued',
+    },
 
     // Relations to other model classes
     measure: { type: ObjectId, ref: 'Measure' },

--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 
-const [mNumber, mString, Mixed, ObjectId] = [
+const [Number, String, Mixed, ObjectId] = [
   mongoose.Schema.Types.Number,
   mongoose.Schema.Types.String,
   mongoose.Schema.Types.Mixed,
@@ -10,16 +10,16 @@ const [mNumber, mString, Mixed, ObjectId] = [
 const IndividualResultSchema = mongoose.Schema(
   {
     // Population Attributes
-    STRAT: mNumber,
-    IPP: mNumber,
-    DENOM: mNumber,
-    NUMER: mNumber,
-    NUMEX: mNumber,
-    DENEX: mNumber,
-    DENEXCEP: mNumber,
-    MSRPOPL: mNumber,
-    OBSERV: mNumber,
-    MSRPOPLEX: mNumber,
+    STRAT: Number,
+    IPP: Number,
+    DENOM: Number,
+    NUMER: Number,
+    NUMEX: Number,
+    DENEX: Number,
+    DENEXCEP: Number,
+    MSRPOPL: Number,
+    OBSERV: Number,
+    MSRPOPLEX: Number,
 
     // Result Attributes
     clause_results: Mixed,
@@ -29,7 +29,7 @@ const IndividualResultSchema = mongoose.Schema(
     statement_results: Mixed,
 
     // Calculation State attributes
-    state: mString,
+    state: String,
 
     // Relations to other model classes
     measure: { type: ObjectId, ref: 'Measure' },

--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -39,8 +39,9 @@ const IndividualResultSchema = mongoose.Schema(
     },
 
     // Relations to other model classes
-    measure: { type: ObjectId, ref: 'Measure' },
-    patient: { type: ObjectId, ref: 'Patient' },
+    // 'alias' field makes it so you can call obj.measure, and get the object referenced by measure_id
+    measure_id: { type: ObjectId, ref: 'Measure', alias: 'measure' },
+    patient_id: { type: ObjectId, ref: 'Patient', alias: 'patient' },
 
   },
   // Options

--- a/app/assets/javascripts/Measure.js
+++ b/app/assets/javascripts/Measure.js
@@ -3,7 +3,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 
-const [mNumber, mString, mBoolean, Mixed, ObjectId, mDate] = [
+const [Number, String, Boolean, Mixed, ObjectId, Date] = [
   mongoose.Schema.Types.Number,
   mongoose.Schema.Types.String,
   mongoose.Schema.Types.Boolean,
@@ -15,32 +15,32 @@ const [mNumber, mString, mBoolean, Mixed, ObjectId, mDate] = [
 const MeasureSchema = mongoose.Schema(
   {
     // ID/other measure information
-    id: mString,
-    measure_id: mString,
-    hqmf_id: mString,
-    hqmf_set_id: mString,
-    hqmf_version_number: mNumber,
-    cms_id: mString,
-    title: mString,
-    description: mString,
-    type: mString,
-    category: { type: mString, default: 'Uncategorized' },
+    id: String,
+    measure_id: String,
+    hqmf_id: String,
+    hqmf_set_id: String,
+    hqmf_version_number: Number,
+    cms_id: String,
+    title: String,
+    description: String,
+    type: String,
+    category: { type: String, default: 'Uncategorized' },
 
     // Measure type variables
-    episode_of_care: mBoolean,
-    continuous_constiable: mBoolean,
+    episode_of_care: Boolean,
+    continuous_constiable: Boolean,
     episode_ids: [],
 
     // Publishing data (used by Bonnie)
-    published: mBoolean,
-    publish_date: mDate,
-    version: mNumber,
+    published: Boolean,
+    publish_date: Date,
+    version: Number,
 
     // ELM/CQL Measure-logic related data
     elm_annotations: Mixed,
-    cql: [mString],
+    cql: [String],
     elm: [Mixed],
-    main_cql_library: mString,
+    main_cql_library: String,
     cql_statement_dependencies: Mixed,
 
     // HQMF/Tacoma-specific Measure-logic related data

--- a/app/assets/javascripts/ValueSet.js
+++ b/app/assets/javascripts/ValueSet.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const Concept = require('./Concept.js');
 
-const [mString, Mixed, ObjectId] = [
+const [String, Mixed, ObjectId] = [
   mongoose.Schema.Types.String,
   mongoose.Schema.Types.Mixed,
   mongoose.Schema.Types.ObjectId,
@@ -9,9 +9,9 @@ const [mString, Mixed, ObjectId] = [
 
 const ValueSetSchema = mongoose.Schema(
   {
-    oid: mString,
-    display_name: mString,
-    version: mString,
+    oid: String,
+    display_name: String,
+    version: String,
     categories: Mixed,
 
     concepts: [Concept.ConceptSchema],

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -10,3 +10,5 @@ module.exports.ValueSet = require('./ValueSet.js').ValueSet;
 module.exports.ValueSetSchema = require('./ValueSet.js').ValueSetSchema;
 module.exports.Concept = require('./Concept.js').Concept;
 module.exports.ConceptSchema = require('./Concept.js').ConceptSchema;
+module.exports.IndividualResult = require('./IndividualResult').IndividualResult;
+module.exports.IndividualResultSchema = require('./IndividualResult').IndividualResultSchema;

--- a/app/models/models.rb
+++ b/app/models/models.rb
@@ -14,6 +14,7 @@ require_relative 'qdm/tacoma/measure'
 require_relative 'qdm/tacoma/measure_package'
 require_relative 'qdm/tacoma/valueset'
 require_relative 'qdm/tacoma/concept'
+require_relative 'qdm/tacoma/individual_result'
 
 # Generated models
 require_relative 'qdm/patient'

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -38,5 +38,22 @@ module QDM
     def to_json(options = nil)
       serializable_hash(methods: :_type).to_json(options)
     end
+
+    # Shift all fields that deal with dates by the given value.
+    # Given value should be in seconds. Positive values shift forward, negative
+    # values shift backwards.
+    def shift_dates(seconds)
+      # Iterate over fields
+      fields.keys.each do |field|
+        # Check if field is a DateTime
+        if send(field).is_a? DateTime
+          send(field + '=', (send(field).to_time + seconds.seconds).to_datetime)
+        end
+        # Check if field is an Interval
+        if (send(field).is_a? Interval) || (send(field).is_a? DataElement)
+          send(field + '=', send(field).shift_dates(seconds))
+        end
+      end
+    end
   end
 end

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -16,6 +16,21 @@ module QDM
       { low: @low, high: @high, lowClosed: @lowClosed, highClosed: @highClosed }
     end
 
+    # Shift dates by the given value.
+    # Given value should be in seconds. Positive values shift forward, negative
+    # values shift backwards.
+    #
+    # NOTE: This will only shift if @high and @low are DateTimes.
+    def shift_dates(seconds)
+      if (@low.is_a? DateTime) || (@low.is_a? Time)
+        @low = (@low.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
+      end
+      if (@high.is_a? DateTime) || (@high.is_a? Time)
+        @high = (@high.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
+      end
+      self
+    end
+
     class << self
       # Get the object as it was stored in the database, and instantiate
       # this custom class from it.
@@ -25,6 +40,7 @@ module QDM
       def demongoize(object)
         return nil unless object
         object = object.symbolize_keys
+        fix_datetime(object)
         QDM::Interval.new(object[:low], object[:high], object[:lowClosed], object[:highClosed]) if object.is_a?(Hash)
       end
 
@@ -36,9 +52,16 @@ module QDM
         when QDM::Interval then object.mongoize
         when Hash
           object = object.symbolize_keys
+          fix_datetime(object)
           QDM::Interval.new(object[:low], object[:high], object[:lowClosed], object[:highClosed]).mongoize
         else object
         end
+      end
+
+      def fix_datetime(object)
+        # Cast to DateTime if it is a string representing a DateTime
+        object[:low] = DateTime.strptime(object[:low]) if (object[:low].is_a? String) && DateTime.strptime(object[:low])
+        object[:high] = DateTime.strptime(object[:high]) if (object[:high].is_a? String) && DateTime.strptime(object[:high])
       end
 
       # Converts the object that was supplied to a criteria and converts it

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -60,8 +60,8 @@ module QDM
 
       def fix_datetime(object)
         # Cast to DateTime if it is a string representing a DateTime
-        object[:low] = DateTime.strptime(object[:low]) if (object[:low].is_a? String) && DateTime.strptime(object[:low])
-        object[:high] = DateTime.strptime(object[:high]) if (object[:high].is_a? String) && DateTime.strptime(object[:high])
+        object[:low] = DateTime.parse(object[:low]) if (object[:low].is_a? String) && DateTime.parse(object[:low])
+        object[:high] = DateTime.parse(object[:high]) if (object[:high].is_a? String) && DateTime.parse(object[:high])
       end
 
       # Converts the object that was supplied to a criteria and converts it

--- a/app/models/qdm/patient.rb
+++ b/app/models/qdm/patient.rb
@@ -29,6 +29,17 @@ module QDM
       dataElements.where(qrdaOid: qrda_oid) || []
     end
 
+    # Shift all data element fields that deal with dates by the given value.
+    # Given value should be in seconds. Positive values shift forward, negative
+    # values shift backwards.
+    #
+    # Note: This will shift dates of the birthdate and
+    # dates on the data elements that exist on the patient.
+    def shift_dates(seconds)
+      self.birthDatetime = (birthDatetime.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
+      dataElements.each { |element| element.shift_dates(seconds) }
+    end
+
     # Returns an array of elements that exist on this patient. Optionally
     # takes a category and/or, which returns all elements of that QDM
     # category. Example: patient.get_data_elements('encounters')

--- a/app/models/qdm/tacoma/individual_result.rb
+++ b/app/models/qdm/tacoma/individual_result.rb
@@ -1,0 +1,33 @@
+module QDM
+  # IndividualResult stores the patient-level (population/clause) results for a patient/measure combination
+  class IndividualResult
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    # Population Attributes
+    field :STRAT, type: Integer
+    field :IPP, type: Integer
+    field :DENOM, type: Integer
+    field :NUMER, type: Integer
+    field :NUMEX, type: Integer
+    field :DENEX, type: Integer
+    field :DENEXCEP, type: Integer
+    field :MSRPOPL, type: Integer
+    field :OBSERV, type: Float
+    field :MSRPOPLEX, type: Integer
+
+    # Result Attributes
+    field :clause_results, type: Hash
+    field :episode_results, type: Hash
+    filed :population_relevance, type: Hash
+    field :statement_relevance, type: Hash
+    field :statement_results, type: Hash
+
+    # Calculation state attributes
+    field :state, type: String
+
+    # Relations to other model classes
+    belongs_to :measure
+    belongs_to :patient
+  end
+end

--- a/app/models/qdm/tacoma/individual_result.rb
+++ b/app/models/qdm/tacoma/individual_result.rb
@@ -4,6 +4,9 @@ module QDM
     include Mongoid::Document
     include Mongoid::Timestamps
 
+    # This is the Mongoid equivalent of the Mongoose "enum" attribute for :state. Throws an error if you try to assign a value that's not in this array.
+    validates_inclusion_of :state, in: %w[queued running complete cancelled failed]
+
     # Population Attributes
     field :STRAT, type: Integer
     field :IPP, type: Integer
@@ -19,12 +22,10 @@ module QDM
     # Result Attributes
     field :clause_results, type: Hash
     field :episode_results, type: Hash
-    filed :population_relevance, type: Hash
-    field :statement_relevance, type: Hash
     field :statement_results, type: Hash
 
     # Calculation state attributes
-    field :state, type: String
+    field :state, type: String, default: 'queued'
 
     # Relations to other model classes
     belongs_to :measure

--- a/app/models/qdm/tacoma/individual_result.rb
+++ b/app/models/qdm/tacoma/individual_result.rb
@@ -24,6 +24,11 @@ module QDM
     field :episode_results, type: Hash
     field :statement_results, type: Hash
 
+    # This field is for application specific information only. If both Bonnie and
+    # Cypress use a common field, it should be made a field on this model,
+    # and not put into extendedData.
+    field :extendedData, type: Hash
+
     # Calculation state attributes
     field :state, type: String, default: 'queued'
 

--- a/app/models/qdm/tacoma/measure.rb
+++ b/app/models/qdm/tacoma/measure.rb
@@ -74,7 +74,7 @@ module QDM
     # Relations to other model classes
     belongs_to :user
     belongs_to :bundle, class_name: 'HealthDataStandards::CQM::Bundle'
-    has_and_belongs_to_many :records, inverse_of: nil
+    has_and_belongs_to_many :patients, inverse_of: nil
     has_one :package, class_name: 'CqlMeasurePackage', inverse_of: :measure, dependent: :destroy
 
     scope :by_measure_id, ->(id) { where('measure_id' => id) }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "^1.2.0",
+    "cql-execution": "1.2.0",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe QDM do
     @patient_big.dataElements << QDM::EncounterPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')])
     @patient_big.dataElements << QDM::CommunicationFromProviderToPatient.new(authorDatetime: 3.years.ago, dataElementCodes: [QDM::Code.new('SNOMED-CT', '428341000124108')])
     @patient_big.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')])
+
+    # Patient with some data elements
+    bd = 70.years.ago
+    @patient_de1 = QDM::Patient.new(birthDatetime: bd, givenNames: %w['First1 Middle1'], familyName: 'Family1', bundleId: '1')
+    @patient_de1.dataElements << QDM::PatientCharacteristicBirthdate.new(birthDatetime: bd)
+    @patient_de1.dataElements << QDM::Diagnosis.new(authorDatetime: DateTime.new(2010, 1, 1, 4, 0, 0), dataElementCodes: [QDM::Code.new('E08.311', 'ICD-10-CM'), QDM::Code.new('362.01', 'ICD-9-CM'), QDM::Code.new('4855003', 'SNOMED-CT')])
+    @patient_de1.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')])
+    @patient_de1.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')])
+
+    # Another patient with some data elements
+    bd = 20.years.ago
+    @patient_de2 = QDM::Patient.new(birthDatetime: bd, givenNames: %w['First2 Middle2'], familyName: 'Family2', bundleId: '1')
+    @patient_de2.dataElements << QDM::PatientCharacteristicBirthdate.new(birthDatetime: bd)
+    @patient_de2.dataElements << QDM::Diagnosis.new(authorDatetime: DateTime.new(2010, 1, 1, 4, 0, 0), dataElementCodes: [QDM::Code.new('E08.311', 'ICD-10-CM'), QDM::Code.new('362.01', 'ICD-9-CM'), QDM::Code.new('4855003', 'SNOMED-CT')])
+    @patient_de2.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')])
+    @patient_de2.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')])
   end
 
   after(:all) do
@@ -65,5 +81,49 @@ RSpec.describe QDM do
 
   it 'patients return datatypes return codes using code_system_pairs' do
     expect(@patient_a.get_data_elements('procedure').first.code_system_pairs.count).to eq 2
+  end
+
+  it 'shift patient data elements forward in time' do
+    # Shift everything two hours ahead
+    @patient_de1.shift_dates(60 * 60 * 2)
+
+    # Diagnosis authorDatetime should be two hours ahead
+    expect(@patient_de1.conditions.first.authorDatetime.utc.to_s).to include('06:00:00')
+
+    # EncounterPerformed authorDatetime should be two hours ahead
+    expect(@patient_de1.encounters.first.authorDatetime.utc.to_s).to include('06:00:00')
+
+    # EncounterPerformed relevantPeriod high and low should be two hours ahead
+    expect(@patient_de1.encounters.first.relevantPeriod.low.utc.to_s).to include('06:00:00')
+    expect(@patient_de1.encounters.first.relevantPeriod.high.utc.to_s).to include('07:00:00')
+
+    # DiagnosticStudyPerformed authorDatetime should be two hours ahead
+    expect(@patient_de1.diagnostic_studies.first.authorDatetime.utc.to_s).to include('06:00:00')
+
+    # DiagnosticStudyPerformed relevantPeriod high and low should be two hours ahead
+    expect(@patient_de1.diagnostic_studies.first.relevantPeriod.low.utc.to_s).to include('06:00:00')
+    expect(@patient_de1.diagnostic_studies.first.relevantPeriod.high.utc.to_s).to include('07:00:00')
+  end
+
+  it 'shift patient data elements backwards in time' do
+    # Shift everything two hours behind
+    @patient_de2.shift_dates(-(60 * 60 * 2))
+
+    # Diagnosis authorDatetime should be two hours behind
+    expect(@patient_de2.conditions.first.authorDatetime.utc.to_s).to include('02:00:00')
+
+    # EncounterPerformed authorDatetime should be two hours behind
+    expect(@patient_de2.encounters.first.authorDatetime.utc.to_s).to include('02:00:00')
+
+    # EncounterPerformed relevantPeriod high and low should be two hours behind
+    expect(@patient_de2.encounters.first.relevantPeriod.low.utc.to_s).to include('02:00:00')
+    expect(@patient_de2.encounters.first.relevantPeriod.high.utc.to_s).to include('03:00:00')
+
+    # DiagnosticStudyPerformed authorDatetime should be two hours behind
+    expect(@patient_de2.diagnostic_studies.first.authorDatetime.utc.to_s).to include('02:00:00')
+
+    # DiagnosticStudyPerformed relevantPeriod high and low should be two hours behind
+    expect(@patient_de2.diagnostic_studies.first.relevantPeriod.low.utc.to_s).to include('02:00:00')
+    expect(@patient_de2.diagnostic_studies.first.relevantPeriod.high.utc.to_s).to include('03:00:00')
   end
 end

--- a/templates/index_template.js.erb
+++ b/templates/index_template.js.erb
@@ -10,3 +10,5 @@ module.exports.ValueSet = require('./ValueSet.js').ValueSet;
 module.exports.ValueSetSchema = require('./ValueSet.js').ValueSetSchema;
 module.exports.Concept = require('./Concept.js').Concept;
 module.exports.ConceptSchema = require('./Concept.js').ConceptSchema;
+module.exports.IndividualResult = require('./IndividualResult').IndividualResult;
+module.exports.IndividualResultSchema = require('./IndividualResult').IndividualResultSchema;


### PR DESCRIPTION
This Pull Request adds an `IndividualResult` object to Javascript and Ruby, which allows for the storage of results about a particular patient-measure combination. Also includes several changes to the `Measure` model to accommodate the relations to `IndividualResult`. 

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/TACO-48
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [ ] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Reviewer 0:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @ljades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
