### PR TITLE
Parse a string into a DateTime instead of trying to format a string a…

### DIFF
--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -60,8 +60,8 @@ module QDM
 
       def fix_datetime(object)
         # Cast to DateTime if it is a string representing a DateTime
-        object[:low] = DateTime.strptime(object[:low]) if (object[:low].is_a? String) && DateTime.strptime(object[:low])
-        object[:high] = DateTime.strptime(object[:high]) if (object[:high].is_a? String) && DateTime.strptime(object[:high])
+        object[:low] = DateTime.parse(object[:low]) if (object[:low].is_a? String) && DateTime.parse(object[:low])
+        object[:high] = DateTime.parse(object[:high]) if (object[:high].is_a? String) && DateTime.parse(object[:high])
       end
 
       # Converts the object that was supplied to a criteria and converts it


### PR DESCRIPTION
…s time

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
