### PR TITLE
Population Ids for Measure Model, Any type with casting for JS Patient Models

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "airbnb-base",
   "rules": {
     "max-len": ["error", {"code": 200, "ignoreComments": true}],
-    "no-unused-vars": ["error", { "varsIgnorePattern": "Code|Quantity|Interval|Integer|Array|Float|Time|Number|Date|Mixed" }],
+    "no-unused-vars": ["error", { "varsIgnorePattern": "Code|Quantity|Interval|Integer|Array|Float|Time|Number|Date|Mixed|Any" }],
     "camelcase": "off",
     "comma-dangle": ["error", {
       "arrays": "always-multiline", 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ matrix:
           - "node_modules"
       script:
         - npm run lint
+        - yarn run test
         - ./bin/validate_dist.sh

--- a/app/assets/javascripts/AdverseEvent.js
+++ b/app/assets/javascripts/AdverseEvent.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/AllergyIntolerance.js
+++ b/app/assets/javascripts/AllergyIntolerance.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -16,7 +16,7 @@ const AssessmentPerformedSchema = DataElementSchema({
   negationRationale: Code,
   reason: Code,
   method: Code,
-  result: {},
+  result: Any,
   components: [],
   relatedTo: [String],
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.3.117' },

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/AssessmentRecommended.js
+++ b/app/assets/javascripts/AssessmentRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -14,7 +14,7 @@ const [Number, String] = [
 const CareGoalSchema = DataElementSchema({
   relevantPeriod: Interval,
   relatedTo: [String],
-  targetOutcome: {},
+  targetOutcome: Any,
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.3.7' },
   category: { type: String, default: 'care_goal' },
   qdmVersion: { type: String, default: '5.3' },

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/CommunicationFromPatientToProvider.js
+++ b/app/assets/javascripts/CommunicationFromPatientToProvider.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/CommunicationFromProviderToPatient.js
+++ b/app/assets/javascripts/CommunicationFromProviderToPatient.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/CommunicationFromProviderToProvider.js
+++ b/app/assets/javascripts/CommunicationFromProviderToProvider.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Component.js
+++ b/app/assets/javascripts/Component.js
@@ -13,7 +13,7 @@ const [Number, String] = [
 
 const ComponentSchema = DataElementSchema({
   code: Code,
-  result: {},
+  result: Any,
   qdmVersion: { type: String, default: '5.3' },
   _type: { type: String, default: 'Component' },
 

--- a/app/assets/javascripts/Component.js
+++ b/app/assets/javascripts/Component.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DeviceApplied.js
+++ b/app/assets/javascripts/DeviceApplied.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DeviceOrder.js
+++ b/app/assets/javascripts/DeviceOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DeviceRecommended.js
+++ b/app/assets/javascripts/DeviceRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Diagnosis.js
+++ b/app/assets/javascripts/Diagnosis.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DiagnosticStudyOrder.js
+++ b/app/assets/javascripts/DiagnosticStudyOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -15,7 +15,7 @@ const DiagnosticStudyPerformedSchema = DataElementSchema({
   authorDatetime: DateTime,
   relevantPeriod: Interval,
   reason: Code,
-  result: {},
+  result: Any,
   resultDatetime: DateTime,
   status: Code,
   method: Code,

--- a/app/assets/javascripts/DiagnosticStudyRecommended.js
+++ b/app/assets/javascripts/DiagnosticStudyRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/EncounterOrder.js
+++ b/app/assets/javascripts/EncounterOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/EncounterPerformed.js
+++ b/app/assets/javascripts/EncounterPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/EncounterRecommended.js
+++ b/app/assets/javascripts/EncounterRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/FacilityLocation.js
+++ b/app/assets/javascripts/FacilityLocation.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/FamilyHistory.js
+++ b/app/assets/javascripts/FamilyHistory.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Id.js
+++ b/app/assets/javascripts/Id.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ImmunizationAdministered.js
+++ b/app/assets/javascripts/ImmunizationAdministered.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ImmunizationOrder.js
+++ b/app/assets/javascripts/ImmunizationOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/InterventionOrder.js
+++ b/app/assets/javascripts/InterventionOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -15,7 +15,7 @@ const InterventionPerformedSchema = DataElementSchema({
   authorDatetime: DateTime,
   relevantPeriod: Interval,
   reason: Code,
-  result: {},
+  result: Any,
   status: Code,
   negationRationale: Code,
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.3.36' },

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/InterventionRecommended.js
+++ b/app/assets/javascripts/InterventionRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/LaboratoryTestOrder.js
+++ b/app/assets/javascripts/LaboratoryTestOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -16,7 +16,7 @@ const LaboratoryTestPerformedSchema = DataElementSchema({
   relevantPeriod: Interval,
   status: Code,
   method: Code,
-  result: {},
+  result: Any,
   resultDatetime: DateTime,
   reason: Code,
   referenceRange: Interval,

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/LaboratoryTestRecommended.js
+++ b/app/assets/javascripts/LaboratoryTestRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Measure.js
+++ b/app/assets/javascripts/Measure.js
@@ -52,6 +52,7 @@ const MeasureSchema = mongoose.Schema(
     populations: [Mixed],
     populations_cql_map: Mixed,
     observations: [Mixed],
+    // TODO: Depending on how we restructure the Measure/Population object, may be deleted in the future
     population_ids: Mixed,
 
     value_sets: [{ type: ObjectId, ref: 'ValueSet' }],

--- a/app/assets/javascripts/Measure.js
+++ b/app/assets/javascripts/Measure.js
@@ -52,6 +52,7 @@ const MeasureSchema = mongoose.Schema(
     populations: [Mixed],
     populations_cql_map: Mixed,
     observations: [Mixed],
+    population_ids: Mixed,
 
     value_sets: [{ type: ObjectId, ref: 'ValueSet' }],
 

--- a/app/assets/javascripts/MedicationActive.js
+++ b/app/assets/javascripts/MedicationActive.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/MedicationAdministered.js
+++ b/app/assets/javascripts/MedicationAdministered.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/MedicationDischarge.js
+++ b/app/assets/javascripts/MedicationDischarge.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/MedicationDispensed.js
+++ b/app/assets/javascripts/MedicationDispensed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/MedicationOrder.js
+++ b/app/assets/javascripts/MedicationOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Patient.js
+++ b/app/assets/javascripts/Patient.js
@@ -4,6 +4,7 @@ const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
 const AllDataElements = require('./AllDataElements');
+const Any = require('./basetypes/Any');
 
 const [Schema, Number, String] = [
   mongoose.Schema,

--- a/app/assets/javascripts/Patient.js
+++ b/app/assets/javascripts/Patient.js
@@ -4,7 +4,6 @@ const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
 const AllDataElements = require('./AllDataElements');
-const Any = require('./basetypes/Any');
 
 const [Schema, Number, String] = [
   mongoose.Schema,

--- a/app/assets/javascripts/PatientCareExperience.js
+++ b/app/assets/javascripts/PatientCareExperience.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristic.js
+++ b/app/assets/javascripts/PatientCharacteristic.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicBirthdate.js
+++ b/app/assets/javascripts/PatientCharacteristicBirthdate.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
+++ b/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicEthnicity.js
+++ b/app/assets/javascripts/PatientCharacteristicEthnicity.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicExpired.js
+++ b/app/assets/javascripts/PatientCharacteristicExpired.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicPayer.js
+++ b/app/assets/javascripts/PatientCharacteristicPayer.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicRace.js
+++ b/app/assets/javascripts/PatientCharacteristicRace.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PatientCharacteristicSex.js
+++ b/app/assets/javascripts/PatientCharacteristicSex.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PhysicalExamOrder.js
+++ b/app/assets/javascripts/PhysicalExamOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -16,7 +16,7 @@ const PhysicalExamPerformedSchema = DataElementSchema({
   relevantPeriod: Interval,
   reason: Code,
   method: Code,
-  result: {},
+  result: Any,
   anatomicalLocationSite: Code,
   negationRationale: Code,
   components: [],

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/PhysicalExamRecommended.js
+++ b/app/assets/javascripts/PhysicalExamRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ProcedureOrder.js
+++ b/app/assets/javascripts/ProcedureOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -16,7 +16,7 @@ const ProcedurePerformedSchema = DataElementSchema({
   relevantPeriod: Interval,
   reason: Code,
   method: Code,
-  result: {},
+  result: Any,
   status: Code,
   anatomicalApproachSite: Code,
   anatomicalLocationSite: Code,

--- a/app/assets/javascripts/ProcedureRecommended.js
+++ b/app/assets/javascripts/ProcedureRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ProviderCareExperience.js
+++ b/app/assets/javascripts/ProviderCareExperience.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ProviderCharacteristic.js
+++ b/app/assets/javascripts/ProviderCharacteristic.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Ratio.js
+++ b/app/assets/javascripts/Ratio.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/ResultComponent.js
+++ b/app/assets/javascripts/ResultComponent.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/SubstanceAdministered.js
+++ b/app/assets/javascripts/SubstanceAdministered.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/SubstanceOrder.js
+++ b/app/assets/javascripts/SubstanceOrder.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/SubstanceRecommended.js
+++ b/app/assets/javascripts/SubstanceRecommended.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/Symptom.js
+++ b/app/assets/javascripts/Symptom.js
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,

--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -6,12 +6,45 @@ function Any(key, options) {
 }
 Any.prototype = Object.create(mongoose.SchemaType.prototype);
 
-Any.prototype.cast = (any) => {
+function RecursiveCast(any) {
   if (any && any.value && any.unit) {
     return new cql.Quantity(any);
   }
+  if (any && any.low) {
+    const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);
+
+    // Cast Low and High values to Quantities if it is a quantity
+    if (casted.low && casted.low.unit && casted.low.value) {
+      casted.low = new cql.Quantity(casted.low);
+      if (casted.high && casted.high.unit && casted.high.value) {
+        casted.high = new cql.Quantity(casted.high);
+      }
+      return casted;
+    }
+
+    // Cast to DateTime if it is a string representing a DateTime
+    if (casted.low && Date.parse(casted.low)) {
+      casted.low = cql.DateTime.fromDate(new Date(casted.low), 0);
+    }
+    if (casted.high && Date.parse(casted.high)) {
+      casted.high = cql.DateTime.fromDate(new Date(casted.high), 0);
+    }
+    return casted;
+  }
+  if (Array.isArray(any)) {
+    const casted = [];
+    any.forEach((val) => {
+      casted.push(RecursiveCast(val));
+    });
+    return casted;
+  }
+  if (Date.parse(any)) {
+    return cql.DateTime.fromDate(new Date(any), 0);
+  }
   return any;
-};
+}
+
+Any.prototype.cast = any => RecursiveCast(any);
 
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;

--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const cql = require('cql-execution');
+
+function Any(key, options) {
+  mongoose.SchemaType.call(this, key, options, 'Any');
+}
+Any.prototype = Object.create(mongoose.SchemaType.prototype);
+
+Any.prototype.cast = (any) => {
+  if (any && any.value && any.unit) {
+    return new cql.Quantity(any);
+  }
+  if (Date.parse(any)) {
+    return cql.Any.fromDate(new Date(any), 0);
+  }
+  if (any && any.low) {
+    const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);
+
+    // Cast Low and High values to Quantities if it is a quantity
+    if (casted.low && casted.low.unit && casted.low.value) {
+      casted.low = new cql.Quantity(casted.low);
+      if (casted.high && casted.high.unit && casted.high.value) {
+        casted.high = new cql.Quantity(casted.high);
+      }
+      return casted;
+    }
+
+    // Cast to DateTime if it is a string representing a DateTime
+    if (casted.low && Date.parse(casted.low)) {
+      casted.low = cql.DateTime.fromDate(new Date(casted.low), 0);
+    }
+    if (casted.high && Date.parse(casted.high)) {
+      casted.high = cql.DateTime.fromDate(new Date(casted.high), 0);
+    }
+    return casted;
+  }
+  return any;
+};
+
+mongoose.Schema.Types.Any = Any;
+module.exports = Any;

--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -10,30 +10,6 @@ Any.prototype.cast = (any) => {
   if (any && any.value && any.unit) {
     return new cql.Quantity(any);
   }
-  if (Date.parse(any)) {
-    return cql.Any.fromDate(new Date(any), 0);
-  }
-  if (any && any.low) {
-    const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);
-
-    // Cast Low and High values to Quantities if it is a quantity
-    if (casted.low && casted.low.unit && casted.low.value) {
-      casted.low = new cql.Quantity(casted.low);
-      if (casted.high && casted.high.unit && casted.high.value) {
-        casted.high = new cql.Quantity(casted.high);
-      }
-      return casted;
-    }
-
-    // Cast to DateTime if it is a string representing a DateTime
-    if (casted.low && Date.parse(casted.low)) {
-      casted.low = cql.DateTime.fromDate(new Date(casted.low), 0);
-    }
-    if (casted.high && Date.parse(casted.high)) {
-      casted.high = cql.DateTime.fromDate(new Date(casted.high), 0);
-    }
-    return casted;
-  }
   return any;
 };
 

--- a/app/models/qdm/tacoma/measure.rb
+++ b/app/models/qdm/tacoma/measure.rb
@@ -63,6 +63,7 @@ module QDM
     field :populations, type: Array
     field :populations_cql_map, type: Hash
     field :observations, type: Array
+    # TODO: Depending on how we restructure the Measure/Population object, may be deleted in the future
     field :population_ids, type: Hash
 
     field :value_set_oids, type: Array, default: []

--- a/app/models/qdm/tacoma/measure.rb
+++ b/app/models/qdm/tacoma/measure.rb
@@ -63,6 +63,7 @@ module QDM
     field :populations, type: Array
     field :populations_cql_map, type: Hash
     field :observations, type: Array
+    field :population_ids, type: Hash
 
     field :value_set_oids, type: Array, default: []
     field :value_set_oid_version_objects, type: Array, default: []

--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '0.7.1'
+  spec.version       = '0.7.2'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'cqm-models'

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -37,7 +37,7 @@ TYPE_LOOKUP_JS = {
   'System.Integer': 'Number',
   'System.Quantity': 'Quantity',
   'System.Code': 'Code',
-  'System.Any': '{}',
+  'System.Any': 'Any',
   'interval<System.DateTime>': 'Interval',
   'interval<System.Quantity>': 'Interval',
   'list<QDM.Component>': '[]',

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -247,7 +247,7 @@ files = Dir.glob(js_models_path + '*.js').each do |file_name|
   contents = File.read(file_name)
 
   # Replace 'Any' type placeholder (these attributes could point to anything).
-  contents.gsub!(/: Any/, ': {}')
+  contents.gsub!(/: Any/, ': Any')
 
   # Add QDM version
   contents.gsub!(/qdmVersion: String/, "qdmVersion: { type: String, default: '#{qdm_version}' }")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "",
   "main": "app/assets/javascripts/index.js",
   "browser": {

--- a/spec/javascript/unit/anySpec.js
+++ b/spec/javascript/unit/anySpec.js
@@ -1,0 +1,18 @@
+const Any = require('./../../../app/assets/javascripts/basetypes/Any');
+const Cql = require('cql-execution');
+
+describe('The Any class', () => {
+  describe('Type casting', () => {
+    it('Should convert a Quantity JS Object to its type', () => {
+      const quantity_obj = {
+        value: 2,
+        unit: 'm',
+      };
+
+      const returned_obj = Any.prototype.cast(quantity_obj);
+      expect(returned_obj instanceof Cql.Quantity).toBe(true);
+      expect(returned_obj.value).toEqual(2);
+      expect(returned_obj.unit).toEqual('m');
+    });
+  });
+});

--- a/spec/javascript/unit/anySpec.js
+++ b/spec/javascript/unit/anySpec.js
@@ -14,5 +14,49 @@ describe('The Any class', () => {
       expect(returned_obj.value).toEqual(2);
       expect(returned_obj.unit).toEqual('m');
     });
+
+    it('Should convert a Interval JS Object to its type', () => {
+      const interval_obj = {
+        low: '2012-05-21T11:30:00.000-04:00',
+      };
+
+      const returned_obj = Any.prototype.cast(interval_obj);
+      expect(returned_obj instanceof Cql.Interval).toBe(true);
+      expect(returned_obj.low instanceof Cql.DateTime).toEqual(true);
+    });
+
+    it('Should convert a DateTime JS Object to its type', () => {
+      const datetime_obj = '2012-05-21T11:30:00.000-04:00';
+
+      const returned_obj = Any.prototype.cast(datetime_obj);
+      expect(returned_obj instanceof Cql.DateTime).toBe(true);
+    });
+
+    it('Should convert a non-special JS Object to its type', () => {
+      const any_obj = { hi: 'no' };
+
+      const returned_obj = Any.prototype.cast(any_obj);
+      expect(returned_obj instanceof Object).toEqual(true);
+      expect(returned_obj.hi).toEqual('no');
+    });
+
+    it('Should recursively convert an Array JS Object to its type', () => {
+      const array_obj = [{
+        low: '2012-05-21T11:30:00.000-04:00',
+      }, {
+        value: 2,
+        unit: 'm',
+      }, {
+        hi: 'no',
+      }];
+
+      const returned_obj = Any.prototype.cast(array_obj);
+      expect(Array.isArray(returned_obj)).toBe(true);
+      expect(returned_obj[0] instanceof Cql.Interval).toEqual(true);
+      expect(returned_obj[0].low instanceof Cql.DateTime).toEqual(true);
+      expect(returned_obj[1] instanceof Cql.Quantity).toEqual(true);
+      expect(returned_obj[2] instanceof Object).toEqual(true);
+      expect(returned_obj[2].hi).toEqual('no');
+    });
   });
 });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+
+  "spec_files": [
+    "javascript/**/*[sS]pec.js"
+  ],
+
+  "helpers": [
+    "javascript/helpers/**/*.js"
+  ]
+}

--- a/templates/mongoose_template.js.erb
+++ b/templates/mongoose_template.js.erb
@@ -4,6 +4,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const Any = require('./basetypes/Any');
 
 const [Number, String] = [
   mongoose.Schema.Types.Number,


### PR DESCRIPTION
This PR is intended to do two things to fix issues coming up in calculation:
1. The Measure model needed an expansion to include the `population_ids` field, so that the specific population could be specified for a measure file.
2. `Any` types in the modelinfo file needed to be casted as a cql.Quantity if they ended up as such, for calculation in the `cql-execution` library. A new JS Basetype was built to accomodate for this.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Reviewer 1:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 3:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
