### PR TITLE
Build cql-execution if needed with 'yarn install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
           - "node_modules"
       script:
         - yarn install
-        - ./bin/build_cql_execution.sh
         - yarn run lint
         - yarn run test
         - ./bin/validate_dist.sh

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jasmine": "^2.9.0"
   },
   "scripts": {
+    "postinstall": "./bin/build_cql_execution.sh",
     "test": "istanbul cover jasmine -x 'spec/**/*'",
     "lint": "eslint 'app/assets/javascripts/**/*.js'",
     "dist": "yarn && browserify app/assets/javascripts/index.js > dist/index.js",


### PR DESCRIPTION
Add something to make previous PR a bit easier to use--build cql-execution if needed when doing yarn install.  Won't build if pointing to a published npm module that already has lib/

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed N/A
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A

** Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

** Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
