### PR TITLE
Remove '_type' from Patient attributes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,13 @@
           "_id", "_type", "_doc"
         ]
       }
-    ]
+    ],
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+        }
+      ]
   },
   "env": {
     "jasmine": true,

--- a/app/assets/javascripts/AdverseEvent.js
+++ b/app/assets/javascripts/AdverseEvent.js
@@ -26,7 +26,7 @@ const AdverseEventSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.120' },
   qdmCategory: { type: String, default: 'adverse_event' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AdverseEvent' },
+  _type: { type: String, default: 'QDM::AdverseEvent' },
 
 });
 

--- a/app/assets/javascripts/AdverseEvent.js
+++ b/app/assets/javascripts/AdverseEvent.js
@@ -34,6 +34,7 @@ module.exports.AdverseEventSchema = AdverseEventSchema;
 class AdverseEvent extends mongoose.Document {
   constructor(object) {
     super(object, AdverseEventSchema);
+    this._type = 'QDM::AdverseEvent';
   }
 }
 module.exports.AdverseEvent = AdverseEvent;

--- a/app/assets/javascripts/AllergyIntolerance.js
+++ b/app/assets/javascripts/AllergyIntolerance.js
@@ -34,6 +34,7 @@ module.exports.AllergyIntoleranceSchema = AllergyIntoleranceSchema;
 class AllergyIntolerance extends mongoose.Document {
   constructor(object) {
     super(object, AllergyIntoleranceSchema);
+    this._type = 'QDM::AllergyIntolerance';
   }
 }
 module.exports.AllergyIntolerance = AllergyIntolerance;

--- a/app/assets/javascripts/AllergyIntolerance.js
+++ b/app/assets/javascripts/AllergyIntolerance.js
@@ -26,7 +26,7 @@ const AllergyIntoleranceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'allergy' },
   qdmStatus: { type: String, default: 'intolerance' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AllergyIntolerance' },
+  _type: { type: String, default: 'QDM::AllergyIntolerance' },
 
 });
 

--- a/app/assets/javascripts/AssessmentOrder.js
+++ b/app/assets/javascripts/AssessmentOrder.js
@@ -33,6 +33,7 @@ module.exports.AssessmentOrderSchema = AssessmentOrderSchema;
 class AssessmentOrder extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentOrderSchema);
+    this._type = 'QDM::AssessmentOrder';
   }
 }
 module.exports.AssessmentOrder = AssessmentOrder;

--- a/app/assets/javascripts/AssessmentOrder.js
+++ b/app/assets/javascripts/AssessmentOrder.js
@@ -25,7 +25,7 @@ const AssessmentOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentOrder' },
+  _type: { type: String, default: 'QDM::AssessmentOrder' },
 
 });
 

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -29,7 +29,7 @@ const AssessmentPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentPerformed' },
+  _type: { type: String, default: 'QDM::AssessmentPerformed' },
 
 });
 

--- a/app/assets/javascripts/AssessmentPerformed.js
+++ b/app/assets/javascripts/AssessmentPerformed.js
@@ -37,6 +37,7 @@ module.exports.AssessmentPerformedSchema = AssessmentPerformedSchema;
 class AssessmentPerformed extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentPerformedSchema);
+    this._type = 'QDM::AssessmentPerformed';
   }
 }
 module.exports.AssessmentPerformed = AssessmentPerformed;

--- a/app/assets/javascripts/AssessmentRecommended.js
+++ b/app/assets/javascripts/AssessmentRecommended.js
@@ -25,7 +25,7 @@ const AssessmentRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentRecommended' },
+  _type: { type: String, default: 'QDM::AssessmentRecommended' },
 
 });
 

--- a/app/assets/javascripts/AssessmentRecommended.js
+++ b/app/assets/javascripts/AssessmentRecommended.js
@@ -33,6 +33,7 @@ module.exports.AssessmentRecommendedSchema = AssessmentRecommendedSchema;
 class AssessmentRecommended extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentRecommendedSchema);
+    this._type = 'QDM::AssessmentRecommended';
   }
 }
 module.exports.AssessmentRecommended = AssessmentRecommended;

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -32,6 +32,7 @@ module.exports.CareGoalSchema = CareGoalSchema;
 class CareGoal extends mongoose.Document {
   constructor(object) {
     super(object, CareGoalSchema);
+    this._type = 'QDM::CareGoal';
   }
 }
 module.exports.CareGoal = CareGoal;

--- a/app/assets/javascripts/CareGoal.js
+++ b/app/assets/javascripts/CareGoal.js
@@ -24,7 +24,7 @@ const CareGoalSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.7' },
   qdmCategory: { type: String, default: 'care_goal' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CareGoal' },
+  _type: { type: String, default: 'QDM::CareGoal' },
 
 });
 

--- a/app/assets/javascripts/CommunicationPerformed.js
+++ b/app/assets/javascripts/CommunicationPerformed.js
@@ -38,6 +38,7 @@ module.exports.CommunicationPerformedSchema = CommunicationPerformedSchema;
 class CommunicationPerformed extends mongoose.Document {
   constructor(object) {
     super(object, CommunicationPerformedSchema);
+    this._type = 'QDM::CommunicationPerformed';
   }
 }
 module.exports.CommunicationPerformed = CommunicationPerformed;

--- a/app/assets/javascripts/CommunicationPerformed.js
+++ b/app/assets/javascripts/CommunicationPerformed.js
@@ -30,7 +30,7 @@ const CommunicationPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'communication' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CommunicationPerformed' },
+  _type: { type: String, default: 'QDM::CommunicationPerformed' },
 
 });
 

--- a/app/assets/javascripts/DeviceApplied.js
+++ b/app/assets/javascripts/DeviceApplied.js
@@ -35,6 +35,7 @@ module.exports.DeviceAppliedSchema = DeviceAppliedSchema;
 class DeviceApplied extends mongoose.Document {
   constructor(object) {
     super(object, DeviceAppliedSchema);
+    this._type = 'QDM::DeviceApplied';
   }
 }
 module.exports.DeviceApplied = DeviceApplied;

--- a/app/assets/javascripts/DeviceApplied.js
+++ b/app/assets/javascripts/DeviceApplied.js
@@ -27,7 +27,7 @@ const DeviceAppliedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'applied' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceApplied' },
+  _type: { type: String, default: 'QDM::DeviceApplied' },
 
 });
 

--- a/app/assets/javascripts/DeviceOrder.js
+++ b/app/assets/javascripts/DeviceOrder.js
@@ -25,7 +25,7 @@ const DeviceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceOrder' },
+  _type: { type: String, default: 'QDM::DeviceOrder' },
 
 });
 

--- a/app/assets/javascripts/DeviceOrder.js
+++ b/app/assets/javascripts/DeviceOrder.js
@@ -33,6 +33,7 @@ module.exports.DeviceOrderSchema = DeviceOrderSchema;
 class DeviceOrder extends mongoose.Document {
   constructor(object) {
     super(object, DeviceOrderSchema);
+    this._type = 'QDM::DeviceOrder';
   }
 }
 module.exports.DeviceOrder = DeviceOrder;

--- a/app/assets/javascripts/DeviceRecommended.js
+++ b/app/assets/javascripts/DeviceRecommended.js
@@ -33,6 +33,7 @@ module.exports.DeviceRecommendedSchema = DeviceRecommendedSchema;
 class DeviceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DeviceRecommendedSchema);
+    this._type = 'QDM::DeviceRecommended';
   }
 }
 module.exports.DeviceRecommended = DeviceRecommended;

--- a/app/assets/javascripts/DeviceRecommended.js
+++ b/app/assets/javascripts/DeviceRecommended.js
@@ -25,7 +25,7 @@ const DeviceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceRecommended' },
+  _type: { type: String, default: 'QDM::DeviceRecommended' },
 
 });
 

--- a/app/assets/javascripts/Diagnosis.js
+++ b/app/assets/javascripts/Diagnosis.js
@@ -34,6 +34,7 @@ module.exports.DiagnosisSchema = DiagnosisSchema;
 class Diagnosis extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosisSchema);
+    this._type = 'QDM::Diagnosis';
   }
 }
 module.exports.Diagnosis = Diagnosis;

--- a/app/assets/javascripts/Diagnosis.js
+++ b/app/assets/javascripts/Diagnosis.js
@@ -26,7 +26,7 @@ const DiagnosisSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   qdmCategory: { type: String, default: 'condition' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Diagnosis' },
+  _type: { type: String, default: 'QDM::Diagnosis' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyOrder.js
+++ b/app/assets/javascripts/DiagnosticStudyOrder.js
@@ -33,6 +33,7 @@ module.exports.DiagnosticStudyOrderSchema = DiagnosticStudyOrderSchema;
 class DiagnosticStudyOrder extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyOrderSchema);
+    this._type = 'QDM::DiagnosticStudyOrder';
   }
 }
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;

--- a/app/assets/javascripts/DiagnosticStudyOrder.js
+++ b/app/assets/javascripts/DiagnosticStudyOrder.js
@@ -25,7 +25,7 @@ const DiagnosticStudyOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyOrder' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyOrder' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -40,6 +40,7 @@ module.exports.DiagnosticStudyPerformedSchema = DiagnosticStudyPerformedSchema;
 class DiagnosticStudyPerformed extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyPerformedSchema);
+    this._type = 'QDM::DiagnosticStudyPerformed';
   }
 }
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;

--- a/app/assets/javascripts/DiagnosticStudyPerformed.js
+++ b/app/assets/javascripts/DiagnosticStudyPerformed.js
@@ -32,7 +32,7 @@ const DiagnosticStudyPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyPerformed' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyPerformed' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyRecommended.js
+++ b/app/assets/javascripts/DiagnosticStudyRecommended.js
@@ -25,7 +25,7 @@ const DiagnosticStudyRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyRecommended' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyRecommended' },
 
 });
 

--- a/app/assets/javascripts/DiagnosticStudyRecommended.js
+++ b/app/assets/javascripts/DiagnosticStudyRecommended.js
@@ -33,6 +33,7 @@ module.exports.DiagnosticStudyRecommendedSchema = DiagnosticStudyRecommendedSche
 class DiagnosticStudyRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyRecommendedSchema);
+    this._type = 'QDM::DiagnosticStudyRecommended';
   }
 }
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;

--- a/app/assets/javascripts/EncounterOrder.js
+++ b/app/assets/javascripts/EncounterOrder.js
@@ -26,7 +26,7 @@ const EncounterOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterOrder' },
+  _type: { type: String, default: 'QDM::EncounterOrder' },
 
 });
 

--- a/app/assets/javascripts/EncounterOrder.js
+++ b/app/assets/javascripts/EncounterOrder.js
@@ -34,6 +34,7 @@ module.exports.EncounterOrderSchema = EncounterOrderSchema;
 class EncounterOrder extends mongoose.Document {
   constructor(object) {
     super(object, EncounterOrderSchema);
+    this._type = 'QDM::EncounterOrder';
   }
 }
 module.exports.EncounterOrder = EncounterOrder;

--- a/app/assets/javascripts/EncounterPerformed.js
+++ b/app/assets/javascripts/EncounterPerformed.js
@@ -31,7 +31,7 @@ const EncounterPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterPerformed' },
+  _type: { type: String, default: 'QDM::EncounterPerformed' },
 
 });
 

--- a/app/assets/javascripts/EncounterPerformed.js
+++ b/app/assets/javascripts/EncounterPerformed.js
@@ -39,6 +39,7 @@ module.exports.EncounterPerformedSchema = EncounterPerformedSchema;
 class EncounterPerformed extends mongoose.Document {
   constructor(object) {
     super(object, EncounterPerformedSchema);
+    this._type = 'QDM::EncounterPerformed';
   }
 }
 module.exports.EncounterPerformed = EncounterPerformed;

--- a/app/assets/javascripts/EncounterRecommended.js
+++ b/app/assets/javascripts/EncounterRecommended.js
@@ -34,6 +34,7 @@ module.exports.EncounterRecommendedSchema = EncounterRecommendedSchema;
 class EncounterRecommended extends mongoose.Document {
   constructor(object) {
     super(object, EncounterRecommendedSchema);
+    this._type = 'QDM::EncounterRecommended';
   }
 }
 module.exports.EncounterRecommended = EncounterRecommended;

--- a/app/assets/javascripts/EncounterRecommended.js
+++ b/app/assets/javascripts/EncounterRecommended.js
@@ -26,7 +26,7 @@ const EncounterRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterRecommended' },
+  _type: { type: String, default: 'QDM::EncounterRecommended' },
 
 });
 

--- a/app/assets/javascripts/FamilyHistory.js
+++ b/app/assets/javascripts/FamilyHistory.js
@@ -24,7 +24,7 @@ const FamilyHistorySchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   qdmCategory: { type: String, default: 'family_history' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FamilyHistory' },
+  _type: { type: String, default: 'QDM::FamilyHistory' },
 
 });
 

--- a/app/assets/javascripts/FamilyHistory.js
+++ b/app/assets/javascripts/FamilyHistory.js
@@ -32,6 +32,7 @@ module.exports.FamilyHistorySchema = FamilyHistorySchema;
 class FamilyHistory extends mongoose.Document {
   constructor(object) {
     super(object, FamilyHistorySchema);
+    this._type = 'QDM::FamilyHistory';
   }
 }
 module.exports.FamilyHistory = FamilyHistory;

