### PR TITLE
Put measure_ids on CQM Patient instead of QDMPatient.extendedData

### DIFF
--- a/app/assets/javascripts/cqm/Patient.js
+++ b/app/assets/javascripts/cqm/Patient.js
@@ -23,6 +23,7 @@ const PatientSchema = new Schema({
   notes: String,
   qdmPatient: QDMPatientSchema,
   providers: [ProviderSchema],
+  measure_ids: [String],
 
 }, { id: false });
 

--- a/app/models/cqm/measure.rb
+++ b/app/models/cqm/measure.rb
@@ -66,15 +66,12 @@ module CQM
     # Relations to other model classes
     # Note: bundle is removed, Cypress may create their own bundle object and inject the relationship
     has_one :package, class_name: 'CQM::MeasurePackage', inverse_of: :measure, dependent: :destroy # Bonnie-specific
-    has_and_belongs_to_many :patients, class_name: 'CQM::Patient'
 
     # Store this references as an Array on the Measure object,
     # but don't care about the inverse relationship (e.g. we never really care
     # about getting all the measures from a ValueSet object,
     # hence the 'inverse_of: nil')
     has_and_belongs_to_many :value_sets, inverse_of: nil
-
-    scope :by_measure_id, ->(id) { where(measure_id: id) }
 
     def all_stratifications
       population_sets.flat_map(&:stratifications)

--- a/app/models/cqm/patient.rb
+++ b/app/models/cqm/patient.rb
@@ -7,6 +7,8 @@ module CQM
     field :bundleId, type: String
     field :expectedValues, type: Array
     field :notes, type: String
+    field :measure_ids, type: Array
+
     has_and_belongs_to_many :providers, class_name: 'CQM::Provider'
     embeds_one :qdmPatient, class_name: 'QDM::Patient', autobuild: true
 

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3280,6 +3280,7 @@ const PatientSchema = new Schema({
   notes: String,
   qdmPatient: QDMPatientSchema,
   providers: [ProviderSchema],
+  measure_ids: [String],
 
 }, { id: false });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3275,6 +3275,7 @@ const PatientSchema = new Schema({
   notes: String,
   qdmPatient: QDMPatientSchema,
   providers: [ProviderSchema],
+  measure_ids: [String],
 
 }, { id: false });
 

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -82,7 +82,19 @@ describe('QDMPatient', () => {
     });
     err = qdmPatient.validateSync();
     expect(err).toBeUndefined();
-    expect(qdmPatient.id()).toBeDefined();
+  });
+
+  it('can construct a patient with extendedData', () => {
+    qdmPatient = new QDMPatient({
+      birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
+      qdmVersion: '0.0',
+      extendedData: {
+        measure_ids: ['ID123']
+      }
+    });
+    err = qdmPatient.validateSync();
+    expect(err).toBeUndefined();
+    expect(qdmPatient.extendedData['measure_ids']).toEqual(['ID123']);
   });
 
   describe('InitializeDataElements', () => {
@@ -350,6 +362,26 @@ describe('CQMPatient', () => {
     expect(err).toBeUndefined();
     expect(patient.qdmPatient).toBeDefined();
   });
+  it('can contain a qdm patient that has extendedData', () => {
+    qdmData = new QDMPatient({
+      birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
+      qdmVersion: '0.0',
+      extendedData: {
+        measure_ids: ['ID123']
+      }
+    });
+    patient = new Patient({
+      givenNames: ['name1', 'name2'],
+      familyName: 'foo',
+      bundleId: '012210',
+      expectedValues: [],
+      notes: 'Random note for testing',
+      qdmPatient: qdmData,
+    });
+    err = patient.validateSync();
+    expect(err).toBeUndefined();
+    expect(patient.qdmPatient.extendedData.measure_ids).toEqual(['ID123']);
+  });
 });
 
 describe('Concept', () => {
@@ -414,3 +446,4 @@ describe('CQLLibrary', () => {
     expect(library.is_top_level).toBe(false);
   });
 });
+

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -362,12 +362,13 @@ describe('CQMPatient', () => {
     expect(err).toBeUndefined();
     expect(patient.qdmPatient).toBeDefined();
   });
+
   it('can contain a qdm patient that has extendedData', () => {
     qdmData = new QDMPatient({
       birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
       qdmVersion: '0.0',
       extendedData: {
-        measure_ids: ['ID123']
+        description: 'A Description'
       }
     });
     patient = new Patient({
@@ -377,10 +378,12 @@ describe('CQMPatient', () => {
       expectedValues: [],
       notes: 'Random note for testing',
       qdmPatient: qdmData,
+      measure_ids: ['ID123']
     });
     err = patient.validateSync();
     expect(err).toBeUndefined();
-    expect(patient.qdmPatient.extendedData.measure_ids).toEqual(['ID123']);
+    expect(patient.qdmPatient.extendedData.description).toEqual('A Description');
+    expect(patient.measure_ids[0]).toEqual('ID123');
   });
 });
 


### PR DESCRIPTION
This moves the `measure_ids` array, which loosely associates a patient with measures in Bonnie, as a top level field on CQM Patient.  Previously, it was in CQM Patient.QDMPatient.extendedData.measure_ids.  Bonnie is hooked up to look for measure_ids at the top level.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1992
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter PR: https://github.com/projecttacoma/cqm-execution/pull/42

**Bonnie Reviewer:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
