### PR TITLE
updated to newer cql-execution, increment version nunmber

### DIFF
--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'Mongo models that correspond to the QDM specification.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "1.3.0",
+    "cql-execution": "1.3.1",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,9 +442,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cql-execution@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.0.tgz#8f02c29477807d080f423e979e1fffac10e21ef5"
+cql-execution@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.1.tgz#79c5fe891202140f6f3d8371fb382765eba06a37"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] ~Internal ticket for this PR:~
- [x] ~Internal ticket links to this PR~
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] All changes can be reproduced by running the generator script

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name:
- [x] ~Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose~
- [x] ~The tests appropriately test the new code, including edge cases~
- [x] ~You have tried to break the code~
- [x] ~You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself~
 