--- a/app/assets/javascripts/Id.js
+++ b/app/assets/javascripts/Id.js
@@ -9,7 +9,6 @@ const IdSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Id' },
 
 }, { _id: false, id: false });
 

--- a/app/assets/javascripts/ImmunizationAdministered.js
+++ b/app/assets/javascripts/ImmunizationAdministered.js
@@ -28,7 +28,7 @@ const ImmunizationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationAdministered' },
+  _type: { type: String, default: 'QDM::ImmunizationAdministered' },
 
 });
 

--- a/app/assets/javascripts/ImmunizationAdministered.js
+++ b/app/assets/javascripts/ImmunizationAdministered.js
@@ -36,6 +36,7 @@ module.exports.ImmunizationAdministeredSchema = ImmunizationAdministeredSchema;
 class ImmunizationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationAdministeredSchema);
+    this._type = 'QDM::ImmunizationAdministered';
   }
 }
 module.exports.ImmunizationAdministered = ImmunizationAdministered;

--- a/app/assets/javascripts/ImmunizationOrder.js
+++ b/app/assets/javascripts/ImmunizationOrder.js
@@ -37,6 +37,7 @@ module.exports.ImmunizationOrderSchema = ImmunizationOrderSchema;
 class ImmunizationOrder extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationOrderSchema);
+    this._type = 'QDM::ImmunizationOrder';
   }
 }
 module.exports.ImmunizationOrder = ImmunizationOrder;

--- a/app/assets/javascripts/ImmunizationOrder.js
+++ b/app/assets/javascripts/ImmunizationOrder.js
@@ -29,7 +29,7 @@ const ImmunizationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationOrder' },
+  _type: { type: String, default: 'QDM::ImmunizationOrder' },
 
 });
 

--- a/app/assets/javascripts/InterventionOrder.js
+++ b/app/assets/javascripts/InterventionOrder.js
@@ -25,7 +25,7 @@ const InterventionOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionOrder' },
+  _type: { type: String, default: 'QDM::InterventionOrder' },
 
 });
 

--- a/app/assets/javascripts/InterventionOrder.js
+++ b/app/assets/javascripts/InterventionOrder.js
@@ -33,6 +33,7 @@ module.exports.InterventionOrderSchema = InterventionOrderSchema;
 class InterventionOrder extends mongoose.Document {
   constructor(object) {
     super(object, InterventionOrderSchema);
+    this._type = 'QDM::InterventionOrder';
   }
 }
 module.exports.InterventionOrder = InterventionOrder;

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -36,6 +36,7 @@ module.exports.InterventionPerformedSchema = InterventionPerformedSchema;
 class InterventionPerformed extends mongoose.Document {
   constructor(object) {
     super(object, InterventionPerformedSchema);
+    this._type = 'QDM::InterventionPerformed';
   }
 }
 module.exports.InterventionPerformed = InterventionPerformed;

--- a/app/assets/javascripts/InterventionPerformed.js
+++ b/app/assets/javascripts/InterventionPerformed.js
@@ -28,7 +28,7 @@ const InterventionPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionPerformed' },
+  _type: { type: String, default: 'QDM::InterventionPerformed' },
 
 });
 

--- a/app/assets/javascripts/InterventionRecommended.js
+++ b/app/assets/javascripts/InterventionRecommended.js
@@ -25,7 +25,7 @@ const InterventionRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionRecommended' },
+  _type: { type: String, default: 'QDM::InterventionRecommended' },
 
 });
 

--- a/app/assets/javascripts/InterventionRecommended.js
+++ b/app/assets/javascripts/InterventionRecommended.js
@@ -33,6 +33,7 @@ module.exports.InterventionRecommendedSchema = InterventionRecommendedSchema;
 class InterventionRecommended extends mongoose.Document {
   constructor(object) {
     super(object, InterventionRecommendedSchema);
+    this._type = 'QDM::InterventionRecommended';
   }
 }
 module.exports.InterventionRecommended = InterventionRecommended;

--- a/app/assets/javascripts/LaboratoryTestOrder.js
+++ b/app/assets/javascripts/LaboratoryTestOrder.js
@@ -25,7 +25,7 @@ const LaboratoryTestOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestOrder' },
+  _type: { type: String, default: 'QDM::LaboratoryTestOrder' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestOrder.js
+++ b/app/assets/javascripts/LaboratoryTestOrder.js
@@ -33,6 +33,7 @@ module.exports.LaboratoryTestOrderSchema = LaboratoryTestOrderSchema;
 class LaboratoryTestOrder extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestOrderSchema);
+    this._type = 'QDM::LaboratoryTestOrder';
   }
 }
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -40,6 +40,7 @@ module.exports.LaboratoryTestPerformedSchema = LaboratoryTestPerformedSchema;
 class LaboratoryTestPerformed extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestPerformedSchema);
+    this._type = 'QDM::LaboratoryTestPerformed';
   }
 }
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;

--- a/app/assets/javascripts/LaboratoryTestPerformed.js
+++ b/app/assets/javascripts/LaboratoryTestPerformed.js
@@ -32,7 +32,7 @@ const LaboratoryTestPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestPerformed' },
+  _type: { type: String, default: 'QDM::LaboratoryTestPerformed' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestRecommended.js
+++ b/app/assets/javascripts/LaboratoryTestRecommended.js
@@ -25,7 +25,7 @@ const LaboratoryTestRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestRecommended' },
+  _type: { type: String, default: 'QDM::LaboratoryTestRecommended' },
 
 });
 

--- a/app/assets/javascripts/LaboratoryTestRecommended.js
+++ b/app/assets/javascripts/LaboratoryTestRecommended.js
@@ -33,6 +33,7 @@ module.exports.LaboratoryTestRecommendedSchema = LaboratoryTestRecommendedSchema
 class LaboratoryTestRecommended extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestRecommendedSchema);
+    this._type = 'QDM::LaboratoryTestRecommended';
   }
 }
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;

--- a/app/assets/javascripts/MedicationActive.js
+++ b/app/assets/javascripts/MedicationActive.js
@@ -34,6 +34,7 @@ module.exports.MedicationActiveSchema = MedicationActiveSchema;
 class MedicationActive extends mongoose.Document {
   constructor(object) {
     super(object, MedicationActiveSchema);
+    this._type = 'QDM::MedicationActive';
   }
 }
 module.exports.MedicationActive = MedicationActive;

--- a/app/assets/javascripts/MedicationActive.js
+++ b/app/assets/javascripts/MedicationActive.js
@@ -26,7 +26,7 @@ const MedicationActiveSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'active' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationActive' },
+  _type: { type: String, default: 'QDM::MedicationActive' },
 
 });
 

--- a/app/assets/javascripts/MedicationAdministered.js
+++ b/app/assets/javascripts/MedicationAdministered.js
@@ -37,6 +37,7 @@ module.exports.MedicationAdministeredSchema = MedicationAdministeredSchema;
 class MedicationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, MedicationAdministeredSchema);
+    this._type = 'QDM::MedicationAdministered';
   }
 }
 module.exports.MedicationAdministered = MedicationAdministered;

--- a/app/assets/javascripts/MedicationAdministered.js
+++ b/app/assets/javascripts/MedicationAdministered.js
@@ -29,7 +29,7 @@ const MedicationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationAdministered' },
+  _type: { type: String, default: 'QDM::MedicationAdministered' },
 
 });
 

--- a/app/assets/javascripts/MedicationDischarge.js
+++ b/app/assets/javascripts/MedicationDischarge.js
@@ -30,7 +30,7 @@ const MedicationDischargeSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'discharge' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDischarge' },
+  _type: { type: String, default: 'QDM::MedicationDischarge' },
 
 });
 

--- a/app/assets/javascripts/MedicationDischarge.js
+++ b/app/assets/javascripts/MedicationDischarge.js
@@ -38,6 +38,7 @@ module.exports.MedicationDischargeSchema = MedicationDischargeSchema;
 class MedicationDischarge extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDischargeSchema);
+    this._type = 'QDM::MedicationDischarge';
   }
 }
 module.exports.MedicationDischarge = MedicationDischarge;

--- a/app/assets/javascripts/MedicationDispensed.js
+++ b/app/assets/javascripts/MedicationDispensed.js
@@ -33,7 +33,7 @@ const MedicationDispensedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'dispensed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDispensed' },
+  _type: { type: String, default: 'QDM::MedicationDispensed' },
 
 });
 

--- a/app/assets/javascripts/MedicationDispensed.js
+++ b/app/assets/javascripts/MedicationDispensed.js
@@ -41,6 +41,7 @@ module.exports.MedicationDispensedSchema = MedicationDispensedSchema;
 class MedicationDispensed extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDispensedSchema);
+    this._type = 'QDM::MedicationDispensed';
   }
 }
 module.exports.MedicationDispensed = MedicationDispensed;

--- a/app/assets/javascripts/MedicationOrder.js
+++ b/app/assets/javascripts/MedicationOrder.js
@@ -34,7 +34,7 @@ const MedicationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationOrder' },
+  _type: { type: String, default: 'QDM::MedicationOrder' },
 
 });
 

--- a/app/assets/javascripts/MedicationOrder.js
+++ b/app/assets/javascripts/MedicationOrder.js
@@ -42,6 +42,7 @@ module.exports.MedicationOrderSchema = MedicationOrderSchema;
 class MedicationOrder extends mongoose.Document {
   constructor(object) {
     super(object, MedicationOrderSchema);
+    this._type = 'QDM::MedicationOrder';
   }
 }
 module.exports.MedicationOrder = MedicationOrder;

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -30,6 +30,7 @@ module.exports.ParticipationSchema = ParticipationSchema;
 class Participation extends mongoose.Document {
   constructor(object) {
     super(object, ParticipationSchema);
+    this._type = 'QDM::Participation';
   }
 }
 module.exports.Participation = Participation;

--- a/app/assets/javascripts/Participation.js
+++ b/app/assets/javascripts/Participation.js
@@ -22,7 +22,7 @@ const ParticipationSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.130' },
   qdmCategory: { type: String, default: 'participation' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Participation' },
+  _type: { type: String, default: 'QDM::Participation' },
 
 });
 

--- a/app/assets/javascripts/PatientCareExperience.js
+++ b/app/assets/javascripts/PatientCareExperience.js
@@ -22,7 +22,7 @@ const PatientCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.52' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCareExperience' },
+  _type: { type: String, default: 'QDM::PatientCareExperience' },
 
 });
 

--- a/app/assets/javascripts/PatientCareExperience.js
+++ b/app/assets/javascripts/PatientCareExperience.js
@@ -30,6 +30,7 @@ module.exports.PatientCareExperienceSchema = PatientCareExperienceSchema;
 class PatientCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, PatientCareExperienceSchema);
+    this._type = 'QDM::PatientCareExperience';
   }
 }
 module.exports.PatientCareExperience = PatientCareExperience;

--- a/app/assets/javascripts/PatientCharacteristic.js
+++ b/app/assets/javascripts/PatientCharacteristic.js
@@ -30,6 +30,7 @@ module.exports.PatientCharacteristicSchema = PatientCharacteristicSchema;
 class PatientCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSchema);
+    this._type = 'QDM::PatientCharacteristic';
   }
 }
 module.exports.PatientCharacteristic = PatientCharacteristic;

--- a/app/assets/javascripts/PatientCharacteristic.js
+++ b/app/assets/javascripts/PatientCharacteristic.js
@@ -22,7 +22,7 @@ const PatientCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.53' },
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristic' },
+  _type: { type: String, default: 'QDM::PatientCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicBirthdate.js
+++ b/app/assets/javascripts/PatientCharacteristicBirthdate.js
@@ -31,6 +31,7 @@ module.exports.PatientCharacteristicBirthdateSchema = PatientCharacteristicBirth
 class PatientCharacteristicBirthdate extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicBirthdateSchema);
+    this._type = 'QDM::PatientCharacteristicBirthdate';
   }
 }
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;

--- a/app/assets/javascripts/PatientCharacteristicBirthdate.js
+++ b/app/assets/javascripts/PatientCharacteristicBirthdate.js
@@ -23,7 +23,7 @@ const PatientCharacteristicBirthdateSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'birthdate' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicBirthdate' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicBirthdate' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
+++ b/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
@@ -25,7 +25,7 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'clinical_trial_participant' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicClinicalTrialParticipant' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
+++ b/app/assets/javascripts/PatientCharacteristicClinicalTrialParticipant.js
@@ -33,6 +33,7 @@ module.exports.PatientCharacteristicClinicalTrialParticipantSchema = PatientChar
 class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicClinicalTrialParticipantSchema);
+    this._type = 'QDM::PatientCharacteristicClinicalTrialParticipant';
   }
 }
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;

--- a/app/assets/javascripts/PatientCharacteristicEthnicity.js
+++ b/app/assets/javascripts/PatientCharacteristicEthnicity.js
@@ -30,6 +30,7 @@ module.exports.PatientCharacteristicEthnicitySchema = PatientCharacteristicEthni
 class PatientCharacteristicEthnicity extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicEthnicitySchema);
+    this._type = 'QDM::PatientCharacteristicEthnicity';
   }
 }
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;

--- a/app/assets/javascripts/PatientCharacteristicEthnicity.js
+++ b/app/assets/javascripts/PatientCharacteristicEthnicity.js
@@ -22,7 +22,7 @@ const PatientCharacteristicEthnicitySchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'ethnicity' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicEthnicity' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicEthnicity' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicExpired.js
+++ b/app/assets/javascripts/PatientCharacteristicExpired.js
@@ -32,6 +32,7 @@ module.exports.PatientCharacteristicExpiredSchema = PatientCharacteristicExpired
 class PatientCharacteristicExpired extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicExpiredSchema);
