### PR TITLE
Modified handling of numbers in Any class

### DIFF
--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -53,7 +53,7 @@ function RecursiveCast(any) {
     });
     return casted;
   }
-  if (Number.isInteger(any)) {
+  if (Number.isFinite(any)) {
     return any;
   }
   if (Date.parse(any)) {

--- a/spec/javascript/unit/anySpec.js
+++ b/spec/javascript/unit/anySpec.js
@@ -58,5 +58,15 @@ describe('The Any class', () => {
       expect(returned_obj[2] instanceof Object).toEqual(true);
       expect(returned_obj[2].hi).toEqual('no');
     });
+
+    it('Should handle decimal values the same as integer values by returning the value', () => {
+      const decimalValue = 0.3;
+      const integerValue = 1;
+      const returnedDecimalObject = Any.prototype.cast(decimalValue);
+      const returnedIntegerObject = Any.prototype.cast(integerValue);
+
+      expect(decimalValue).toEqual(returnedDecimalObject);
+      expect(integerValue).toEqual(returnedIntegerObject);
+    });
   });
 });


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

This is fix related to handling decimal values that are passed into the `Any` class. Previously, the decimal value would fail the `Number.isInteger()` check and fall into the `Date.parse()` if statement. A decimal value passed in, would become a Date. Now decimal values will be returned just as integers are returned.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1685
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] ~If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated~
- [x] All changes can be reproduced by running the generator script

**Bonnie Reviewer:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
