### PR TITLE
Fixes for bonnie integration

### DIFF
--- a/app/assets/javascripts/cqm/AllCQMModels.js
+++ b/app/assets/javascripts/cqm/AllCQMModels.js
@@ -16,5 +16,7 @@ module.exports.PopulationSet = require('./PopulationSet.js').PopulationSet;
 module.exports.PopulationSetSchema = require('./PopulationSet.js').PopulationSetSchema;
 module.exports.PopulationMap = require('./PopulationSet.js').PopulationMap;
 module.exports.PopulationMapSchema = require('./PopulationSet.js').PopulationMapSchema;
+module.exports.Stratification = require('./PopulationSet.js').Stratification;
+module.exports.StratificationSchema = require('./PopulationSet.js').StratificationSchema;
 module.exports.Patient = require('./Patient.js').Patient;
 module.exports.PatientSchema = require('./Patient.js').PatientSchema;

--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -81,6 +81,10 @@ const MeasureSchema = new mongoose.Schema(
   }
 );
 
+MeasureSchema.methods.all_stratifications = function all_stratifications() {
+  return this.population_sets.flatMap(ps => ps.stratifications);
+};
+
 module.exports.MeasureSchema = MeasureSchema;
 class Measure extends mongoose.Document {
   constructor(object) {

--- a/app/models/cqm/cql_library.rb
+++ b/app/models/cqm/cql_library.rb
@@ -12,6 +12,11 @@ module CQM
     field :elm_annotations, type: Hash
     field :is_main_library, type: Boolean, default: false
 
+    # Currently this is only relevant for cql libraries that are included in composite measures,
+    # true indicates the library files are in the "top level" folder of the measure package, rather
+    # than coming from a component measure folder.
+    field :is_top_level, type: Boolean, default: true
+
     embeds_many :statement_dependencies, class_name: 'CQM::StatementDependency'
   end
 end

--- a/app/models/cqm/measure.rb
+++ b/app/models/cqm/measure.rb
@@ -10,8 +10,6 @@ module CQM
     validates_inclusion_of :measure_scoring, in: %w[PROPORTION RATIO CONTINUOUS_VARIABLE COHORT]
     validates_inclusion_of :calculation_method, in: %w[PATIENT EPISODE_OF_CARE]
 
-    TYPES = %w[ep eh].freeze
-
     IPP = 'IPP'.freeze
     DENOM = 'DENOM'.freeze
     NUMER = 'NUMER'.freeze
@@ -78,6 +76,10 @@ module CQM
     has_and_belongs_to_many :value_sets, inverse_of: nil
 
     scope :by_measure_id, ->(id) { where(measure_id: id) }
+
+    def all_stratifications
+      population_sets.flat_map(&:stratifications)
+    end
 
     # Returns the hqmf-parser's ruby implementation of an HQMF document.
     # Rebuild from population_criteria, data_criteria, and measure_period JSON

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3033,6 +3033,10 @@ const MeasureSchema = new mongoose.Schema(
   }
 );
 
+MeasureSchema.methods.all_stratifications = function all_stratifications() {
+  return this.population_sets.flatMap(ps => ps.stratifications);
+};
+
 module.exports.MeasureSchema = MeasureSchema;
 class Measure extends mongoose.Document {
   constructor(object) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3028,6 +3028,10 @@ const MeasureSchema = new mongoose.Schema(
   }
 );
 
+MeasureSchema.methods.all_stratifications = function all_stratifications() {
+  return this.population_sets.flatMap(ps => ps.stratifications);
+};
+
 module.exports.MeasureSchema = MeasureSchema;
 class Measure extends mongoose.Document {
   constructor(object) {

--- a/spec/cqm/measure_models_spec.rb
+++ b/spec/cqm/measure_models_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe CQM::Measure do
     measure.save!
   end
 
+  it 'can construct a measure with multiple population_sets and stratifications and execute all_stratifications' do
+    measure = CQM::Measure.new
+    measure.population_sets << CQM::PopulationSet.new(
+      title: 'PS1',
+      stratifications: [CQM::Stratification.new(title: 'PS1 S1'), CQM::Stratification.new(title: 'PS1 S2')]
+    )
+    measure.population_sets << CQM::PopulationSet.new(
+      title: 'PS2',
+      stratifications: [CQM::Stratification.new(title: 'PS2 S1'), CQM::Stratification.new(title: 'PS2 S2')]
+    )
+    expect(measure.all_stratifications.map(&:title)).to eq(['PS1 S1', 'PS1 S2', 'PS2 S1', 'PS2 S2'])
+  end
+
   it 'can construct and save a measure with a package' do
     expect do
       measure = CQM::Measure.new(

--- a/spec/javascript/unit/measure_models_spec.js
+++ b/spec/javascript/unit/measure_models_spec.js
@@ -52,6 +52,19 @@ describe('CQM', () => {
       expect(err).toBeUndefined();
     });
 
+    it('can construct a measure with multiple population_sets and stratifications and execute all_stratifications', () => {
+      measure = new CQM.Measure();
+      measure.population_sets.push(new CQM.PopulationSet({
+        title: 'PS1',
+        stratifications: [new CQM.Stratification({ title: "PS1 S1" }), new CQM.Stratification({ title: "PS1 S2" })]
+      }))
+      measure.population_sets.push(new CQM.PopulationSet({
+        title: 'PS2',
+        stratifications: [new CQM.Stratification({ title: "PS2 S1" }), new CQM.Stratification({ title: "PS2 S2" })]
+      }))
+      expect(measure.all_stratifications().map(s => s.title)).toEqual(["PS1 S1", "PS1 S2", "PS2 S1", "PS2 S2"])
+    })
+
     it('can construct and save a measure with a package', () => {
       measure = new CQM.Measure({
         title: 'Measure with package',
@@ -88,9 +101,10 @@ describe('CQM', () => {
         elm_annotations: { test: { elm: 'data' } },
         is_main_library: true,
         statement_dependencies: [
-          new CQM.StatementDependency({ statement_name: 'test1', statement_references: [
-            new CQM.StatementReference({ library_name: 'TestMainLibrary', statement_name: 'test2' }),
-            new CQM.StatementReference({ library_name: 'TestHelperLibrary', statement_name: 'test34' })
+          new CQM.StatementDependency({
+            statement_name: 'test1', statement_references: [
+              new CQM.StatementReference({ library_name: 'TestMainLibrary', statement_name: 'test2' }),
+              new CQM.StatementReference({ library_name: 'TestHelperLibrary', statement_name: 'test34' })
             ]
           }),
           new CQM.StatementDependency({ statement_name: 'test2', statement_references: [] })
@@ -103,8 +117,9 @@ describe('CQM', () => {
         elm: { test: { elm: 'data' } },
         elm_annotations: { test: { elm: 'data' } },
         statement_dependencies: [
-          new CQM.StatementDependency({ statement_name: 'test34', statement_references: [
-            new CQM.StatementReference({ library_name: 'TestHelperLibrary', statement_name: 'test35' })
+          new CQM.StatementDependency({
+            statement_name: 'test34', statement_references: [
+              new CQM.StatementReference({ library_name: 'TestHelperLibrary', statement_name: 'test35' })
             ]
           }),
           new CQM.StatementDependency({ statement_name: 'test35', statement_references: [] })


### PR DESCRIPTION
This PR adds the "is_top_level" field, and a convenience method for accessing all the stratifications.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1835
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter (will be tracked with https://jira.mitre.org/browse/BONNIE-1926)

**Bonnie Reviewer:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
