### PR TITLE
Skip the setting of a Data Elements codeListId in 'Generate Patients'

### DIFF
--- a/lib/generate_patients.rb
+++ b/lib/generate_patients.rb
@@ -75,6 +75,8 @@ module QDM
       # There are certain fields that we want to populate manually
       if field_name == 'description'
         # Skip the setting of patient description for now
+      elsif field_name == 'codeListId'
+        # Skip the setting code list id. It is not used in a patient's data_element, only in the measure's
       elsif field_name == 'negationRationale'
         data_element[field_name] = QDM::BaseTypeGeneration.generate_code_field if negate_data_element
       elsif field_name == 'components'


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Bonnie Reviewer:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
