### PR TITLE
Initialize SDC as concrete types on measure

### DIFF
--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3117,6 +3117,7 @@ const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
 const Quantity = require('../basetypes/Quantity');
 const DataElementSchema = require('../basetypes/DataElement').DataElementSchema();
+const AllDataElements = require('../AllDataElements');
 const { CQLLibrarySchema } = require('./CQLLibrary');
 const { PopulationSetSchema } = require('./PopulationSet');
 
@@ -3176,7 +3177,7 @@ const MeasureSchema = new mongoose.Schema(
 
     // HQMF/Tacoma-specific Measure-logic related data
     population_criteria: Mixed,
-    source_data_criteria: [DataElementSchema],
+    source_data_criteria: [],
     measure_period: Interval,
     measure_attributes: [],
 
@@ -3195,6 +3196,18 @@ const MeasureSchema = new mongoose.Schema(
   }
 );
 
+// After initialization of a Measure model, initialize every individual data element
+// to its respective Mongoose Model
+MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
+  let typeStripped;
+  const sourceDataCriteriaInit = [];
+  this.source_data_criteria.forEach((element) => {
+    typeStripped = element._type.replace(/QDM::/, '');
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
+  });
+  this.set('source_data_criteria', sourceDataCriteriaInit);
+};
+
 MeasureSchema.methods.all_stratifications = function all_stratifications() {
   return this.population_sets.flatMap(ps => ps.stratifications);
 };
@@ -3203,11 +3216,12 @@ module.exports.MeasureSchema = MeasureSchema;
 class Measure extends mongoose.Document {
   constructor(object) {
     super(object, MeasureSchema);
+    this.initializeDataElements();
   }
 }
 module.exports.Measure = Measure;
 
-},{"../basetypes/Code":63,"../basetypes/DataElement":64,"../basetypes/Interval":66,"../basetypes/Quantity":67,"./CQLLibrary":69,"./PopulationSet":75,"mongoose/browser":255}],73:[function(require,module,exports){
+},{"../AllDataElements":2,"../basetypes/Code":63,"../basetypes/DataElement":64,"../basetypes/Interval":66,"../basetypes/Quantity":67,"./CQLLibrary":69,"./PopulationSet":75,"mongoose/browser":255}],73:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 // using mBuffer to not conflict with system Buffer

--- a/spec/javascript/unit/measure_models_spec.js
+++ b/spec/javascript/unit/measure_models_spec.js
@@ -1,4 +1,5 @@
 const CQM = require('./../../../app/assets/javascripts/cqm/AllCQMModels')
+const AdverseEvent = require('./../../../app/assets/javascripts/AdverseEvent.js').AdverseEvent;
 const Buffer = require('mongoose/browser').Schema.Types.Buffer;
 
 describe('CQM', () => {
@@ -11,11 +12,17 @@ describe('CQM', () => {
         hqmf_id: '40280582-5C5B-CF39-015C-A69BB10D15D8',
         hqmf_set_id: '6DB434E0-8FC7-42C8-B3B2-A7653E2A0D16',
         hqmf_version_number: '0.1.023',
+        source_data_criteria: [
+          new AdverseEvent(),
+          new AdverseEvent(),
+          new AdverseEvent()
+        ],
         cms_id: 'CMS9999v3',
         main_cql_library: 'TestMainLibrary'
       });
       err = measure.validateSync();
       expect(err).toBeUndefined();
+      expect(measure.source_data_criteria.length).toEqual(3)
     });
 
     it('can construct and save a measure with two population_sets', () => {


### PR DESCRIPTION
Initialize source data criteria as concrete types so that mongoose functionality is preserved on individual data elements on for front end use. This mirrors what we do for QDM Patient dataElements.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1841
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases Tested through measure intitialization
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated NA
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter NA fixture fields do not change

**Bonnie Reviewer:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
