### PR TITLE
Adjust name type used when generating QDM::Id

### DIFF
--- a/app/models/qdm/medication_dispensed.rb
+++ b/app/models/qdm/medication_dispensed.rb
@@ -11,8 +11,8 @@ module QDM
     field :frequency, type: QDM::Code
     field :daysSupplied, type: Integer
     field :route, type: QDM::Code
-    field :prescriberId, type: QDM::Id
-    field :dispenserId, type: QDM::Id
+    embeds_one :prescriberId, class_name: 'QDM::Id'
+    embeds_one :dispenserId, class_name: 'QDM::Id'
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Dispensed'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.49'

--- a/app/models/qdm/medication_dispensed.rb
+++ b/app/models/qdm/medication_dispensed.rb
@@ -11,8 +11,8 @@ module QDM
     field :frequency, type: QDM::Code
     field :daysSupplied, type: Integer
     field :route, type: QDM::Code
-    field :prescriberQDM::Id, type: QDM::Id
-    field :dispenserQDM::Id, type: QDM::Id
+    field :prescriberId, type: QDM::Id
+    field :dispenserId, type: QDM::Id
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Dispensed'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.49'

--- a/app/models/qdm/medication_dispensed.rb
+++ b/app/models/qdm/medication_dispensed.rb
@@ -11,8 +11,8 @@ module QDM
     field :frequency, type: QDM::Code
     field :daysSupplied, type: Integer
     field :route, type: QDM::Code
-    field :prescriberId, type: Id
-    field :dispenserId, type: Id
+    field :prescriberQDM::Id, type: QDM::Id
+    field :dispenserQDM::Id, type: QDM::Id
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Dispensed'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.49'

--- a/app/models/qdm/medication_order.rb
+++ b/app/models/qdm/medication_order.rb
@@ -13,7 +13,7 @@ module QDM
     field :route, type: QDM::Code
     field :setting, type: QDM::Code
     field :reason, type: QDM::Code
-    field :prescriberQDM::Id, type: QDM::Id
+    field :prescriberId, type: QDM::Id
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Order'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.51'

--- a/app/models/qdm/medication_order.rb
+++ b/app/models/qdm/medication_order.rb
@@ -13,7 +13,7 @@ module QDM
     field :route, type: QDM::Code
     field :setting, type: QDM::Code
     field :reason, type: QDM::Code
-    field :prescriberId, type: QDM::Id
+    embeds_one :prescriberId, class_name: 'QDM::Id'
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Order'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.51'

--- a/app/models/qdm/medication_order.rb
+++ b/app/models/qdm/medication_order.rb
@@ -13,7 +13,7 @@ module QDM
     field :route, type: QDM::Code
     field :setting, type: QDM::Code
     field :reason, type: QDM::Code
-    field :prescriberId, type: Id
+    field :prescriberQDM::Id, type: QDM::Id
     field :negationRationale, type: QDM::Code
     field :qdmTitle, type: String, default: 'Medication, Order'
     field :hqmfOid, type: String, default: '2.16.840.1.113883.10.20.28.4.51'

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -244,7 +244,7 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   contents.gsub!(/field :facilityLocation, type: Code/, 'field :facilityLocation, type: QDM::FacilityLocation')
 
   # Make relatedTo embeds_many instead of field
-  contents.gsub!(/  field :relatedTo, type: Array\n/, "  embeds_many :relatedTo, class_name: 'QDM::Id'\n")
+  contents.gsub!(/  field :relatedTo, type: Array\n/, "  embeds_many :relatedTo, class_name: 'Id'\n")
 
   File.open(file_name, 'w') { |file| file.puts contents }
 end
@@ -282,6 +282,7 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   contents = File.read(file_name)
   contents.gsub!('Qdm', 'QDM')
   contents.gsub!('Code', 'QDM::Code')
+  contents.gsub!('Id', 'QDM::Id')
   contents.gsub!('Interval', 'QDM::Interval')
   contents.gsub!('Quantity', 'QDM::Quantity')
   File.open(file_name, 'w') { |file| file.puts contents }

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -246,6 +246,12 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   # Make relatedTo embeds_many instead of field
   contents.gsub!(/  field :relatedTo, type: Array\n/, "  embeds_many :relatedTo, class_name: 'QDM::Id'\n")
 
+  # Make prescriberId embeds_many instead of field
+  contents.gsub!(/  field :prescriberId, type: Id\n/, "  embeds_one :prescriberId, class_name: 'QDM::Id'\n")
+
+  # Make dispenserId embeds_many instead of field
+  contents.gsub!(/  field :dispenserId, type: Id\n/, "  embeds_one :dispenserId, class_name: 'QDM::Id'\n")
+
   File.open(file_name, 'w') { |file| file.puts contents }
 end
 

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -244,7 +244,7 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   contents.gsub!(/field :facilityLocation, type: Code/, 'field :facilityLocation, type: QDM::FacilityLocation')
 
   # Make relatedTo embeds_many instead of field
-  contents.gsub!(/  field :relatedTo, type: Array\n/, "  embeds_many :relatedTo, class_name: 'Id'\n")
+  contents.gsub!(/  field :relatedTo, type: Array\n/, "  embeds_many :relatedTo, class_name: 'QDM::Id'\n")
 
   File.open(file_name, 'w') { |file| file.puts contents }
 end
@@ -282,7 +282,7 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   contents = File.read(file_name)
   contents.gsub!('Qdm', 'QDM')
   contents.gsub!('Code', 'QDM::Code')
-  contents.gsub!('Id', 'QDM::Id')
+  contents.gsub!(' Id', ' QDM::Id')
   contents.gsub!('Interval', 'QDM::Interval')
   contents.gsub!('Quantity', 'QDM::Quantity')
   File.open(file_name, 'w') { |file| file.puts contents }


### PR DESCRIPTION
Regenerate models with Id => QDM::Id
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-460
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases NA
- [x] Tests have been run locally and pass NA
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated NA
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter NA

**Bonnie Reviewer:**

Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
