### PR TITLE
Bonnie v3.1.1 max only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only",
+    "cql-execution": "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "1.3.2",
+    "cql-execution": "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,7 +444,7 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#683f2fea526ac8ad041a368c43dbb326240bed52"
+  resolved "https://github.com/cqframework/cql-execution.git#cad0acc11b6c3def032f21f528bc10d2452ba982"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,9 +442,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cql-execution@1.3.2:
+"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only":
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.2.tgz#3599ef31a0196e8ee679a37e1eee1911d731360b"
+  resolved "https://github.com/cqframework/cql-execution.git#683f2fea526ac8ad041a368c43dbb326240bed52"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,9 +442,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only":
+"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#5624e1e29db220b68edd248e1bdb590f998c7ced"
+  resolved "https://github.com/cqframework/cql-execution.git#1f8976f2ce752925705887331de09caf46c86194"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,7 +444,7 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1-max-only":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#cad0acc11b6c3def032f21f528bc10d2452ba982"
+  resolved "https://github.com/cqframework/cql-execution.git#5624e1e29db220b68edd248e1bdb590f998c7ced"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"


### PR DESCRIPTION
Point to new cql-execution with `maximum DateTime` fix.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1897
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If there were any JavaScript changes, this PR has updated the `dist` directory using `npm run dist`
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] All changes can be reproduced by running the generator script
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself

**Cypress Reviewer:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] You have executed the generator script, and made sure no changes were made that the generator did not reproduce itself