+    this._type = 'QDM::PatientCharacteristicExpired';
   }
 }
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;

--- a/app/assets/javascripts/PatientCharacteristicExpired.js
+++ b/app/assets/javascripts/PatientCharacteristicExpired.js
@@ -24,7 +24,7 @@ const PatientCharacteristicExpiredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'expired' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicExpired' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicExpired' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicPayer.js
+++ b/app/assets/javascripts/PatientCharacteristicPayer.js
@@ -31,6 +31,7 @@ module.exports.PatientCharacteristicPayerSchema = PatientCharacteristicPayerSche
 class PatientCharacteristicPayer extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicPayerSchema);
+    this._type = 'QDM::PatientCharacteristicPayer';
   }
 }
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;

--- a/app/assets/javascripts/PatientCharacteristicPayer.js
+++ b/app/assets/javascripts/PatientCharacteristicPayer.js
@@ -23,7 +23,7 @@ const PatientCharacteristicPayerSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'payer' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicPayer' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicPayer' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicRace.js
+++ b/app/assets/javascripts/PatientCharacteristicRace.js
@@ -30,6 +30,7 @@ module.exports.PatientCharacteristicRaceSchema = PatientCharacteristicRaceSchema
 class PatientCharacteristicRace extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicRaceSchema);
+    this._type = 'QDM::PatientCharacteristicRace';
   }
 }
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;

--- a/app/assets/javascripts/PatientCharacteristicRace.js
+++ b/app/assets/javascripts/PatientCharacteristicRace.js
@@ -22,7 +22,7 @@ const PatientCharacteristicRaceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'race' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicRace' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicRace' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicSex.js
+++ b/app/assets/javascripts/PatientCharacteristicSex.js
@@ -22,7 +22,7 @@ const PatientCharacteristicSexSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'gender' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicSex' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicSex' },
 
 });
 

--- a/app/assets/javascripts/PatientCharacteristicSex.js
+++ b/app/assets/javascripts/PatientCharacteristicSex.js
@@ -30,6 +30,7 @@ module.exports.PatientCharacteristicSexSchema = PatientCharacteristicSexSchema;
 class PatientCharacteristicSex extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSexSchema);
+    this._type = 'QDM::PatientCharacteristicSex';
   }
 }
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;

--- a/app/assets/javascripts/PhysicalExamOrder.js
+++ b/app/assets/javascripts/PhysicalExamOrder.js
@@ -34,6 +34,7 @@ module.exports.PhysicalExamOrderSchema = PhysicalExamOrderSchema;
 class PhysicalExamOrder extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamOrderSchema);
+    this._type = 'QDM::PhysicalExamOrder';
   }
 }
 module.exports.PhysicalExamOrder = PhysicalExamOrder;

--- a/app/assets/javascripts/PhysicalExamOrder.js
+++ b/app/assets/javascripts/PhysicalExamOrder.js
@@ -26,7 +26,7 @@ const PhysicalExamOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamOrder' },
+  _type: { type: String, default: 'QDM::PhysicalExamOrder' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -30,7 +30,7 @@ const PhysicalExamPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamPerformed' },
+  _type: { type: String, default: 'QDM::PhysicalExamPerformed' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamPerformed.js
+++ b/app/assets/javascripts/PhysicalExamPerformed.js
@@ -38,6 +38,7 @@ module.exports.PhysicalExamPerformedSchema = PhysicalExamPerformedSchema;
 class PhysicalExamPerformed extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamPerformedSchema);
+    this._type = 'QDM::PhysicalExamPerformed';
   }
 }
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;

--- a/app/assets/javascripts/PhysicalExamRecommended.js
+++ b/app/assets/javascripts/PhysicalExamRecommended.js
@@ -26,7 +26,7 @@ const PhysicalExamRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamRecommended' },
+  _type: { type: String, default: 'QDM::PhysicalExamRecommended' },
 
 });
 

--- a/app/assets/javascripts/PhysicalExamRecommended.js
+++ b/app/assets/javascripts/PhysicalExamRecommended.js
@@ -34,6 +34,7 @@ module.exports.PhysicalExamRecommendedSchema = PhysicalExamRecommendedSchema;
 class PhysicalExamRecommended extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamRecommendedSchema);
+    this._type = 'QDM::PhysicalExamRecommended';
   }
 }
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;

--- a/app/assets/javascripts/ProcedureOrder.js
+++ b/app/assets/javascripts/ProcedureOrder.js
@@ -27,7 +27,7 @@ const ProcedureOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureOrder' },
+  _type: { type: String, default: 'QDM::ProcedureOrder' },
 
 });
 

--- a/app/assets/javascripts/ProcedureOrder.js
+++ b/app/assets/javascripts/ProcedureOrder.js
@@ -35,6 +35,7 @@ module.exports.ProcedureOrderSchema = ProcedureOrderSchema;
 class ProcedureOrder extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureOrderSchema);
+    this._type = 'QDM::ProcedureOrder';
   }
 }
 module.exports.ProcedureOrder = ProcedureOrder;

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -33,7 +33,7 @@ const ProcedurePerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedurePerformed' },
+  _type: { type: String, default: 'QDM::ProcedurePerformed' },
 
 });
 

--- a/app/assets/javascripts/ProcedurePerformed.js
+++ b/app/assets/javascripts/ProcedurePerformed.js
@@ -41,6 +41,7 @@ module.exports.ProcedurePerformedSchema = ProcedurePerformedSchema;
 class ProcedurePerformed extends mongoose.Document {
   constructor(object) {
     super(object, ProcedurePerformedSchema);
+    this._type = 'QDM::ProcedurePerformed';
   }
 }
 module.exports.ProcedurePerformed = ProcedurePerformed;

--- a/app/assets/javascripts/ProcedureRecommended.js
+++ b/app/assets/javascripts/ProcedureRecommended.js
@@ -27,7 +27,7 @@ const ProcedureRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureRecommended' },
+  _type: { type: String, default: 'QDM::ProcedureRecommended' },
 
 });
 

--- a/app/assets/javascripts/ProcedureRecommended.js
+++ b/app/assets/javascripts/ProcedureRecommended.js
@@ -35,6 +35,7 @@ module.exports.ProcedureRecommendedSchema = ProcedureRecommendedSchema;
 class ProcedureRecommended extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureRecommendedSchema);
+    this._type = 'QDM::ProcedureRecommended';
   }
 }
 module.exports.ProcedureRecommended = ProcedureRecommended;

--- a/app/assets/javascripts/ProviderCareExperience.js
+++ b/app/assets/javascripts/ProviderCareExperience.js
@@ -30,6 +30,7 @@ module.exports.ProviderCareExperienceSchema = ProviderCareExperienceSchema;
 class ProviderCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCareExperienceSchema);
+    this._type = 'QDM::ProviderCareExperience';
   }
 }
 module.exports.ProviderCareExperience = ProviderCareExperience;

--- a/app/assets/javascripts/ProviderCareExperience.js
+++ b/app/assets/javascripts/ProviderCareExperience.js
@@ -22,7 +22,7 @@ const ProviderCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.70' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCareExperience' },
+  _type: { type: String, default: 'QDM::ProviderCareExperience' },
 
 });
 

--- a/app/assets/javascripts/ProviderCharacteristic.js
+++ b/app/assets/javascripts/ProviderCharacteristic.js
@@ -22,7 +22,7 @@ const ProviderCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.71' },
   qdmCategory: { type: String, default: 'provider_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCharacteristic' },
+  _type: { type: String, default: 'QDM::ProviderCharacteristic' },
 
 });
 

--- a/app/assets/javascripts/ProviderCharacteristic.js
+++ b/app/assets/javascripts/ProviderCharacteristic.js
@@ -30,6 +30,7 @@ module.exports.ProviderCharacteristicSchema = ProviderCharacteristicSchema;
 class ProviderCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCharacteristicSchema);
+    this._type = 'QDM::ProviderCharacteristic';
   }
 }
 module.exports.ProviderCharacteristic = ProviderCharacteristic;

--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -32,13 +32,10 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
 };

--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -32,11 +32,13 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set({ dataElements: dataElementsInit });
 };

--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -15,7 +15,6 @@ const [Schema, Number, String, Mixed] = [
 const QDMPatientSchema = new Schema({
   birthDatetime: DateTime,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'QdmPatient' },
 
   // These are the "data criteria", or QDM datatype elements that exist on a
   // patient.
@@ -36,6 +35,7 @@ QDMPatientSchema.methods.initializeDataElements = function initializeDataElement
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });

--- a/app/assets/javascripts/ResultComponent.js
+++ b/app/assets/javascripts/ResultComponent.js
@@ -27,6 +27,7 @@ module.exports.ResultComponentSchema = ResultComponentSchema;
 class ResultComponent extends mongoose.Document {
   constructor(object) {
     super(object, ResultComponentSchema);
+    this._type = 'QDM::ResultComponent';
   }
 }
 module.exports.ResultComponent = ResultComponent;

--- a/app/assets/javascripts/ResultComponent.js
+++ b/app/assets/javascripts/ResultComponent.js
@@ -19,7 +19,7 @@ const [Number, String] = [
 const ResultComponentSchema = DataElementSchema({
   referenceRange: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ResultComponent' },
+  _type: { type: String, default: 'QDM::ResultComponent' },
 
 });
 

--- a/app/assets/javascripts/SubstanceAdministered.js
+++ b/app/assets/javascripts/SubstanceAdministered.js
@@ -28,7 +28,7 @@ const SubstanceAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceAdministered' },
+  _type: { type: String, default: 'QDM::SubstanceAdministered' },
 
 });
 

--- a/app/assets/javascripts/SubstanceAdministered.js
+++ b/app/assets/javascripts/SubstanceAdministered.js
@@ -36,6 +36,7 @@ module.exports.SubstanceAdministeredSchema = SubstanceAdministeredSchema;
 class SubstanceAdministered extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceAdministeredSchema);
+    this._type = 'QDM::SubstanceAdministered';
   }
 }
 module.exports.SubstanceAdministered = SubstanceAdministered;

--- a/app/assets/javascripts/SubstanceOrder.js
+++ b/app/assets/javascripts/SubstanceOrder.js
@@ -38,6 +38,7 @@ module.exports.SubstanceOrderSchema = SubstanceOrderSchema;
 class SubstanceOrder extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceOrderSchema);
+    this._type = 'QDM::SubstanceOrder';
   }
 }
 module.exports.SubstanceOrder = SubstanceOrder;

--- a/app/assets/javascripts/SubstanceOrder.js
+++ b/app/assets/javascripts/SubstanceOrder.js
@@ -30,7 +30,7 @@ const SubstanceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceOrder' },
+  _type: { type: String, default: 'QDM::SubstanceOrder' },
 
 });
 

--- a/app/assets/javascripts/SubstanceRecommended.js
+++ b/app/assets/javascripts/SubstanceRecommended.js
@@ -29,7 +29,7 @@ const SubstanceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceRecommended' },
+  _type: { type: String, default: 'QDM::SubstanceRecommended' },
 
 });
 

--- a/app/assets/javascripts/SubstanceRecommended.js
+++ b/app/assets/javascripts/SubstanceRecommended.js
@@ -37,6 +37,7 @@ module.exports.SubstanceRecommendedSchema = SubstanceRecommendedSchema;
 class SubstanceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceRecommendedSchema);
+    this._type = 'QDM::SubstanceRecommended';
   }
 }
 module.exports.SubstanceRecommended = SubstanceRecommended;

--- a/app/assets/javascripts/Symptom.js
+++ b/app/assets/javascripts/Symptom.js
@@ -32,6 +32,7 @@ module.exports.SymptomSchema = SymptomSchema;
 class Symptom extends mongoose.Document {
   constructor(object) {
     super(object, SymptomSchema);
+    this._type = 'QDM::Symptom';
   }
 }
 module.exports.Symptom = Symptom;

--- a/app/assets/javascripts/Symptom.js
+++ b/app/assets/javascripts/Symptom.js
@@ -24,7 +24,7 @@ const SymptomSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   qdmCategory: { type: String, default: 'symptom' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Symptom' },
+  _type: { type: String, default: 'QDM::Symptom' },
 
 });
 

--- a/app/assets/javascripts/attributes/Component.js
+++ b/app/assets/javascripts/attributes/Component.js
@@ -24,6 +24,7 @@ module.exports.ComponentSchema = ComponentSchema;
 class Component extends mongoose.Document {
   constructor(object) {
     super(object, ComponentSchema);
+    this._type = 'QDM::Component';
   }
 }
 module.exports.Component = Component;

--- a/app/assets/javascripts/attributes/Component.js
+++ b/app/assets/javascripts/attributes/Component.js
@@ -16,7 +16,7 @@ const ComponentSchema = new mongoose.Schema({
   code: Code,
   result: Any,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Component' },
+  _type: { type: String, default: 'QDM::Component' },
 
 });
 

--- a/app/assets/javascripts/attributes/FacilityLocation.js
+++ b/app/assets/javascripts/attributes/FacilityLocation.js
@@ -24,6 +24,7 @@ module.exports.FacilityLocationSchema = FacilityLocationSchema;
 class FacilityLocation extends mongoose.Document {
   constructor(object) {
     super(object, FacilityLocationSchema);
+    this._type = 'QDM::FacilityLocation';
   }
 }
 module.exports.FacilityLocation = FacilityLocation;

