### PR TITLE
Restrict max date year to 9999

### DIFF
--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -6,7 +6,7 @@ module QDM
     # Low and high are required (at minimum).
     def initialize(low, high, lowClosed = true, highClosed = true)
       @low = low
-      @high = high
+      @high = high.is_a?(DateTime) && (high.year > 9999) ? high.change(year: 9999) : high
       @lowClosed = lowClosed
       @highClosed = highClosed
     end
@@ -27,6 +27,7 @@ module QDM
       end
       if (@high.is_a? DateTime) || (@high.is_a? Time)
         @high = (@high.utc.to_time + seconds.seconds).to_datetime.new_offset(0)
+        @high = @high.year > 9999 ? @high.change(year: 9999) : @high
       end
       self
     end

--- a/spec/cqm/interval_spec.rb
+++ b/spec/cqm/interval_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe QDM::Interval do
+  it 'shouldn\'t shift dates with a high past 9998' do
+    dt_low = DateTime.new(2018, 10, 29, 9, 54, 0)
+    dt_high = DateTime.new(9999, 12, 31, 23, 59, 59)
+
+    # number of seconds to shift (4 years, plus 1 day for the leap year 2022)
+    shift_seconds = 60 * 60 * 24 * (365 * 4 + 1)
+
+    interval = QDM::Interval.new(dt_low, dt_high)
+
+    interval.shift_dates(shift_seconds)
+
+    expect(interval.high).to eq(dt_high)
+    expect(interval.low).to eq(dt_low.next_year(4))
+  end
+end


### PR DESCRIPTION
When the year of the date goes beyond 9999 it causes issues in Cypress. This was sometimes happening when the Cypress performs a date shift to a date which was already close to 9999. The shift would push it to over 10000 which causes problems when handing off to cqm-execution-service.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] All changes can be reproduced by running the generator script
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
