### PR TITLE
Is top level js

### DIFF
--- a/app/assets/javascripts/cqm/CQLLibrary.js
+++ b/app/assets/javascripts/cqm/CQLLibrary.js
@@ -14,6 +14,7 @@ const CQLLibrarySchema = new mongoose.Schema(
     elm: Mixed,
     elm_annotations: Mixed,
     is_main_library: { type: Boolean, default: false },
+    is_top_level: { type: Boolean, default: true },
     statement_dependencies: [StatementDependencySchema],
   },
   // Options

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3050,6 +3050,7 @@ const CQLLibrarySchema = new mongoose.Schema(
     elm: Mixed,
     elm_annotations: Mixed,
     is_main_library: { type: Boolean, default: false },
+    is_top_level: { type: Boolean, default: true },
     statement_dependencies: [StatementDependencySchema],
   },
   // Options

--- a/dist/index.js
+++ b/dist/index.js
@@ -3045,6 +3045,7 @@ const CQLLibrarySchema = new mongoose.Schema(
     elm: Mixed,
     elm_annotations: Mixed,
     is_main_library: { type: Boolean, default: false },
+    is_top_level: { type: Boolean, default: true },
     statement_dependencies: [StatementDependencySchema],
   },
   // Options

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -12,6 +12,7 @@ const CareGoal = require('./../../../app/assets/javascripts/CareGoal.js').CareGo
 const Concept = require('./../../../app/assets/javascripts/cqm/Concept.js').Concept;
 const Component = require('./../../../app/assets/javascripts/attributes/Component.js').Component;
 const CommunicationPerformed = require('./../../../app/assets/javascripts/CommunicationPerformed.js').CommunicationPerformed;
+const CQLLibrary = require('./../../../app/assets/javascripts/cqm/CQLLibrary.js').CQLLibrary;
 const DateTime = require('./../../../app/assets/javascripts/basetypes/DateTime.js');
 const Diagnosis = require('./../../../app/assets/javascripts/Diagnosis.js').Diagnosis;
 const DeviceApplied = require('./../../../app/assets/javascripts/DeviceApplied.js').DeviceApplied;
@@ -399,5 +400,17 @@ describe('DateTime', () => {
   });
   it('throws if invalid DateTime passed to cast', () => {
     expect(() => {DateTime.cast('some invalid DateTime arg')}).toThrow();
+  });
+});
+
+describe('CQLLibrary', () => {
+  it('defaults to be top level', () => {
+    library = new CQLLibrary();
+    expect(library.is_top_level).toBe(true);
+  });
+
+  it('can create a non top level CQLLibrary', () => {
+    library = new CQLLibrary({ is_top_level: false });
+    expect(library.is_top_level).toBe(false);
   });
 });


### PR DESCRIPTION
The `is_top_level` field that was added to the CQLLibrary model in ruby was missing from the Mongoose version.  This PR adds it and a test for it.


Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1979
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A the javascript code wont affect fixtures (which is why this wasn't noticed originally, probably)

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