--- a/app/assets/javascripts/attributes/FacilityLocation.js
+++ b/app/assets/javascripts/attributes/FacilityLocation.js
@@ -16,7 +16,7 @@ const FacilityLocationSchema = new mongoose.Schema({
   code: Code,
   locationPeriod: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FacilityLocation' },
+  _type: { type: String, default: 'QDM::FacilityLocation' },
 
 });
 

--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -86,13 +86,10 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -86,11 +86,13 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -89,6 +89,7 @@ MeasureSchema.methods.initializeDataElements = function initializeDataElements()
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);

--- a/app/assets/javascripts/cqm/Patient.js
+++ b/app/assets/javascripts/cqm/Patient.js
@@ -14,7 +14,6 @@ const [Schema, Number, String, Mixed] = [
 ];
 
 const PatientSchema = new Schema({
-  _type: { type: String, default: 'Patient' },
 
   givenNames: [String],
   familyName: String,

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -35,6 +35,7 @@ module.exports.AdverseEventSchema = AdverseEventSchema;
 class AdverseEvent extends mongoose.Document {
   constructor(object) {
     super(object, AdverseEventSchema);
+    this._type = 'QDM::AdverseEvent';
   }
 }
 module.exports.AdverseEvent = AdverseEvent;
@@ -194,6 +195,7 @@ module.exports.AllergyIntoleranceSchema = AllergyIntoleranceSchema;
 class AllergyIntolerance extends mongoose.Document {
   constructor(object) {
     super(object, AllergyIntoleranceSchema);
+    this._type = 'QDM::AllergyIntolerance';
   }
 }
 module.exports.AllergyIntolerance = AllergyIntolerance;
@@ -234,6 +236,7 @@ module.exports.AssessmentOrderSchema = AssessmentOrderSchema;
 class AssessmentOrder extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentOrderSchema);
+    this._type = 'QDM::AssessmentOrder';
   }
 }
 module.exports.AssessmentOrder = AssessmentOrder;
@@ -278,6 +281,7 @@ module.exports.AssessmentPerformedSchema = AssessmentPerformedSchema;
 class AssessmentPerformed extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentPerformedSchema);
+    this._type = 'QDM::AssessmentPerformed';
   }
 }
 module.exports.AssessmentPerformed = AssessmentPerformed;
@@ -318,6 +322,7 @@ module.exports.AssessmentRecommendedSchema = AssessmentRecommendedSchema;
 class AssessmentRecommended extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentRecommendedSchema);
+    this._type = 'QDM::AssessmentRecommended';
   }
 }
 module.exports.AssessmentRecommended = AssessmentRecommended;
@@ -357,6 +362,7 @@ module.exports.CareGoalSchema = CareGoalSchema;
 class CareGoal extends mongoose.Document {
   constructor(object) {
     super(object, CareGoalSchema);
+    this._type = 'QDM::CareGoal';
   }
 }
 module.exports.CareGoal = CareGoal;
@@ -402,6 +408,7 @@ module.exports.CommunicationPerformedSchema = CommunicationPerformedSchema;
 class CommunicationPerformed extends mongoose.Document {
   constructor(object) {
     super(object, CommunicationPerformedSchema);
+    this._type = 'QDM::CommunicationPerformed';
   }
 }
 module.exports.CommunicationPerformed = CommunicationPerformed;
@@ -444,6 +451,7 @@ module.exports.DeviceAppliedSchema = DeviceAppliedSchema;
 class DeviceApplied extends mongoose.Document {
   constructor(object) {
     super(object, DeviceAppliedSchema);
+    this._type = 'QDM::DeviceApplied';
   }
 }
 module.exports.DeviceApplied = DeviceApplied;
@@ -484,6 +492,7 @@ module.exports.DeviceOrderSchema = DeviceOrderSchema;
 class DeviceOrder extends mongoose.Document {
   constructor(object) {
     super(object, DeviceOrderSchema);
+    this._type = 'QDM::DeviceOrder';
   }
 }
 module.exports.DeviceOrder = DeviceOrder;
@@ -524,6 +533,7 @@ module.exports.DeviceRecommendedSchema = DeviceRecommendedSchema;
 class DeviceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DeviceRecommendedSchema);
+    this._type = 'QDM::DeviceRecommended';
   }
 }
 module.exports.DeviceRecommended = DeviceRecommended;
@@ -565,6 +575,7 @@ module.exports.DiagnosisSchema = DiagnosisSchema;
 class Diagnosis extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosisSchema);
+    this._type = 'QDM::Diagnosis';
   }
 }
 module.exports.Diagnosis = Diagnosis;
@@ -605,6 +616,7 @@ module.exports.DiagnosticStudyOrderSchema = DiagnosticStudyOrderSchema;
 class DiagnosticStudyOrder extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyOrderSchema);
+    this._type = 'QDM::DiagnosticStudyOrder';
   }
 }
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;
@@ -652,6 +664,7 @@ module.exports.DiagnosticStudyPerformedSchema = DiagnosticStudyPerformedSchema;
 class DiagnosticStudyPerformed extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyPerformedSchema);
+    this._type = 'QDM::DiagnosticStudyPerformed';
   }
 }
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;
@@ -692,6 +705,7 @@ module.exports.DiagnosticStudyRecommendedSchema = DiagnosticStudyRecommendedSche
 class DiagnosticStudyRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyRecommendedSchema);
+    this._type = 'QDM::DiagnosticStudyRecommended';
   }
 }
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;
@@ -733,6 +747,7 @@ module.exports.EncounterOrderSchema = EncounterOrderSchema;
 class EncounterOrder extends mongoose.Document {
   constructor(object) {
     super(object, EncounterOrderSchema);
+    this._type = 'QDM::EncounterOrder';
   }
 }
 module.exports.EncounterOrder = EncounterOrder;
@@ -779,6 +794,7 @@ module.exports.EncounterPerformedSchema = EncounterPerformedSchema;
 class EncounterPerformed extends mongoose.Document {
   constructor(object) {
     super(object, EncounterPerformedSchema);
+    this._type = 'QDM::EncounterPerformed';
   }
 }
 module.exports.EncounterPerformed = EncounterPerformed;
@@ -820,6 +836,7 @@ module.exports.EncounterRecommendedSchema = EncounterRecommendedSchema;
 class EncounterRecommended extends mongoose.Document {
   constructor(object) {
     super(object, EncounterRecommendedSchema);
+    this._type = 'QDM::EncounterRecommended';
   }
 }
 module.exports.EncounterRecommended = EncounterRecommended;
@@ -859,6 +876,7 @@ module.exports.FamilyHistorySchema = FamilyHistorySchema;
 class FamilyHistory extends mongoose.Document {
   constructor(object) {
     super(object, FamilyHistorySchema);
+    this._type = 'QDM::FamilyHistory';
   }
 }
 module.exports.FamilyHistory = FamilyHistory;
@@ -925,6 +943,7 @@ module.exports.ImmunizationAdministeredSchema = ImmunizationAdministeredSchema;
 class ImmunizationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationAdministeredSchema);
+    this._type = 'QDM::ImmunizationAdministered';
   }
 }
 module.exports.ImmunizationAdministered = ImmunizationAdministered;
@@ -969,6 +988,7 @@ module.exports.ImmunizationOrderSchema = ImmunizationOrderSchema;
 class ImmunizationOrder extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationOrderSchema);
+    this._type = 'QDM::ImmunizationOrder';
   }
 }
 module.exports.ImmunizationOrder = ImmunizationOrder;
@@ -1073,6 +1093,7 @@ module.exports.InterventionOrderSchema = InterventionOrderSchema;
 class InterventionOrder extends mongoose.Document {
   constructor(object) {
     super(object, InterventionOrderSchema);
+    this._type = 'QDM::InterventionOrder';
   }
 }
 module.exports.InterventionOrder = InterventionOrder;
@@ -1116,6 +1137,7 @@ module.exports.InterventionPerformedSchema = InterventionPerformedSchema;
 class InterventionPerformed extends mongoose.Document {
   constructor(object) {
     super(object, InterventionPerformedSchema);
+    this._type = 'QDM::InterventionPerformed';
   }
 }
 module.exports.InterventionPerformed = InterventionPerformed;
@@ -1156,6 +1178,7 @@ module.exports.InterventionRecommendedSchema = InterventionRecommendedSchema;
 class InterventionRecommended extends mongoose.Document {
   constructor(object) {
     super(object, InterventionRecommendedSchema);
+    this._type = 'QDM::InterventionRecommended';
   }
 }
 module.exports.InterventionRecommended = InterventionRecommended;
@@ -1196,6 +1219,7 @@ module.exports.LaboratoryTestOrderSchema = LaboratoryTestOrderSchema;
 class LaboratoryTestOrder extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestOrderSchema);
+    this._type = 'QDM::LaboratoryTestOrder';
   }
 }
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;
@@ -1243,6 +1267,7 @@ module.exports.LaboratoryTestPerformedSchema = LaboratoryTestPerformedSchema;
 class LaboratoryTestPerformed extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestPerformedSchema);
+    this._type = 'QDM::LaboratoryTestPerformed';
   }
 }
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;
@@ -1283,6 +1308,7 @@ module.exports.LaboratoryTestRecommendedSchema = LaboratoryTestRecommendedSchema
 class LaboratoryTestRecommended extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestRecommendedSchema);
+    this._type = 'QDM::LaboratoryTestRecommended';
   }
 }
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;
@@ -1324,6 +1350,7 @@ module.exports.MedicationActiveSchema = MedicationActiveSchema;
 class MedicationActive extends mongoose.Document {
   constructor(object) {
     super(object, MedicationActiveSchema);
+    this._type = 'QDM::MedicationActive';
   }
 }
 module.exports.MedicationActive = MedicationActive;
@@ -1368,6 +1395,7 @@ module.exports.MedicationAdministeredSchema = MedicationAdministeredSchema;
 class MedicationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, MedicationAdministeredSchema);
+    this._type = 'QDM::MedicationAdministered';
   }
 }
 module.exports.MedicationAdministered = MedicationAdministered;
@@ -1413,6 +1441,7 @@ module.exports.MedicationDischargeSchema = MedicationDischargeSchema;
 class MedicationDischarge extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDischargeSchema);
+    this._type = 'QDM::MedicationDischarge';
   }
 }
 module.exports.MedicationDischarge = MedicationDischarge;
@@ -1461,6 +1490,7 @@ module.exports.MedicationDispensedSchema = MedicationDispensedSchema;
 class MedicationDispensed extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDispensedSchema);
+    this._type = 'QDM::MedicationDispensed';
   }
 }
 module.exports.MedicationDispensed = MedicationDispensed;
@@ -1510,6 +1540,7 @@ module.exports.MedicationOrderSchema = MedicationOrderSchema;
 class MedicationOrder extends mongoose.Document {
   constructor(object) {
     super(object, MedicationOrderSchema);
+    this._type = 'QDM::MedicationOrder';
   }
 }
 module.exports.MedicationOrder = MedicationOrder;
@@ -1547,6 +1578,7 @@ module.exports.ParticipationSchema = ParticipationSchema;
 class Participation extends mongoose.Document {
   constructor(object) {
     super(object, ParticipationSchema);
+    this._type = 'QDM::Participation';
   }
 }
 module.exports.Participation = Participation;
@@ -1584,6 +1616,7 @@ module.exports.PatientCareExperienceSchema = PatientCareExperienceSchema;
 class PatientCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, PatientCareExperienceSchema);
+    this._type = 'QDM::PatientCareExperience';
   }
 }
 module.exports.PatientCareExperience = PatientCareExperience;
@@ -1621,6 +1654,7 @@ module.exports.PatientCharacteristicSchema = PatientCharacteristicSchema;
 class PatientCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSchema);
+    this._type = 'QDM::PatientCharacteristic';
   }
 }
 module.exports.PatientCharacteristic = PatientCharacteristic;
@@ -1659,6 +1693,7 @@ module.exports.PatientCharacteristicBirthdateSchema = PatientCharacteristicBirth
 class PatientCharacteristicBirthdate extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicBirthdateSchema);
+    this._type = 'QDM::PatientCharacteristicBirthdate';
   }
 }
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;
@@ -1699,6 +1734,7 @@ module.exports.PatientCharacteristicClinicalTrialParticipantSchema = PatientChar
 class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicClinicalTrialParticipantSchema);
+    this._type = 'QDM::PatientCharacteristicClinicalTrialParticipant';
   }
 }
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;
@@ -1736,6 +1772,7 @@ module.exports.PatientCharacteristicEthnicitySchema = PatientCharacteristicEthni
 class PatientCharacteristicEthnicity extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicEthnicitySchema);
+    this._type = 'QDM::PatientCharacteristicEthnicity';
   }
 }
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;
@@ -1775,6 +1812,7 @@ module.exports.PatientCharacteristicExpiredSchema = PatientCharacteristicExpired
 class PatientCharacteristicExpired extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicExpiredSchema);
+    this._type = 'QDM::PatientCharacteristicExpired';
   }
 }
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;
@@ -1813,6 +1851,7 @@ module.exports.PatientCharacteristicPayerSchema = PatientCharacteristicPayerSche
 class PatientCharacteristicPayer extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicPayerSchema);
