### PR TITLE
Added participation type to OIDs lookup; Updated participation model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/projecttacoma/cqm-models.svg?branch=master)](https://travis-ci.org/projecttacoma/cqm-models)
+[![Gem Version](https://badge.fury.io/rb/cqm-models.svg)](https://badge.fury.io/rb/cqm-models)
+
 # cqm-models
 
 ## QDM Models

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -13,6 +13,8 @@ const [Number, String] = [
 
 const ParticipationSchema = DataElementSchema({
   participationPeriod: Interval,
+  hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.130' },
+  category: { type: String, default: 'participation' },
   qdmVersion: { type: String, default: '5.3' },
   _type: { type: String, default: 'Participation' },
 

--- a/app/models/qdm/participation.rb
+++ b/app/models/qdm/participation.rb
@@ -4,6 +4,8 @@ module QDM
     include Mongoid::Document
     embedded_in :patient
     field :participationPeriod, type: QDM::Interval
+    field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.130'
+    field :category, type: String, default: 'participation'
     field :qdmVersion, type: String, default: '5.3'
   end
 end

--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '0.7.6'
+  spec.version       = '0.7.7'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'Mongo models that correspond to the QDM specification.'

--- a/data/oids.json
+++ b/data/oids.json
@@ -413,6 +413,12 @@
     "category": "patient_characteristic",
     "status": "race"
   },
+  "participation": {
+    "hqmf_oid": "2.16.840.1.113883.10.20.28.4.130",
+    "qrda_oid": "",
+    "category": "participation",
+    "status": ""
+  },
   "physical_exam": {
     "hqmf_oid": "2.16.840.1.113883.10.20.28.3.60",
     "qrda_oid": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {


### PR DESCRIPTION
Added participation type to OIDs lookup; Updated participation model

---

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] <s>Internal ticket for this PR:</s>
- [x] <s>Internal ticket links to this PR</s>
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Bonnie Reviewer:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
