### PR TITLE
postinstall -> prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jasmine": "^2.9.0"
   },
   "scripts": {
-    "postinstall": "./bin/build_cql_execution.sh",
+    "prepublish": "./bin/build_cql_execution.sh",
     "test": "istanbul cover jasmine -x 'spec/**/*'",
     "lint": "eslint 'app/assets/javascripts/**/*.js'",
     "dist": "yarn && browserify app/assets/javascripts/index.js > dist/index.js",


### PR DESCRIPTION
Build cql-exectution in a `prepublish` script rather than `postinstall`.  Both will automatically run after `yarn install`, but `postinstall` will be run erroneously when using cqm-models as a dependency apparently, while `prepublish` does not have the same issue.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A

**Bonnie Reviewer:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