+    this._type = 'QDM::PatientCharacteristicPayer';
   }
 }
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;
@@ -1850,6 +1889,7 @@ module.exports.PatientCharacteristicRaceSchema = PatientCharacteristicRaceSchema
 class PatientCharacteristicRace extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicRaceSchema);
+    this._type = 'QDM::PatientCharacteristicRace';
   }
 }
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;
@@ -1887,6 +1927,7 @@ module.exports.PatientCharacteristicSexSchema = PatientCharacteristicSexSchema;
 class PatientCharacteristicSex extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSexSchema);
+    this._type = 'QDM::PatientCharacteristicSex';
   }
 }
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;
@@ -1928,6 +1969,7 @@ module.exports.PhysicalExamOrderSchema = PhysicalExamOrderSchema;
 class PhysicalExamOrder extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamOrderSchema);
+    this._type = 'QDM::PhysicalExamOrder';
   }
 }
 module.exports.PhysicalExamOrder = PhysicalExamOrder;
@@ -1973,6 +2015,7 @@ module.exports.PhysicalExamPerformedSchema = PhysicalExamPerformedSchema;
 class PhysicalExamPerformed extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamPerformedSchema);
+    this._type = 'QDM::PhysicalExamPerformed';
   }
 }
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;
@@ -2014,6 +2057,7 @@ module.exports.PhysicalExamRecommendedSchema = PhysicalExamRecommendedSchema;
 class PhysicalExamRecommended extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamRecommendedSchema);
+    this._type = 'QDM::PhysicalExamRecommended';
   }
 }
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;
@@ -2056,6 +2100,7 @@ module.exports.ProcedureOrderSchema = ProcedureOrderSchema;
 class ProcedureOrder extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureOrderSchema);
+    this._type = 'QDM::ProcedureOrder';
   }
 }
 module.exports.ProcedureOrder = ProcedureOrder;
@@ -2104,6 +2149,7 @@ module.exports.ProcedurePerformedSchema = ProcedurePerformedSchema;
 class ProcedurePerformed extends mongoose.Document {
   constructor(object) {
     super(object, ProcedurePerformedSchema);
+    this._type = 'QDM::ProcedurePerformed';
   }
 }
 module.exports.ProcedurePerformed = ProcedurePerformed;
@@ -2146,6 +2192,7 @@ module.exports.ProcedureRecommendedSchema = ProcedureRecommendedSchema;
 class ProcedureRecommended extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureRecommendedSchema);
+    this._type = 'QDM::ProcedureRecommended';
   }
 }
 module.exports.ProcedureRecommended = ProcedureRecommended;
@@ -2183,6 +2230,7 @@ module.exports.ProviderCareExperienceSchema = ProviderCareExperienceSchema;
 class ProviderCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCareExperienceSchema);
+    this._type = 'QDM::ProviderCareExperience';
   }
 }
 module.exports.ProviderCareExperience = ProviderCareExperience;
@@ -2220,6 +2268,7 @@ module.exports.ProviderCharacteristicSchema = ProviderCharacteristicSchema;
 class ProviderCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCharacteristicSchema);
+    this._type = 'QDM::ProviderCharacteristic';
   }
 }
 module.exports.ProviderCharacteristic = ProviderCharacteristic;
@@ -2259,13 +2308,10 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
 };
@@ -2556,6 +2602,7 @@ module.exports.ResultComponentSchema = ResultComponentSchema;
 class ResultComponent extends mongoose.Document {
   constructor(object) {
     super(object, ResultComponentSchema);
+    this._type = 'QDM::ResultComponent';
   }
 }
 module.exports.ResultComponent = ResultComponent;
@@ -2599,6 +2646,7 @@ module.exports.SubstanceAdministeredSchema = SubstanceAdministeredSchema;
 class SubstanceAdministered extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceAdministeredSchema);
+    this._type = 'QDM::SubstanceAdministered';
   }
 }
 module.exports.SubstanceAdministered = SubstanceAdministered;
@@ -2644,6 +2692,7 @@ module.exports.SubstanceOrderSchema = SubstanceOrderSchema;
 class SubstanceOrder extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceOrderSchema);
+    this._type = 'QDM::SubstanceOrder';
   }
 }
 module.exports.SubstanceOrder = SubstanceOrder;
@@ -2688,6 +2737,7 @@ module.exports.SubstanceRecommendedSchema = SubstanceRecommendedSchema;
 class SubstanceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceRecommendedSchema);
+    this._type = 'QDM::SubstanceRecommended';
   }
 }
 module.exports.SubstanceRecommended = SubstanceRecommended;
@@ -2727,6 +2777,7 @@ module.exports.SymptomSchema = SymptomSchema;
 class Symptom extends mongoose.Document {
   constructor(object) {
     super(object, SymptomSchema);
+    this._type = 'QDM::Symptom';
   }
 }
 module.exports.Symptom = Symptom;
@@ -2758,6 +2809,7 @@ module.exports.ComponentSchema = ComponentSchema;
 class Component extends mongoose.Document {
   constructor(object) {
     super(object, ComponentSchema);
+    this._type = 'QDM::Component';
   }
 }
 module.exports.Component = Component;
@@ -2789,6 +2841,7 @@ module.exports.FacilityLocationSchema = FacilityLocationSchema;
 class FacilityLocation extends mongoose.Document {
   constructor(object) {
     super(object, FacilityLocationSchema);
+    this._type = 'QDM::FacilityLocation';
   }
 }
 module.exports.FacilityLocation = FacilityLocation;
@@ -3206,13 +3259,10 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -27,7 +27,7 @@ const AdverseEventSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.120' },
   qdmCategory: { type: String, default: 'adverse_event' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AdverseEvent' },
+  _type: { type: String, default: 'QDM::AdverseEvent' },
 
 });
 
@@ -186,7 +186,7 @@ const AllergyIntoleranceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'allergy' },
   qdmStatus: { type: String, default: 'intolerance' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AllergyIntolerance' },
+  _type: { type: String, default: 'QDM::AllergyIntolerance' },
 
 });
 
@@ -226,7 +226,7 @@ const AssessmentOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentOrder' },
+  _type: { type: String, default: 'QDM::AssessmentOrder' },
 
 });
 
@@ -270,7 +270,7 @@ const AssessmentPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentPerformed' },
+  _type: { type: String, default: 'QDM::AssessmentPerformed' },
 
 });
 
@@ -310,7 +310,7 @@ const AssessmentRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentRecommended' },
+  _type: { type: String, default: 'QDM::AssessmentRecommended' },
 
 });
 
@@ -349,7 +349,7 @@ const CareGoalSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.7' },
   qdmCategory: { type: String, default: 'care_goal' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CareGoal' },
+  _type: { type: String, default: 'QDM::CareGoal' },
 
 });
 
@@ -394,7 +394,7 @@ const CommunicationPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'communication' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CommunicationPerformed' },
+  _type: { type: String, default: 'QDM::CommunicationPerformed' },
 
 });
 
@@ -436,7 +436,7 @@ const DeviceAppliedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'applied' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceApplied' },
+  _type: { type: String, default: 'QDM::DeviceApplied' },
 
 });
 
@@ -476,7 +476,7 @@ const DeviceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceOrder' },
+  _type: { type: String, default: 'QDM::DeviceOrder' },
 
 });
 
@@ -516,7 +516,7 @@ const DeviceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceRecommended' },
+  _type: { type: String, default: 'QDM::DeviceRecommended' },
 
 });
 
@@ -557,7 +557,7 @@ const DiagnosisSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   qdmCategory: { type: String, default: 'condition' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Diagnosis' },
+  _type: { type: String, default: 'QDM::Diagnosis' },
 
 });
 
@@ -597,7 +597,7 @@ const DiagnosticStudyOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyOrder' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyOrder' },
 
 });
 
@@ -644,7 +644,7 @@ const DiagnosticStudyPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyPerformed' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyPerformed' },
 
 });
 
@@ -684,7 +684,7 @@ const DiagnosticStudyRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyRecommended' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyRecommended' },
 
 });
 
@@ -725,7 +725,7 @@ const EncounterOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterOrder' },
+  _type: { type: String, default: 'QDM::EncounterOrder' },
 
 });
 
@@ -771,7 +771,7 @@ const EncounterPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterPerformed' },
+  _type: { type: String, default: 'QDM::EncounterPerformed' },
 
 });
 
@@ -812,7 +812,7 @@ const EncounterRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterRecommended' },
+  _type: { type: String, default: 'QDM::EncounterRecommended' },
 
 });
 
@@ -851,7 +851,7 @@ const FamilyHistorySchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   qdmCategory: { type: String, default: 'family_history' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FamilyHistory' },
+  _type: { type: String, default: 'QDM::FamilyHistory' },
 
 });
 
@@ -875,7 +875,6 @@ const IdSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Id' },
 
 }, { _id: false, id: false });
 
@@ -918,7 +917,7 @@ const ImmunizationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationAdministered' },
+  _type: { type: String, default: 'QDM::ImmunizationAdministered' },
 
 });
 
@@ -962,7 +961,7 @@ const ImmunizationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationOrder' },
+  _type: { type: String, default: 'QDM::ImmunizationOrder' },
 
 });
 
@@ -1066,7 +1065,7 @@ const InterventionOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionOrder' },
+  _type: { type: String, default: 'QDM::InterventionOrder' },
 
 });
 
@@ -1109,7 +1108,7 @@ const InterventionPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionPerformed' },
+  _type: { type: String, default: 'QDM::InterventionPerformed' },
 
 });
 
@@ -1149,7 +1148,7 @@ const InterventionRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionRecommended' },
+  _type: { type: String, default: 'QDM::InterventionRecommended' },
 
 });
 
@@ -1189,7 +1188,7 @@ const LaboratoryTestOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestOrder' },
+  _type: { type: String, default: 'QDM::LaboratoryTestOrder' },
 
 });
 
@@ -1236,7 +1235,7 @@ const LaboratoryTestPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestPerformed' },
+  _type: { type: String, default: 'QDM::LaboratoryTestPerformed' },
 
 });
 
@@ -1276,7 +1275,7 @@ const LaboratoryTestRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestRecommended' },
+  _type: { type: String, default: 'QDM::LaboratoryTestRecommended' },
 
 });
 
@@ -1317,7 +1316,7 @@ const MedicationActiveSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'active' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationActive' },
+  _type: { type: String, default: 'QDM::MedicationActive' },
 
 });
 
@@ -1361,7 +1360,7 @@ const MedicationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationAdministered' },
+  _type: { type: String, default: 'QDM::MedicationAdministered' },
 
 });
 
@@ -1406,7 +1405,7 @@ const MedicationDischargeSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'discharge' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDischarge' },
+  _type: { type: String, default: 'QDM::MedicationDischarge' },
 
 });
 
@@ -1454,7 +1453,7 @@ const MedicationDispensedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'dispensed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDispensed' },
+  _type: { type: String, default: 'QDM::MedicationDispensed' },
 
 });
 
@@ -1503,7 +1502,7 @@ const MedicationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationOrder' },
+  _type: { type: String, default: 'QDM::MedicationOrder' },
 
 });
 
@@ -1540,7 +1539,7 @@ const ParticipationSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.130' },
   qdmCategory: { type: String, default: 'participation' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Participation' },
+  _type: { type: String, default: 'QDM::Participation' },
 
 });
 
@@ -1577,7 +1576,7 @@ const PatientCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.52' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCareExperience' },
+  _type: { type: String, default: 'QDM::PatientCareExperience' },
 
 });
 
@@ -1614,7 +1613,7 @@ const PatientCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.53' },
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristic' },
+  _type: { type: String, default: 'QDM::PatientCharacteristic' },
 
 });
 
@@ -1652,7 +1651,7 @@ const PatientCharacteristicBirthdateSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'birthdate' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicBirthdate' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicBirthdate' },
 
 });
 
@@ -1692,7 +1691,7 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'clinical_trial_participant' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicClinicalTrialParticipant' },
 
 });
 
@@ -1729,7 +1728,7 @@ const PatientCharacteristicEthnicitySchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'ethnicity' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicEthnicity' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicEthnicity' },
 
 });
 
@@ -1768,7 +1767,7 @@ const PatientCharacteristicExpiredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'expired' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicExpired' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicExpired' },
 
 });
 
@@ -1806,7 +1805,7 @@ const PatientCharacteristicPayerSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'payer' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicPayer' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicPayer' },
 
 });
 
@@ -1843,7 +1842,7 @@ const PatientCharacteristicRaceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'race' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicRace' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicRace' },
 
 });
 
@@ -1880,7 +1879,7 @@ const PatientCharacteristicSexSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'gender' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicSex' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicSex' },
 
 });
 
@@ -1921,7 +1920,7 @@ const PhysicalExamOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamOrder' },
+  _type: { type: String, default: 'QDM::PhysicalExamOrder' },
 
 });
 
@@ -1966,7 +1965,7 @@ const PhysicalExamPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamPerformed' },
+  _type: { type: String, default: 'QDM::PhysicalExamPerformed' },
 
 });
 
@@ -2007,7 +2006,7 @@ const PhysicalExamRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamRecommended' },
+  _type: { type: String, default: 'QDM::PhysicalExamRecommended' },
 
 });
 
@@ -2049,7 +2048,7 @@ const ProcedureOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureOrder' },
+  _type: { type: String, default: 'QDM::ProcedureOrder' },
 
 });
 
