### PR TITLE
Move attr_reader fields to attr_accessor, and add two missing fields to Interval

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,21 +10,14 @@ Pull requests into cqm-models require the following. Submitter and reviewer shou
 - [ ] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
 - [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
 
-**Reviewer 1:**
+**Bonnie Reviewer:**
 
 Name:
 - [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
 - [ ] The tests appropriately test the new code, including edge cases
 - [ ] You have tried to break the code
 
-**Reviewer 2:**
-
-Name:
-- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
-- [ ] The tests appropriately test the new code, including edge cases
-- [ ] You have tried to break the code
-
-**Reviewer 3:**
+**Cypress Reviewer:**
 
 Name:
 - [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose

--- a/app/models/qdm/basetypes/code.rb
+++ b/app/models/qdm/basetypes/code.rb
@@ -1,7 +1,7 @@
 module QDM
   # Represents a Code
   class Code
-    attr_reader :code, :codeSystem, :descriptor, :codeSystemOid, :version
+    attr_accessor :code, :codeSystem, :descriptor, :codeSystemOid, :version
 
     # Code and code system are required (at minimum).
     def initialize(code, codeSystem, descriptor = nil, codeSystemOid = nil, version = nil)

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -1,7 +1,7 @@
 module QDM
   # Represents an Interval
   class Interval
-    attr_reader :low, :high
+    attr_accessor :low, :high, :lowClosed, :highClosed
 
     # Low and high are required (at minimum).
     def initialize(low, high, lowClosed = true, highClosed = true)

--- a/app/models/qdm/basetypes/quantity.rb
+++ b/app/models/qdm/basetypes/quantity.rb
@@ -1,7 +1,7 @@
 module QDM
   # Represents a Quantity
   class Quantity
-    attr_reader :value, :unit
+    attr_accessor :value, :unit
 
     # Value and unit are required.
     def initialize(value, unit)

--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '0.7.3'
+  spec.version       = '0.7.4'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'Mongo models that correspond to the QDM specification.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {


### PR DESCRIPTION
`attr_reader` fields are read-only, so they were migrated to `attr_accessor` instead, so they can be written.

Also, `lowClosed` and `highClosed` were missing entirely on `Interval.rb`, so those were added.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist` N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 3:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
