### PR TITLE
Ensure 'yarn' gets run before browserify-ing code

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "jasmine",
     "lint": "eslint 'app/assets/javascripts/**/*.js'",
-    "dist": "browserify app/assets/javascripts/index.js > dist/index.js",
+    "dist": "yarn && browserify app/assets/javascripts/index.js > dist/index.js",
     "dist_test": "browserify app/assets/javascripts/index.js > tmp/dist/index.js"
   }
 }


### PR DESCRIPTION
As it turns out, if you don't run `yarn` before running the `browserify` code, it could browser-ify the code with out-of-date dependencies compared to what will be run on Travis. This PR adds the `yarn` command to `yarn run dist`, so you can't forget to run it. It _doesn't_ add it to `yarn run dist_test`, because that's designed for use on Travis, where `yarn` will already be run.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