@@ -2097,7 +2096,7 @@ const ProcedurePerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedurePerformed' },
+  _type: { type: String, default: 'QDM::ProcedurePerformed' },
 
 });
 
@@ -2139,7 +2138,7 @@ const ProcedureRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureRecommended' },
+  _type: { type: String, default: 'QDM::ProcedureRecommended' },
 
 });
 
@@ -2176,7 +2175,7 @@ const ProviderCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.70' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCareExperience' },
+  _type: { type: String, default: 'QDM::ProviderCareExperience' },
 
 });
 
@@ -2213,7 +2212,7 @@ const ProviderCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.71' },
   qdmCategory: { type: String, default: 'provider_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCharacteristic' },
+  _type: { type: String, default: 'QDM::ProviderCharacteristic' },
 
 });
 
@@ -2243,7 +2242,6 @@ const [Schema, Number, String, Mixed] = [
 const QDMPatientSchema = new Schema({
   birthDatetime: DateTime,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'QdmPatient' },
 
   // These are the "data criteria", or QDM datatype elements that exist on a
   // patient.
@@ -2264,6 +2262,7 @@ QDMPatientSchema.methods.initializeDataElements = function initializeDataElement
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
@@ -2547,7 +2546,7 @@ const [Number, String] = [
 const ResultComponentSchema = DataElementSchema({
   referenceRange: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ResultComponent' },
+  _type: { type: String, default: 'QDM::ResultComponent' },
 
 });
 
@@ -2590,7 +2589,7 @@ const SubstanceAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceAdministered' },
+  _type: { type: String, default: 'QDM::SubstanceAdministered' },
 
 });
 
@@ -2635,7 +2634,7 @@ const SubstanceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceOrder' },
+  _type: { type: String, default: 'QDM::SubstanceOrder' },
 
 });
 
@@ -2679,7 +2678,7 @@ const SubstanceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceRecommended' },
+  _type: { type: String, default: 'QDM::SubstanceRecommended' },
 
 });
 
@@ -2718,7 +2717,7 @@ const SymptomSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   qdmCategory: { type: String, default: 'symptom' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Symptom' },
+  _type: { type: String, default: 'QDM::Symptom' },
 
 });
 
@@ -2749,7 +2748,7 @@ const ComponentSchema = new mongoose.Schema({
   code: Code,
   result: Any,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Component' },
+  _type: { type: String, default: 'QDM::Component' },
 
 });
 
@@ -2780,7 +2779,7 @@ const FacilityLocationSchema = new mongoose.Schema({
   code: Code,
   locationPeriod: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FacilityLocation' },
+  _type: { type: String, default: 'QDM::FacilityLocation' },
 
 });
 
@@ -3208,6 +3207,7 @@ MeasureSchema.methods.initializeDataElements = function initializeDataElements()
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
@@ -3271,7 +3271,6 @@ const [Schema, Number, String, Mixed] = [
 ];
 
 const PatientSchema = new Schema({
-  _type: { type: String, default: 'Patient' },
 
   givenNames: [String],
   familyName: String,

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2259,11 +2259,13 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set({ dataElements: dataElementsInit });
 };
@@ -3204,11 +3206,13 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -35,6 +35,7 @@ module.exports.AdverseEventSchema = AdverseEventSchema;
 class AdverseEvent extends mongoose.Document {
   constructor(object) {
     super(object, AdverseEventSchema);
+    this._type = 'QDM::AdverseEvent';
   }
 }
 module.exports.AdverseEvent = AdverseEvent;
@@ -194,6 +195,7 @@ module.exports.AllergyIntoleranceSchema = AllergyIntoleranceSchema;
 class AllergyIntolerance extends mongoose.Document {
   constructor(object) {
     super(object, AllergyIntoleranceSchema);
+    this._type = 'QDM::AllergyIntolerance';
   }
 }
 module.exports.AllergyIntolerance = AllergyIntolerance;
@@ -234,6 +236,7 @@ module.exports.AssessmentOrderSchema = AssessmentOrderSchema;
 class AssessmentOrder extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentOrderSchema);
+    this._type = 'QDM::AssessmentOrder';
   }
 }
 module.exports.AssessmentOrder = AssessmentOrder;
@@ -278,6 +281,7 @@ module.exports.AssessmentPerformedSchema = AssessmentPerformedSchema;
 class AssessmentPerformed extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentPerformedSchema);
+    this._type = 'QDM::AssessmentPerformed';
   }
 }
 module.exports.AssessmentPerformed = AssessmentPerformed;
@@ -318,6 +322,7 @@ module.exports.AssessmentRecommendedSchema = AssessmentRecommendedSchema;
 class AssessmentRecommended extends mongoose.Document {
   constructor(object) {
     super(object, AssessmentRecommendedSchema);
+    this._type = 'QDM::AssessmentRecommended';
   }
 }
 module.exports.AssessmentRecommended = AssessmentRecommended;
@@ -357,6 +362,7 @@ module.exports.CareGoalSchema = CareGoalSchema;
 class CareGoal extends mongoose.Document {
   constructor(object) {
     super(object, CareGoalSchema);
+    this._type = 'QDM::CareGoal';
   }
 }
 module.exports.CareGoal = CareGoal;
@@ -402,6 +408,7 @@ module.exports.CommunicationPerformedSchema = CommunicationPerformedSchema;
 class CommunicationPerformed extends mongoose.Document {
   constructor(object) {
     super(object, CommunicationPerformedSchema);
+    this._type = 'QDM::CommunicationPerformed';
   }
 }
 module.exports.CommunicationPerformed = CommunicationPerformed;
@@ -444,6 +451,7 @@ module.exports.DeviceAppliedSchema = DeviceAppliedSchema;
 class DeviceApplied extends mongoose.Document {
   constructor(object) {
     super(object, DeviceAppliedSchema);
+    this._type = 'QDM::DeviceApplied';
   }
 }
 module.exports.DeviceApplied = DeviceApplied;
@@ -484,6 +492,7 @@ module.exports.DeviceOrderSchema = DeviceOrderSchema;
 class DeviceOrder extends mongoose.Document {
   constructor(object) {
     super(object, DeviceOrderSchema);
+    this._type = 'QDM::DeviceOrder';
   }
 }
 module.exports.DeviceOrder = DeviceOrder;
@@ -524,6 +533,7 @@ module.exports.DeviceRecommendedSchema = DeviceRecommendedSchema;
 class DeviceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DeviceRecommendedSchema);
+    this._type = 'QDM::DeviceRecommended';
   }
 }
 module.exports.DeviceRecommended = DeviceRecommended;
@@ -565,6 +575,7 @@ module.exports.DiagnosisSchema = DiagnosisSchema;
 class Diagnosis extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosisSchema);
+    this._type = 'QDM::Diagnosis';
   }
 }
 module.exports.Diagnosis = Diagnosis;
@@ -605,6 +616,7 @@ module.exports.DiagnosticStudyOrderSchema = DiagnosticStudyOrderSchema;
 class DiagnosticStudyOrder extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyOrderSchema);
+    this._type = 'QDM::DiagnosticStudyOrder';
   }
 }
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;
@@ -652,6 +664,7 @@ module.exports.DiagnosticStudyPerformedSchema = DiagnosticStudyPerformedSchema;
 class DiagnosticStudyPerformed extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyPerformedSchema);
+    this._type = 'QDM::DiagnosticStudyPerformed';
   }
 }
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;
@@ -692,6 +705,7 @@ module.exports.DiagnosticStudyRecommendedSchema = DiagnosticStudyRecommendedSche
 class DiagnosticStudyRecommended extends mongoose.Document {
   constructor(object) {
     super(object, DiagnosticStudyRecommendedSchema);
+    this._type = 'QDM::DiagnosticStudyRecommended';
   }
 }
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;
@@ -733,6 +747,7 @@ module.exports.EncounterOrderSchema = EncounterOrderSchema;
 class EncounterOrder extends mongoose.Document {
   constructor(object) {
     super(object, EncounterOrderSchema);
+    this._type = 'QDM::EncounterOrder';
   }
 }
 module.exports.EncounterOrder = EncounterOrder;
@@ -779,6 +794,7 @@ module.exports.EncounterPerformedSchema = EncounterPerformedSchema;
 class EncounterPerformed extends mongoose.Document {
   constructor(object) {
     super(object, EncounterPerformedSchema);
+    this._type = 'QDM::EncounterPerformed';
   }
 }
 module.exports.EncounterPerformed = EncounterPerformed;
@@ -820,6 +836,7 @@ module.exports.EncounterRecommendedSchema = EncounterRecommendedSchema;
 class EncounterRecommended extends mongoose.Document {
   constructor(object) {
     super(object, EncounterRecommendedSchema);
+    this._type = 'QDM::EncounterRecommended';
   }
 }
 module.exports.EncounterRecommended = EncounterRecommended;
@@ -859,6 +876,7 @@ module.exports.FamilyHistorySchema = FamilyHistorySchema;
 class FamilyHistory extends mongoose.Document {
   constructor(object) {
     super(object, FamilyHistorySchema);
+    this._type = 'QDM::FamilyHistory';
   }
 }
 module.exports.FamilyHistory = FamilyHistory;
@@ -925,6 +943,7 @@ module.exports.ImmunizationAdministeredSchema = ImmunizationAdministeredSchema;
 class ImmunizationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationAdministeredSchema);
+    this._type = 'QDM::ImmunizationAdministered';
   }
 }
 module.exports.ImmunizationAdministered = ImmunizationAdministered;
@@ -969,6 +988,7 @@ module.exports.ImmunizationOrderSchema = ImmunizationOrderSchema;
 class ImmunizationOrder extends mongoose.Document {
   constructor(object) {
     super(object, ImmunizationOrderSchema);
+    this._type = 'QDM::ImmunizationOrder';
   }
 }
 module.exports.ImmunizationOrder = ImmunizationOrder;
@@ -1073,6 +1093,7 @@ module.exports.InterventionOrderSchema = InterventionOrderSchema;
 class InterventionOrder extends mongoose.Document {
   constructor(object) {
     super(object, InterventionOrderSchema);
+    this._type = 'QDM::InterventionOrder';
   }
 }
 module.exports.InterventionOrder = InterventionOrder;
@@ -1116,6 +1137,7 @@ module.exports.InterventionPerformedSchema = InterventionPerformedSchema;
 class InterventionPerformed extends mongoose.Document {
   constructor(object) {
     super(object, InterventionPerformedSchema);
+    this._type = 'QDM::InterventionPerformed';
   }
 }
 module.exports.InterventionPerformed = InterventionPerformed;
@@ -1156,6 +1178,7 @@ module.exports.InterventionRecommendedSchema = InterventionRecommendedSchema;
 class InterventionRecommended extends mongoose.Document {
   constructor(object) {
     super(object, InterventionRecommendedSchema);
+    this._type = 'QDM::InterventionRecommended';
   }
 }
 module.exports.InterventionRecommended = InterventionRecommended;
@@ -1196,6 +1219,7 @@ module.exports.LaboratoryTestOrderSchema = LaboratoryTestOrderSchema;
 class LaboratoryTestOrder extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestOrderSchema);
+    this._type = 'QDM::LaboratoryTestOrder';
   }
 }
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;
@@ -1243,6 +1267,7 @@ module.exports.LaboratoryTestPerformedSchema = LaboratoryTestPerformedSchema;
 class LaboratoryTestPerformed extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestPerformedSchema);
+    this._type = 'QDM::LaboratoryTestPerformed';
   }
 }
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;
@@ -1283,6 +1308,7 @@ module.exports.LaboratoryTestRecommendedSchema = LaboratoryTestRecommendedSchema
 class LaboratoryTestRecommended extends mongoose.Document {
   constructor(object) {
     super(object, LaboratoryTestRecommendedSchema);
+    this._type = 'QDM::LaboratoryTestRecommended';
   }
 }
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;
@@ -1324,6 +1350,7 @@ module.exports.MedicationActiveSchema = MedicationActiveSchema;
 class MedicationActive extends mongoose.Document {
   constructor(object) {
     super(object, MedicationActiveSchema);
+    this._type = 'QDM::MedicationActive';
   }
 }
 module.exports.MedicationActive = MedicationActive;
@@ -1368,6 +1395,7 @@ module.exports.MedicationAdministeredSchema = MedicationAdministeredSchema;
 class MedicationAdministered extends mongoose.Document {
   constructor(object) {
     super(object, MedicationAdministeredSchema);
+    this._type = 'QDM::MedicationAdministered';
   }
 }
 module.exports.MedicationAdministered = MedicationAdministered;
@@ -1413,6 +1441,7 @@ module.exports.MedicationDischargeSchema = MedicationDischargeSchema;
 class MedicationDischarge extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDischargeSchema);
+    this._type = 'QDM::MedicationDischarge';
   }
 }
 module.exports.MedicationDischarge = MedicationDischarge;
@@ -1461,6 +1490,7 @@ module.exports.MedicationDispensedSchema = MedicationDispensedSchema;
 class MedicationDispensed extends mongoose.Document {
   constructor(object) {
     super(object, MedicationDispensedSchema);
+    this._type = 'QDM::MedicationDispensed';
   }
 }
 module.exports.MedicationDispensed = MedicationDispensed;
