### PR TITLE
Codecov edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ matrix:
         - yarn run lint
         - yarn run test
         - ./bin/validate_dist.sh
-        - istanbul cover ./node_modules/jasmine/bin/jasmine.js
         - codecov

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jasmine": "^2.9.0"
   },
   "scripts": {
-    "test": "istanbul cover jasmine",
+    "test": "istanbul cover jasmine -x 'spec/**/*'",
     "lint": "eslint 'app/assets/javascripts/**/*.js'",
     "dist": "yarn && browserify app/assets/javascripts/index.js > dist/index.js",
     "dist_test": "browserify app/assets/javascripts/index.js > tmp/dist/index.js"

--- a/spec/simplecov_init.rb
+++ b/spec/simplecov_init.rb
@@ -1,0 +1,8 @@
+require 'simplecov'
+require 'codecov'
+
+SimpleCov.start do
+  add_filter 'spec/**/*'
+end
+
+SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/spec/simplecov_init.rb
+++ b/spec/simplecov_init.rb
@@ -2,7 +2,7 @@ require 'simplecov'
 require 'codecov'
 
 SimpleCov.start do
-  add_filter 'spec/**/*'
+  add_filter 'spec/'
 end
 
 SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,8 @@
-require 'simplecov'
-require 'codecov'
+require_relative './simplecov_init'
 require 'bundler/setup'
 require 'cqm/models'
 require 'nokogiri'
 require 'byebug'
-
-SimpleCov.start do
-  add_filter 'spec/**/*'
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 Mongoid.load!('config/mongoid.yml', :test)
 


### PR DESCRIPTION
Codecov was not properly tracking ruby files.  This makes it so that ruby files are included in the codecov report, and that spec files are properly ignored.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist` N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [x] All changes can be reproduced by running the generator script N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A

**Bonnie Reviewer:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
