### PR TITLE
Added a high_unbound? method, used it in shift_dates, and added tests

### DIFF
--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -6,7 +6,7 @@ module QDM
     # Low and high are required (at minimum).
     def initialize(low, high, lowClosed = true, highClosed = true)
       @low = low
-      @high = high
+      @high = high.is_a?(DateTime) && (high.year > 9999) ? high.change(year: 9999) : high
       @lowClosed = lowClosed
       @highClosed = highClosed
     end

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -27,7 +27,7 @@ module QDM
       end
       if (@high.is_a? DateTime) || (@high.is_a? Time)
         @high = (@high.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
-        @high = (@high.year > 9999) ? @high.change(year: 9999) : @high
+        @high = @high.year > 9999 ? @high.change(year: 9999) : @high
       end
       self
     end

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -25,15 +25,11 @@ module QDM
       if (@low.is_a? DateTime) || (@low.is_a? Time)
         @low = (@low.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
       end
-      if ((@high.is_a? DateTime) || (@high.is_a? Time)) && !high_unbound?
+      if (@high.is_a? DateTime) || (@high.is_a? Time)
         @high = (@high.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
+        @high = (@high.year > 9999) ? @high.change(year: 9999) : @high
       end
       self
-    end
-
-    def high_unbound?
-      return @high.year >= 9999 if @high.is_a? DateTime
-      false
     end
 
     class << self

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -25,10 +25,15 @@ module QDM
       if (@low.is_a? DateTime) || (@low.is_a? Time)
         @low = (@low.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
       end
-      if (@high.is_a? DateTime) || (@high.is_a? Time)
+      if ((@high.is_a? DateTime) || (@high.is_a? Time)) && !high_unbound?
         @high = (@high.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
       end
       self
+    end
+
+    def high_unbound?
+      return @high.year >= 9999 if @high.is_a? DateTime
+      false
     end
 
     class << self

--- a/spec/cqm/interval_spec.rb
+++ b/spec/cqm/interval_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe QDM::Interval do
 
     interval = QDM::Interval.new(dt_low, dt_high)
 
-    expect(interval.high_unbound?).to be true
-
     interval.shift_dates(shift_seconds)
 
     expect(interval.high).to eq(dt_high)

--- a/spec/cqm/interval_spec.rb
+++ b/spec/cqm/interval_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe QDM::Interval do
+  it 'shouldn\'t shift dates with a high past 9998' do
+    dt_low = DateTime.new(2018, 10, 29, 9, 54, 0)
+    dt_high = DateTime.new(9999, 12, 31, 23, 59, 59)
+
+    # number of seconds to shift (4 years, plus 1 day for the leap year 2022)
+    shift_seconds = 60 * 60 * 24 * (365 * 4 + 1)
+
+    interval = QDM::Interval.new(dt_low, dt_high)
+
+    expect(interval.high_unbound?).to be true
+
+    interval.shift_dates(shift_seconds)
+
+    expect(interval.high).to eq(dt_high)
+    expect(interval.low).to eq(dt_low.next_year(4))
+  end
+end


### PR DESCRIPTION
When an `Interval` has `DateTime`s, values that are "unbound" (e.g., the interval doesn't end, such as an ongoing diagnosis) are represented by a high `DateTime` in year `9999`. This caused issues when we shifted dates into the future (or the past, for that matter) because the `shift_dates` function shifts those `9999`-valued `high` dates into years after `9999`. This PR adds a method to recognize those unbound `high` values, and keeps them from being date-shifted.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] All changes can be reproduced by running the generator script
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name: Robert Clark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