@@ -1510,6 +1540,7 @@ module.exports.MedicationOrderSchema = MedicationOrderSchema;
 class MedicationOrder extends mongoose.Document {
   constructor(object) {
     super(object, MedicationOrderSchema);
+    this._type = 'QDM::MedicationOrder';
   }
 }
 module.exports.MedicationOrder = MedicationOrder;
@@ -1547,6 +1578,7 @@ module.exports.ParticipationSchema = ParticipationSchema;
 class Participation extends mongoose.Document {
   constructor(object) {
     super(object, ParticipationSchema);
+    this._type = 'QDM::Participation';
   }
 }
 module.exports.Participation = Participation;
@@ -1584,6 +1616,7 @@ module.exports.PatientCareExperienceSchema = PatientCareExperienceSchema;
 class PatientCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, PatientCareExperienceSchema);
+    this._type = 'QDM::PatientCareExperience';
   }
 }
 module.exports.PatientCareExperience = PatientCareExperience;
@@ -1621,6 +1654,7 @@ module.exports.PatientCharacteristicSchema = PatientCharacteristicSchema;
 class PatientCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSchema);
+    this._type = 'QDM::PatientCharacteristic';
   }
 }
 module.exports.PatientCharacteristic = PatientCharacteristic;
@@ -1659,6 +1693,7 @@ module.exports.PatientCharacteristicBirthdateSchema = PatientCharacteristicBirth
 class PatientCharacteristicBirthdate extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicBirthdateSchema);
+    this._type = 'QDM::PatientCharacteristicBirthdate';
   }
 }
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;
@@ -1699,6 +1734,7 @@ module.exports.PatientCharacteristicClinicalTrialParticipantSchema = PatientChar
 class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicClinicalTrialParticipantSchema);
+    this._type = 'QDM::PatientCharacteristicClinicalTrialParticipant';
   }
 }
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;
@@ -1736,6 +1772,7 @@ module.exports.PatientCharacteristicEthnicitySchema = PatientCharacteristicEthni
 class PatientCharacteristicEthnicity extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicEthnicitySchema);
+    this._type = 'QDM::PatientCharacteristicEthnicity';
   }
 }
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;
@@ -1775,6 +1812,7 @@ module.exports.PatientCharacteristicExpiredSchema = PatientCharacteristicExpired
 class PatientCharacteristicExpired extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicExpiredSchema);
+    this._type = 'QDM::PatientCharacteristicExpired';
   }
 }
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;
@@ -1813,6 +1851,7 @@ module.exports.PatientCharacteristicPayerSchema = PatientCharacteristicPayerSche
 class PatientCharacteristicPayer extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicPayerSchema);
+    this._type = 'QDM::PatientCharacteristicPayer';
   }
 }
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;
@@ -1850,6 +1889,7 @@ module.exports.PatientCharacteristicRaceSchema = PatientCharacteristicRaceSchema
 class PatientCharacteristicRace extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicRaceSchema);
+    this._type = 'QDM::PatientCharacteristicRace';
   }
 }
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;
@@ -1887,6 +1927,7 @@ module.exports.PatientCharacteristicSexSchema = PatientCharacteristicSexSchema;
 class PatientCharacteristicSex extends mongoose.Document {
   constructor(object) {
     super(object, PatientCharacteristicSexSchema);
+    this._type = 'QDM::PatientCharacteristicSex';
   }
 }
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;
@@ -1928,6 +1969,7 @@ module.exports.PhysicalExamOrderSchema = PhysicalExamOrderSchema;
 class PhysicalExamOrder extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamOrderSchema);
+    this._type = 'QDM::PhysicalExamOrder';
   }
 }
 module.exports.PhysicalExamOrder = PhysicalExamOrder;
@@ -1973,6 +2015,7 @@ module.exports.PhysicalExamPerformedSchema = PhysicalExamPerformedSchema;
 class PhysicalExamPerformed extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamPerformedSchema);
+    this._type = 'QDM::PhysicalExamPerformed';
   }
 }
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;
@@ -2014,6 +2057,7 @@ module.exports.PhysicalExamRecommendedSchema = PhysicalExamRecommendedSchema;
 class PhysicalExamRecommended extends mongoose.Document {
   constructor(object) {
     super(object, PhysicalExamRecommendedSchema);
+    this._type = 'QDM::PhysicalExamRecommended';
   }
 }
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;
@@ -2056,6 +2100,7 @@ module.exports.ProcedureOrderSchema = ProcedureOrderSchema;
 class ProcedureOrder extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureOrderSchema);
+    this._type = 'QDM::ProcedureOrder';
   }
 }
 module.exports.ProcedureOrder = ProcedureOrder;
@@ -2104,6 +2149,7 @@ module.exports.ProcedurePerformedSchema = ProcedurePerformedSchema;
 class ProcedurePerformed extends mongoose.Document {
   constructor(object) {
     super(object, ProcedurePerformedSchema);
+    this._type = 'QDM::ProcedurePerformed';
   }
 }
 module.exports.ProcedurePerformed = ProcedurePerformed;
@@ -2146,6 +2192,7 @@ module.exports.ProcedureRecommendedSchema = ProcedureRecommendedSchema;
 class ProcedureRecommended extends mongoose.Document {
   constructor(object) {
     super(object, ProcedureRecommendedSchema);
+    this._type = 'QDM::ProcedureRecommended';
   }
 }
 module.exports.ProcedureRecommended = ProcedureRecommended;
@@ -2183,6 +2230,7 @@ module.exports.ProviderCareExperienceSchema = ProviderCareExperienceSchema;
 class ProviderCareExperience extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCareExperienceSchema);
+    this._type = 'QDM::ProviderCareExperience';
   }
 }
 module.exports.ProviderCareExperience = ProviderCareExperience;
@@ -2220,6 +2268,7 @@ module.exports.ProviderCharacteristicSchema = ProviderCharacteristicSchema;
 class ProviderCharacteristic extends mongoose.Document {
   constructor(object) {
     super(object, ProviderCharacteristicSchema);
+    this._type = 'QDM::ProviderCharacteristic';
   }
 }
 module.exports.ProviderCharacteristic = ProviderCharacteristic;
@@ -2259,13 +2308,10 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
 };
@@ -2556,6 +2602,7 @@ module.exports.ResultComponentSchema = ResultComponentSchema;
 class ResultComponent extends mongoose.Document {
   constructor(object) {
     super(object, ResultComponentSchema);
+    this._type = 'QDM::ResultComponent';
   }
 }
 module.exports.ResultComponent = ResultComponent;
@@ -2599,6 +2646,7 @@ module.exports.SubstanceAdministeredSchema = SubstanceAdministeredSchema;
 class SubstanceAdministered extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceAdministeredSchema);
+    this._type = 'QDM::SubstanceAdministered';
   }
 }
 module.exports.SubstanceAdministered = SubstanceAdministered;
@@ -2644,6 +2692,7 @@ module.exports.SubstanceOrderSchema = SubstanceOrderSchema;
 class SubstanceOrder extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceOrderSchema);
+    this._type = 'QDM::SubstanceOrder';
   }
 }
 module.exports.SubstanceOrder = SubstanceOrder;
@@ -2688,6 +2737,7 @@ module.exports.SubstanceRecommendedSchema = SubstanceRecommendedSchema;
 class SubstanceRecommended extends mongoose.Document {
   constructor(object) {
     super(object, SubstanceRecommendedSchema);
+    this._type = 'QDM::SubstanceRecommended';
   }
 }
 module.exports.SubstanceRecommended = SubstanceRecommended;
@@ -2727,6 +2777,7 @@ module.exports.SymptomSchema = SymptomSchema;
 class Symptom extends mongoose.Document {
   constructor(object) {
     super(object, SymptomSchema);
+    this._type = 'QDM::Symptom';
   }
 }
 module.exports.Symptom = Symptom;
@@ -2758,6 +2809,7 @@ module.exports.ComponentSchema = ComponentSchema;
 class Component extends mongoose.Document {
   constructor(object) {
     super(object, ComponentSchema);
+    this._type = 'QDM::Component';
   }
 }
 module.exports.Component = Component;
@@ -2789,6 +2841,7 @@ module.exports.FacilityLocationSchema = FacilityLocationSchema;
 class FacilityLocation extends mongoose.Document {
   constructor(object) {
     super(object, FacilityLocationSchema);
+    this._type = 'QDM::FacilityLocation';
   }
 }
 module.exports.FacilityLocation = FacilityLocation;
@@ -3201,13 +3254,10 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -27,7 +27,7 @@ const AdverseEventSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.120' },
   qdmCategory: { type: String, default: 'adverse_event' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AdverseEvent' },
+  _type: { type: String, default: 'QDM::AdverseEvent' },
 
 });
 
@@ -186,7 +186,7 @@ const AllergyIntoleranceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'allergy' },
   qdmStatus: { type: String, default: 'intolerance' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AllergyIntolerance' },
+  _type: { type: String, default: 'QDM::AllergyIntolerance' },
 
 });
 
@@ -226,7 +226,7 @@ const AssessmentOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentOrder' },
+  _type: { type: String, default: 'QDM::AssessmentOrder' },
 
 });
 
@@ -270,7 +270,7 @@ const AssessmentPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentPerformed' },
+  _type: { type: String, default: 'QDM::AssessmentPerformed' },
 
 });
 
@@ -310,7 +310,7 @@ const AssessmentRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'assessment' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'AssessmentRecommended' },
+  _type: { type: String, default: 'QDM::AssessmentRecommended' },
 
 });
 
@@ -349,7 +349,7 @@ const CareGoalSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.7' },
   qdmCategory: { type: String, default: 'care_goal' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CareGoal' },
+  _type: { type: String, default: 'QDM::CareGoal' },
 
 });
 
@@ -394,7 +394,7 @@ const CommunicationPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'communication' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'CommunicationPerformed' },
+  _type: { type: String, default: 'QDM::CommunicationPerformed' },
 
 });
 
@@ -436,7 +436,7 @@ const DeviceAppliedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'applied' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceApplied' },
+  _type: { type: String, default: 'QDM::DeviceApplied' },
 
 });
 
@@ -476,7 +476,7 @@ const DeviceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceOrder' },
+  _type: { type: String, default: 'QDM::DeviceOrder' },
 
 });
 
@@ -516,7 +516,7 @@ const DeviceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'device' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DeviceRecommended' },
+  _type: { type: String, default: 'QDM::DeviceRecommended' },
 
 });
 
@@ -557,7 +557,7 @@ const DiagnosisSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.135' },
   qdmCategory: { type: String, default: 'condition' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Diagnosis' },
+  _type: { type: String, default: 'QDM::Diagnosis' },
 
 });
 
@@ -597,7 +597,7 @@ const DiagnosticStudyOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyOrder' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyOrder' },
 
 });
 
@@ -644,7 +644,7 @@ const DiagnosticStudyPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyPerformed' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyPerformed' },
 
 });
 
@@ -684,7 +684,7 @@ const DiagnosticStudyRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'diagnostic_study' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'DiagnosticStudyRecommended' },
+  _type: { type: String, default: 'QDM::DiagnosticStudyRecommended' },
 
 });
 
@@ -725,7 +725,7 @@ const EncounterOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterOrder' },
+  _type: { type: String, default: 'QDM::EncounterOrder' },
 
 });
 
@@ -771,7 +771,7 @@ const EncounterPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterPerformed' },
+  _type: { type: String, default: 'QDM::EncounterPerformed' },
 
 });
 
@@ -812,7 +812,7 @@ const EncounterRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'encounter' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'EncounterRecommended' },
+  _type: { type: String, default: 'QDM::EncounterRecommended' },
 
 });
 
@@ -851,7 +851,7 @@ const FamilyHistorySchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.12' },
   qdmCategory: { type: String, default: 'family_history' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FamilyHistory' },
+  _type: { type: String, default: 'QDM::FamilyHistory' },
 
 });
 
@@ -875,7 +875,6 @@ const IdSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Id' },
 
 }, { _id: false, id: false });
 
@@ -918,7 +917,7 @@ const ImmunizationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationAdministered' },
+  _type: { type: String, default: 'QDM::ImmunizationAdministered' },
 
 });
 
@@ -962,7 +961,7 @@ const ImmunizationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'immunization' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ImmunizationOrder' },
+  _type: { type: String, default: 'QDM::ImmunizationOrder' },
 
 });
 
@@ -1066,7 +1065,7 @@ const InterventionOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionOrder' },
+  _type: { type: String, default: 'QDM::InterventionOrder' },
 
 });
 
@@ -1109,7 +1108,7 @@ const InterventionPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionPerformed' },
+  _type: { type: String, default: 'QDM::InterventionPerformed' },
 
 });
 
@@ -1149,7 +1148,7 @@ const InterventionRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'intervention' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'InterventionRecommended' },
+  _type: { type: String, default: 'QDM::InterventionRecommended' },
 
 });
 
@@ -1189,7 +1188,7 @@ const LaboratoryTestOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestOrder' },
+  _type: { type: String, default: 'QDM::LaboratoryTestOrder' },
 
 });
 
@@ -1236,7 +1235,7 @@ const LaboratoryTestPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestPerformed' },
+  _type: { type: String, default: 'QDM::LaboratoryTestPerformed' },
 
 });
 
@@ -1276,7 +1275,7 @@ const LaboratoryTestRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'laboratory_test' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'LaboratoryTestRecommended' },
+  _type: { type: String, default: 'QDM::LaboratoryTestRecommended' },
 
 });
 
