### PR TITLE
No coded uncertainty

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1",
+    "cql-execution": "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty",
+    "cql-execution": "https://github.com/cqframework/cql-execution.git#bonnie-patch",
     "mongoose": "^5.0.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,9 +442,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1":
+"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#1f8976f2ce752925705887331de09caf46c86194"
+  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,9 +442,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
+"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-patch":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#628b4565ce10ae373ecc5cbc6e073e49f5c32bf7"
+  resolved "https://github.com/cqframework/cql-execution.git#cc3cfe97e06d9804106149116e2bd599ad932611"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,7 +444,7 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
+  resolved "https://github.com/cqframework/cql-execution.git#628b4565ce10ae373ecc5cbc6e073e49f5c32bf7"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"


### PR DESCRIPTION
Cql-execution update for bonnie patch release
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1938
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated NA
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter NA

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
