### PR TITLE
Added a validate_dist shell script that gets run on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 node_modules/
+tmp/
 
 # yarn error tracking
 yarn-error.log

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'bin/**/*'
+    - 'vendor/**/*'
   TargetRubyVersion: 2.3
 
 Metrics/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 matrix:
   include:
     - language: ruby
-      sudo: false
-      dist: trusty
       cache: bundler
       rvm:
         - 2.4.1
@@ -12,8 +10,6 @@ matrix:
         - bundle exec rake
         - bundle exec rubocop
     - language: node_js
-      sudo: false
-      dist: trusty
       node_js:
         - "node"
         - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ matrix:
           - "node_modules"
       script:
         - npm run lint
+        - ./bin/validate_dist.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 matrix:
   include:
     - language: ruby
+      sudo: false
+      dist: trusty
       cache: bundler
       rvm:
         - 2.4.1
@@ -10,6 +12,8 @@ matrix:
         - bundle exec rake
         - bundle exec rubocop
     - language: node_js
+      sudo: false
+      dist: trusty
       node_js:
         - "node"
         - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
   include:
     - language: ruby
+      cache: bundler
       rvm:
         - 2.4.1
       services:

--- a/bin/validate_dist.sh
+++ b/bin/validate_dist.sh
@@ -10,6 +10,8 @@ diff=`diff dist/index.js tmp/dist/index.js`
 
 # Exit with a non-zero code if the diff isn't empty
 if [ "$diff" != "" ]; then
-  echo "$diff"
+  echo "dist/index.js is out of date. Please run 'yarn run dist' locally and commit/push the result"
   exit 1
 fi
+
+echo "dist/index.js is up to date"

--- a/bin/validate_dist.sh
+++ b/bin/validate_dist.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+mkdir -p tmp/dist/
+
+# dist_test browserifies index.js to tmp/dist
+yarn run dist_test
+
+# comm -3 only returns lines that differ between the two files. If none are different, diff will be empty
+diff=`diff dist/index.js tmp/dist/index.js`
+
+# Exit with a non-zero code if the diff isn't empty
+if [ "$diff" != "" ]; then
+  echo "$diff"
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "test": "jasmine",
     "lint": "eslint 'app/assets/javascripts/**/*.js'",
-    "dist": "browserify app/assets/javascripts/index.js > dist/index.js"
+    "dist": "browserify app/assets/javascripts/index.js > dist/index.js",
+    "dist_test": "browserify app/assets/javascripts/index.js > tmp/dist/index.js"
   }
 }


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

This Pull Request adds a Travis test to ensure that dist/index.js has been rebuilt. For example, this will fail currently, because dist is out-of-date. It will pass once #27 is merged in, and I rebase.

Also: I added a `cache: bundler` line to the `ruby` test language, so we don't have to wait for `bundle install` to complete every time we run a travis build.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass 
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist` N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A

**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 3:**

Name: @ljades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