@@ -1317,7 +1316,7 @@ const MedicationActiveSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'active' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationActive' },
+  _type: { type: String, default: 'QDM::MedicationActive' },
 
 });
 
@@ -1361,7 +1360,7 @@ const MedicationAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationAdministered' },
+  _type: { type: String, default: 'QDM::MedicationAdministered' },
 
 });
 
@@ -1406,7 +1405,7 @@ const MedicationDischargeSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'discharge' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDischarge' },
+  _type: { type: String, default: 'QDM::MedicationDischarge' },
 
 });
 
@@ -1454,7 +1453,7 @@ const MedicationDispensedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'dispensed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationDispensed' },
+  _type: { type: String, default: 'QDM::MedicationDispensed' },
 
 });
 
@@ -1503,7 +1502,7 @@ const MedicationOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'medication' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'MedicationOrder' },
+  _type: { type: String, default: 'QDM::MedicationOrder' },
 
 });
 
@@ -1540,7 +1539,7 @@ const ParticipationSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.130' },
   qdmCategory: { type: String, default: 'participation' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Participation' },
+  _type: { type: String, default: 'QDM::Participation' },
 
 });
 
@@ -1577,7 +1576,7 @@ const PatientCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.52' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCareExperience' },
+  _type: { type: String, default: 'QDM::PatientCareExperience' },
 
 });
 
@@ -1614,7 +1613,7 @@ const PatientCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.53' },
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristic' },
+  _type: { type: String, default: 'QDM::PatientCharacteristic' },
 
 });
 
@@ -1652,7 +1651,7 @@ const PatientCharacteristicBirthdateSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'birthdate' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicBirthdate' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicBirthdate' },
 
 });
 
@@ -1692,7 +1691,7 @@ const PatientCharacteristicClinicalTrialParticipantSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'clinical_trial_participant' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicClinicalTrialParticipant' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicClinicalTrialParticipant' },
 
 });
 
@@ -1729,7 +1728,7 @@ const PatientCharacteristicEthnicitySchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'ethnicity' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicEthnicity' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicEthnicity' },
 
 });
 
@@ -1768,7 +1767,7 @@ const PatientCharacteristicExpiredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'expired' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicExpired' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicExpired' },
 
 });
 
@@ -1806,7 +1805,7 @@ const PatientCharacteristicPayerSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'payer' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicPayer' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicPayer' },
 
 });
 
@@ -1843,7 +1842,7 @@ const PatientCharacteristicRaceSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'race' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicRace' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicRace' },
 
 });
 
@@ -1880,7 +1879,7 @@ const PatientCharacteristicSexSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'patient_characteristic' },
   qdmStatus: { type: String, default: 'gender' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PatientCharacteristicSex' },
+  _type: { type: String, default: 'QDM::PatientCharacteristicSex' },
 
 });
 
@@ -1921,7 +1920,7 @@ const PhysicalExamOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamOrder' },
+  _type: { type: String, default: 'QDM::PhysicalExamOrder' },
 
 });
 
@@ -1966,7 +1965,7 @@ const PhysicalExamPerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamPerformed' },
+  _type: { type: String, default: 'QDM::PhysicalExamPerformed' },
 
 });
 
@@ -2007,7 +2006,7 @@ const PhysicalExamRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'physical_exam' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'PhysicalExamRecommended' },
+  _type: { type: String, default: 'QDM::PhysicalExamRecommended' },
 
 });
 
@@ -2049,7 +2048,7 @@ const ProcedureOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureOrder' },
+  _type: { type: String, default: 'QDM::ProcedureOrder' },
 
 });
 
@@ -2097,7 +2096,7 @@ const ProcedurePerformedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'performed' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedurePerformed' },
+  _type: { type: String, default: 'QDM::ProcedurePerformed' },
 
 });
 
@@ -2139,7 +2138,7 @@ const ProcedureRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'procedure' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProcedureRecommended' },
+  _type: { type: String, default: 'QDM::ProcedureRecommended' },
 
 });
 
@@ -2176,7 +2175,7 @@ const ProviderCareExperienceSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.70' },
   qdmCategory: { type: String, default: 'care_experience' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCareExperience' },
+  _type: { type: String, default: 'QDM::ProviderCareExperience' },
 
 });
 
@@ -2213,7 +2212,7 @@ const ProviderCharacteristicSchema = DataElementSchema({
   hqmfOid: { type: String, default: '2.16.840.1.113883.10.20.28.4.71' },
   qdmCategory: { type: String, default: 'provider_characteristic' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ProviderCharacteristic' },
+  _type: { type: String, default: 'QDM::ProviderCharacteristic' },
 
 });
 
@@ -2243,7 +2242,6 @@ const [Schema, Number, String, Mixed] = [
 const QDMPatientSchema = new Schema({
   birthDatetime: DateTime,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'QdmPatient' },
 
   // These are the "data criteria", or QDM datatype elements that exist on a
   // patient.
@@ -2264,6 +2262,7 @@ QDMPatientSchema.methods.initializeDataElements = function initializeDataElement
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
@@ -2547,7 +2546,7 @@ const [Number, String] = [
 const ResultComponentSchema = DataElementSchema({
   referenceRange: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'ResultComponent' },
+  _type: { type: String, default: 'QDM::ResultComponent' },
 
 });
 
@@ -2590,7 +2589,7 @@ const SubstanceAdministeredSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'administered' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceAdministered' },
+  _type: { type: String, default: 'QDM::SubstanceAdministered' },
 
 });
 
@@ -2635,7 +2634,7 @@ const SubstanceOrderSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'order' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceOrder' },
+  _type: { type: String, default: 'QDM::SubstanceOrder' },
 
 });
 
@@ -2679,7 +2678,7 @@ const SubstanceRecommendedSchema = DataElementSchema({
   qdmCategory: { type: String, default: 'substance' },
   qdmStatus: { type: String, default: 'recommended' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'SubstanceRecommended' },
+  _type: { type: String, default: 'QDM::SubstanceRecommended' },
 
 });
 
@@ -2718,7 +2717,7 @@ const SymptomSchema = DataElementSchema({
   qrdaOid: { type: String, default: '2.16.840.1.113883.10.20.24.3.136' },
   qdmCategory: { type: String, default: 'symptom' },
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Symptom' },
+  _type: { type: String, default: 'QDM::Symptom' },
 
 });
 
@@ -2749,7 +2748,7 @@ const ComponentSchema = new mongoose.Schema({
   code: Code,
   result: Any,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'Component' },
+  _type: { type: String, default: 'QDM::Component' },
 
 });
 
@@ -2780,7 +2779,7 @@ const FacilityLocationSchema = new mongoose.Schema({
   code: Code,
   locationPeriod: Interval,
   qdmVersion: { type: String, default: '5.4' },
-  _type: { type: String, default: 'FacilityLocation' },
+  _type: { type: String, default: 'QDM::FacilityLocation' },
 
 });
 
@@ -3203,6 +3202,7 @@ MeasureSchema.methods.initializeDataElements = function initializeDataElements()
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
@@ -3266,7 +3266,6 @@ const [Schema, Number, String, Mixed] = [
 ];
 
 const PatientSchema = new Schema({
-  _type: { type: String, default: 'Patient' },
 
   givenNames: [String],
   familyName: String,

--- a/dist/index.js
+++ b/dist/index.js
@@ -2259,11 +2259,13 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set({ dataElements: dataElementsInit });
 };
@@ -3199,11 +3201,13 @@ const MeasureSchema = new mongoose.Schema(
 // to its respective Mongoose Model
 MeasureSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const sourceDataCriteriaInit = [];
   this.source_data_criteria.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    sourceDataCriteriaInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set('source_data_criteria', sourceDataCriteriaInit);
 };

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -195,7 +195,10 @@ datatypes.each do |datatype, info|
     renderer = ERB.new(File.read(datatype_custom_templates[datatype.to_sym]), nil, '-')
   end
   attrs_with_extras = info[:attributes] # this field gets used in the template
-  attrs_with_extras << { name: '_type', type: 'System.String', default: datatype.underscore.camelize } # Add Class
+  # Custom datatypes don't need _type
+  unless datatype_custom_templates.key?(datatype.to_sym)
+    attrs_with_extras << { name: '_type', type: 'System.String', default: "QDM::#{datatype.underscore.camelize}" } # Add Class
+  end
   puts '  ' + file_path + datatype + '.js'
   File.open(file_path + datatype + '.js', 'w') { |file| file.puts renderer.result(binding) }
 end

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe QDM do
     system('rm -rf app/models/test')
   end
 
+  it 'patient elements have _type when expected' do
+    # These are the only three models where _type shouldn't exist
+    # Due to conversion to a mongoid document on the backend
+    expect(@patient_a.methods.include?(:_type)).to eq false
+    expect(@patient_a.qdmPatient.methods.include?(:_type)).to eq false
+    expect(@patient_a.qdmPatient.dataElements[0].id.methods.include?(:_type)).to eq false
+
+    expect(@patient_a.qdmPatient.dataElements[0]._type).to eq 'QDM::ProcedurePerformed'
+    expect(@patient_a.qdmPatient.dataElements[1]._type).to eq 'QDM::EncounterOrder'
+    expect(@patient_big.qdmPatient.dataElements[0]._type).to eq 'QDM::PatientCharacteristicBirthdate'
+  end
+
   it 'patients have patient characteristics' do
     expect(@patient_a.qdmPatient.birthDatetime).to be
     expect(@patient_b.givenNames).to be

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -116,6 +116,19 @@ describe('QDMPatient', () => {
       expect(qdmPatient.dataElements.length).toEqual(1);
     });
 
+    it('can initialize a data elements array JSON with a single entry without QDM:: in _type', () => {
+      qdmPatient = new QDMPatient({
+        birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
+        qdmVersion: '0.0',
+        dataElements: [{
+          _type: "MedicationOrder"
+        }]
+      });
+      expect(qdmPatient.dataElements.length).toEqual(1);
+      expect(qdmPatient.dataElements[0]._type).toEqual('QDM::MedicationOrder');
+      expect(qdmPatient.dataElements[0] instanceof MedicationOrder).toBe(true);
+    });
+
     it('can initialize a data elements array with a multiple entries', () => {
       qdmPatient = new QDMPatient({
         birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -124,6 +124,18 @@ describe('QDMPatient', () => {
       });
       expect(qdmPatient.dataElements.length).toEqual(2);
     });
+
+    it('initializes qdmPatients and data element IDs without a _type field', () => {
+      qdmPatient = new QDMPatient({
+        birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
+        qdmVersion: '0.0',
+        dataElements: [new MedicationOrder(), new MedicationOrder()]
+      });
+      expect(qdmPatient._type).toBeUndefined();
+      expect(qdmPatient.dataElements[0].id._type).toBeUndefined();
+      expect(qdmPatient.dataElements[0]._type).toEqual('QDM::MedicationOrder');
+    });
+
   });
   describe('getDataElements', () => {
     it('can return dataElements with and without qdmCategory', () => {
@@ -331,6 +343,11 @@ describe('QDMPatient', () => {
 describe('CQMPatient', () => {
   it('can create a blank patient', () => {
     expect(() => {new Patient()}).not.toThrow();
+  });
+
+  it('initializes cqmPatients without a _type field', () => {
+    patient = new Patient();
+    expect(patient._type).toBeUndefined();
   });
 
   it('can construct a patient with data', () => {

--- a/templates/mongoose_template.js.erb
+++ b/templates/mongoose_template.js.erb
@@ -32,6 +32,7 @@ module.exports.<%= datatype %>Schema = <%= datatype %>Schema;
 class <%= datatype %> extends mongoose.Document {
   constructor(object) {
     super(object, <%= datatype %>Schema);
+    this._type = 'QDM::<%= datatype %>';
   }
 }
 module.exports.<%= datatype %> = <%= datatype %>;

--- a/templates/patient_template.js.erb
+++ b/templates/patient_template.js.erb
@@ -32,13 +32,10 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
-  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    elementTypeRemoved = JSON.parse(JSON.stringify(element));
-    delete elementTypeRemoved._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
+    dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });
 };

--- a/templates/patient_template.js.erb
+++ b/templates/patient_template.js.erb
@@ -35,6 +35,7 @@ QDMPatientSchema.methods.initializeDataElements = function initializeDataElement
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
+    delete element._type;
     dataElementsInit.push(new AllDataElements[typeStripped](element));
   });
   this.set({ dataElements: dataElementsInit });

--- a/templates/patient_template.js.erb
+++ b/templates/patient_template.js.erb
@@ -32,11 +32,13 @@ const QDMPatientSchema = new Schema({
 // to its respective Mongoose Model
 QDMPatientSchema.methods.initializeDataElements = function initializeDataElements() {
   let typeStripped;
+  let elementTypeRemoved;
   const dataElementsInit = [];
   this.dataElements.forEach((element) => {
     typeStripped = element._type.replace(/QDM::/, '');
-    delete element._type;
-    dataElementsInit.push(new AllDataElements[typeStripped](element));
+    elementTypeRemoved = JSON.parse(JSON.stringify(element));
+    delete elementTypeRemoved._type;
+    dataElementsInit.push(new AllDataElements[typeStripped](elementTypeRemoved));
   });
   this.set({ dataElements: dataElementsInit });
 };


### PR DESCRIPTION
Removed '_type' from Id and QDMPatient, included 'QDM::' in front of _type for all other models. This was done in order to properly save the patient in the backend without throwing errors.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2016
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated - N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
