### PR TITLE
Add special case to dataElement's shift_dates function for facilityLocations

### DIFF
--- a/app/assets/javascripts/Patient.js
+++ b/app/assets/javascripts/Patient.js
@@ -81,6 +81,9 @@ PatientSchema.methods.getDataElements = function getDataElements(params) {
 
 // Returns an array of dataElements that exist on the patient, queried by
 // QDM profile
+// @param {string} profile - the data criteria requested by the execution engine
+// @param {boolean} isNegated - whether dataElements should be returned based on their negation status
+// @returns {DataElement[]}
 PatientSchema.methods.getByProfile = function getByProfile(profile, isNegated = null) {
   // If isNegated == true, only return data elements with a negationRationale that is not null.
   // If isNegated == false, only return data elements with a null negationRationale.
@@ -89,11 +92,13 @@ PatientSchema.methods.getByProfile = function getByProfile(profile, isNegated = 
   return results.map((result) => {
     const getCodeFunction = Object.getPrototypeOf(result).getCode;
     const codeFunction = Object.getPrototypeOf(result).code;
+    const idField = result.id;
     const removedMongooseItems = AllDataElements[profile](result).toObject();
     // toObject() will remove all mongoose functions but also removed the getCode and code functions
     // the execution engine requires the code and getCode functions so we have to add them back
     removedMongooseItems.getCode = getCodeFunction;
     removedMongooseItems.code = codeFunction;
+    removedMongooseItems.id = idField;
     return removedMongooseItems;
   });
 };

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -65,8 +65,8 @@ module QDM
         # Special case for facility locations
         next unless field == 'facilityLocations'
         send(field).each do |facility_location|
-          facility_location['locationPeriod'][:low] = facility_location['locationPeriod'][:low].to_time + seconds
-          facility_location['locationPeriod'][:high] = facility_location['locationPeriod'][:high].to_time + seconds
+          facility_location['locationPeriod'][:low] = (facility_location['locationPeriod'][:low].to_time + seconds).to_datetime
+          facility_location['locationPeriod'][:high] = (facility_location['locationPeriod'][:high].to_time + seconds).to_datetime
         end
       end
     end

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -61,6 +61,13 @@ module QDM
         if (send(field).is_a? Interval) || (send(field).is_a? DataElement)
           send(field + '=', send(field).shift_dates(seconds))
         end
+
+        # Special case for facility locations
+        next unless field == 'facilityLocations'
+        send(field).each do |facility_location|
+          facility_location['locationPeriod'][:low] = facility_location['locationPeriod'][:low].to_time + seconds
+          facility_location['locationPeriod'][:high] = facility_location['locationPeriod'][:high].to_time + seconds
+        end
       end
     end
 

--- a/app/models/qdm/encounter_performed.rb
+++ b/app/models/qdm/encounter_performed.rb
@@ -7,7 +7,7 @@ module QDM
     field :admissionSource, type: QDM::Code
     field :relevantPeriod, type: QDM::Interval
     field :dischargeDisposition, type: QDM::Code
-    field :facilityLocations, type: Array
+    field :facilityLocations, type: Array, default: []
     field :diagnoses, type: Array
     field :principalDiagnosis, type: QDM::Code
     field :negationRationale, type: QDM::Code

--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '0.8.1'
+  spec.version       = '0.8.2'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'Mongo models that correspond to the QDM specification.'

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -208,6 +208,9 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   # Add QDM version
   contents.gsub!(/field :qdmVersion, type: String/, "field :qdmVersion, type: String, default: '#{qdm_version}'")
 
+  # Add default to [] for facilityLocations
+  contents.gsub!(/field :facilityLocations, type: Array/, 'field :facilityLocations, type: Array, default: []')
+
   # Add HQMF oid (if it exists in the given HQMF oid mapping file)
   dc_name = File.basename(file_name, '.*')
   if oids[dc_name].present? && oids[dc_name]['hqmf_oid'].present?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe QDM do
     @patient_de1 = QDM::Patient.new(birthDatetime: bd, givenNames: %w['First1 Middle1'], familyName: 'Family1', bundleId: '1')
     @patient_de1.dataElements << QDM::PatientCharacteristicBirthdate.new(birthDatetime: bd)
     @patient_de1.dataElements << QDM::Diagnosis.new(authorDatetime: DateTime.new(2010, 1, 1, 4, 0, 0), dataElementCodes: [QDM::Code.new('E08.311', 'ICD-10-CM'), QDM::Code.new('362.01', 'ICD-9-CM'), QDM::Code.new('4855003', 'SNOMED-CT')])
-    @patient_de1.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')])
+    @patient_de1.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')], facilityLocations: [QDM::FacilityLocation.new(locationPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)))])
     @patient_de1.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')])
 
     # Another patient with some data elements
@@ -50,7 +50,7 @@ RSpec.describe QDM do
     @patient_de2 = QDM::Patient.new(birthDatetime: bd, givenNames: %w['First2 Middle2'], familyName: 'Family2', bundleId: '1')
     @patient_de2.dataElements << QDM::PatientCharacteristicBirthdate.new(birthDatetime: bd)
     @patient_de2.dataElements << QDM::Diagnosis.new(authorDatetime: DateTime.new(2010, 1, 1, 4, 0, 0), dataElementCodes: [QDM::Code.new('E08.311', 'ICD-10-CM'), QDM::Code.new('362.01', 'ICD-9-CM'), QDM::Code.new('4855003', 'SNOMED-CT')])
-    @patient_de2.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')])
+    @patient_de2.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMED-CT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMED-CT', '17436001'), QDM::Code.new('99241', 'CPT')], facilityLocations: [QDM::FacilityLocation.new(locationPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)))])
     @patient_de2.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')])
   end
 
@@ -97,6 +97,10 @@ RSpec.describe QDM do
     expect(@patient_de1.encounters.first.relevantPeriod.low.utc.to_s).to include('06:00:00')
     expect(@patient_de1.encounters.first.relevantPeriod.high.utc.to_s).to include('07:00:00')
 
+    # EncounterPerformed facilityLocation high and low should be two hours ahead
+    expect(@patient_de1.encounters.first.facilityLocations.first['locationPeriod'][:low].utc.to_s).to include('06:00:00')
+    expect(@patient_de1.encounters.first.facilityLocations.first['locationPeriod'][:high].utc.to_s).to include('07:00:00')
+
     # DiagnosticStudyPerformed authorDatetime should be two hours ahead
     expect(@patient_de1.diagnostic_studies.first.authorDatetime.utc.to_s).to include('06:00:00')
 
@@ -118,6 +122,10 @@ RSpec.describe QDM do
     # EncounterPerformed relevantPeriod high and low should be two hours behind
     expect(@patient_de2.encounters.first.relevantPeriod.low.utc.to_s).to include('02:00:00')
     expect(@patient_de2.encounters.first.relevantPeriod.high.utc.to_s).to include('03:00:00')
+
+    # EncounterPerformed facilityLocation high and low should be two hours behind
+    expect(@patient_de2.encounters.first.facilityLocations.first['locationPeriod'][:low].utc.to_s).to include('02:00:00')
+    expect(@patient_de2.encounters.first.facilityLocations.first['locationPeriod'][:high].utc.to_s).to include('03:00:00')
 
     # DiagnosticStudyPerformed authorDatetime should be two hours behind
     expect(@patient_de2.diagnostic_studies.first.authorDatetime.utc.to_s).to include('02:00:00')

--- a/templates/patient_template.js.erb
+++ b/templates/patient_template.js.erb
@@ -80,6 +80,9 @@ PatientSchema.methods.getDataElements = function getDataElements(params) {
 
 // Returns an array of dataElements that exist on the patient, queried by
 // QDM profile
+// @param {string} profile - the data criteria requested by the execution engine
+// @param {boolean} isNegated - whether dataElements should be returned based on their negation status
+// @returns {DataElement[]}
 PatientSchema.methods.getByProfile = function getByProfile(profile, isNegated = null) {
   // If isNegated == true, only return data elements with a negationRationale that is not null.
   // If isNegated == false, only return data elements with a null negationRationale.
@@ -88,11 +91,13 @@ PatientSchema.methods.getByProfile = function getByProfile(profile, isNegated = 
   return results.map((result) => {
     const getCodeFunction = Object.getPrototypeOf(result).getCode;
     const codeFunction = Object.getPrototypeOf(result).code;
+    const idField = result.id;
     const removedMongooseItems = AllDataElements[profile](result).toObject();
     // toObject() will remove all mongoose functions but also removed the getCode and code functions
     // the execution engine requires the code and getCode functions so we have to add them back
     removedMongooseItems.getCode = getCodeFunction;
     removedMongooseItems.code = codeFunction;
+    removedMongooseItems.id = idField;
     return removedMongooseItems;
   });
 };


### PR DESCRIPTION
This was done so EncounterPerformed elements would be properly date-shifted. Also added tests, and a default to `[]` for `facilityLocation` `Array` types.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] All changes can be reproduced by running the generator script

**Bonnie Reviewer:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
