### PR TITLE
A StatementReference has an HQMF identifier.

### DIFF
--- a/app/assets/javascripts/cqm/CQLStatementDependency.js
+++ b/app/assets/javascripts/cqm/CQLStatementDependency.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose/browser');
 const StatementReferenceSchema = new mongoose.Schema({
   library_name: String,
   statement_name: String,
+  hqmf_id: String,
 });
 
 const StatementDependencySchema = new mongoose.Schema({

--- a/app/assets/javascripts/cqm/PopulationSet.js
+++ b/app/assets/javascripts/cqm/PopulationSet.js
@@ -42,6 +42,7 @@ const ObservationSchema = new mongoose.Schema({
   observation_function: StatementReferenceSchema,
   observation_parameter: StatementReferenceSchema,
   aggregation_type: String,
+  hqmf_id: String,
 });
 
 const PopulationSetSchema = new mongoose.Schema({

--- a/app/assets/javascripts/cqm/PopulationSet.js
+++ b/app/assets/javascripts/cqm/PopulationSet.js
@@ -34,6 +34,7 @@ PopulationMapSchema.options.toObject.transform = function transform(doc, ret, op
 const StratificationSchema = new mongoose.Schema({
   title: String,
   stratification_id: String,
+  hqmf_id: String,
   statement: StatementReferenceSchema,
 });
 

--- a/app/models/cqm/cql_statement_dependency.rb
+++ b/app/models/cqm/cql_statement_dependency.rb
@@ -19,5 +19,6 @@ module CQM
 
     field :library_name, type: String
     field :statement_name, type: String
+    field :hqmf_id, type: String
   end
 end

--- a/app/models/cqm/population_set.rb
+++ b/app/models/cqm/population_set.rb
@@ -22,6 +22,7 @@ module CQM
 
     field :title, type: String
     field :stratification_id, type: String
+    field :hqmf_id, type: String
     embeds_one :statement, class_name: 'CQM::StatementReference'
   end
 

--- a/app/models/cqm/population_set.rb
+++ b/app/models/cqm/population_set.rb
@@ -34,6 +34,7 @@ module CQM
     embeds_one :observation_function, class_name: 'CQM::StatementReference'
     embeds_one :observation_parameter, class_name: 'CQM::StatementReference'
     field :aggregation_type, type: String
+    field :hqmf_id, type: String
   end
 
   # Base class for the population maps

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2906,6 +2906,7 @@ const mongoose = require('mongoose/browser');
 const StatementReferenceSchema = new mongoose.Schema({
   library_name: String,
   statement_name: String,
+  hqmf_id: String,
 });
 
 const StatementDependencySchema = new mongoose.Schema({
@@ -3105,6 +3106,7 @@ PopulationMapSchema.options.toObject.transform = function transform(doc, ret, op
 const StratificationSchema = new mongoose.Schema({
   title: String,
   stratification_id: String,
+  hqmf_id: String,
   statement: StatementReferenceSchema,
 });
 
@@ -3113,6 +3115,7 @@ const ObservationSchema = new mongoose.Schema({
   observation_function: StatementReferenceSchema,
   observation_parameter: StatementReferenceSchema,
   aggregation_type: String,
+  hqmf_id: String,
 });
 
 const PopulationSetSchema = new mongoose.Schema({

--- a/dist/index.js
+++ b/dist/index.js
@@ -3109,6 +3109,7 @@ const ObservationSchema = new mongoose.Schema({
   observation_function: StatementReferenceSchema,
   observation_parameter: StatementReferenceSchema,
   aggregation_type: String,
+  hqmf_id: String,
 });
 
 const PopulationSetSchema = new mongoose.Schema({

--- a/dist/index.js
+++ b/dist/index.js
@@ -3101,6 +3101,7 @@ PopulationMapSchema.options.toObject.transform = function transform(doc, ret, op
 const StratificationSchema = new mongoose.Schema({
   title: String,
   stratification_id: String,
+  hqmf_id: String,
   statement: StatementReferenceSchema,
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2901,6 +2901,7 @@ const mongoose = require('mongoose/browser');
 const StatementReferenceSchema = new mongoose.Schema({
   library_name: String,
   statement_name: String,
+  hqmf_id: String,
 });
 
 const StatementDependencySchema = new mongoose.Schema({


### PR DESCRIPTION
Currently the HQMF ids for a population are only stored in the population criteria hash
![currently ids are stored in population_criteria](https://user-images.githubusercontent.com/8173551/53262896-d4405380-36a5-11e9-8251-cc04071034ea.png)
It would make sense to store the HQMF ids with the population sets.
![ids populated in population set](https://user-images.githubusercontent.com/8173551/53262915-e6ba8d00-36a5-11e9-881a-15d792c8af93.png)
This makes it so you won't need to infer the relationship between the two.  cqm-parsers needs to be updated accordingly to populate this field.

Relates to https://github.com/projecttacoma/cqm-parsers/pull/25

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code N/A It is just adding an optional field.

**Cypress Reviewer:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code