### PR TITLE
Observation values

### DIFF
--- a/app/assets/javascripts/IndividualResult.js
+++ b/app/assets/javascripts/IndividualResult.js
@@ -25,6 +25,7 @@ const IndividualResultSchema = mongoose.Schema(
     clause_results: Mixed,
     episode_results: Mixed,
     statement_results: Mixed,
+    observation_values: [Number],
 
     // This field is for application specific information only. If both Bonnie and
     // Cypress use a common field, it should be made a field on this model,

--- a/app/models/qdm/tacoma/individual_result.rb
+++ b/app/models/qdm/tacoma/individual_result.rb
@@ -23,6 +23,7 @@ module QDM
     field :clause_results, type: Hash
     field :episode_results, type: Hash
     field :statement_results, type: Hash
+    field :observation_values, type: Array, default: []
 
     # This field is for application specific information only. If both Bonnie and
     # Cypress use a common field, it should be made a field on this model,

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -1021,6 +1021,7 @@ const IndividualResultSchema = mongoose.Schema(
     clause_results: Mixed,
     episode_results: Mixed,
     statement_results: Mixed,
+    observation_values: [Number],
 
     // This field is for application specific information only. If both Bonnie and
     // Cypress use a common field, it should be made a field on this model,

--- a/dist/index.js
+++ b/dist/index.js
@@ -1021,6 +1021,7 @@ const IndividualResultSchema = mongoose.Schema(
     clause_results: Mixed,
     episode_results: Mixed,
     statement_results: Mixed,
+    observation_values: [Number],
 
     // This field is for application specific information only. If both Bonnie and
     // Cypress use a common field, it should be made a field on this model,

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe QDM do
     @patient_de2.qdmPatient.dataElements << QDM::Diagnosis.new(authorDatetime: DateTime.new(2010, 1, 1, 4, 0, 0), dataElementCodes: [QDM::Code.new('E08.311', 'ICD10CM'), QDM::Code.new('362.01', 'ICD9CM'), QDM::Code.new('4855003', 'SNOMEDCT')])
     @patient_de2.qdmPatient.dataElements << QDM::EncounterPerformed.new(authorDatetime: DateTime.new(2010, 1, 2, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 2, 4, 0, 0), DateTime.new(2010, 1, 2, 5, 0, 0)), principalDiagnosis: QDM::Code.new('SNOMEDCT', '419099009'), dataElementCodes: [QDM::Code.new('SNOMEDCT', '17436001'), QDM::Code.new('99241', 'CPT')], facilityLocations: [facility_location2])
     @patient_de2.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location2)
+
+    # An individual Result
+    @individualResult = QDM::IndividualResult.new()
   end
 
   after(:all) do
@@ -195,5 +198,9 @@ RSpec.describe QDM do
     id = QDM::Id.new(value: @patient_de1.qdmPatient.dataElements.first.id.value)
     expect(care_goal.relatedTo.first.value).to eq id.value
     @patient_de1.save
+  end
+
+  it 'individualResult has empty observation_values by default' do
+    expect(@individualResult.observation_values).to eq []
   end
 end

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe QDM do
     @patient_de2.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: DateTime.new(2010, 1, 3, 4, 0, 0), relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location2)
 
     # An individual Result
-    @individualResult = QDM::IndividualResult.new()
+    @individualResult = QDM::IndividualResult.new
   end
 
   after(:all) do

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -28,6 +28,7 @@ const FacilityLocation = require('./../../../app/assets/javascripts/attributes/F
 const FamilyHistory = require('./../../../app/assets/javascripts/FamilyHistory.js').FamilyHistory;
 const ImmunizationAdministered = require('./../../../app/assets/javascripts/ImmunizationAdministered.js').ImmunizationAdministered;
 const ImmunizationOrder = require('./../../../app/assets/javascripts/ImmunizationOrder.js').ImmunizationOrder;
+const IndividualResult = require('./../../../app/assets/javascripts/IndividualResult.js').IndividualResult;
 const InterventionOrder = require('./../../../app/assets/javascripts/InterventionOrder.js').InterventionOrder;
 const InterventionPerformed = require('./../../../app/assets/javascripts/InterventionPerformed.js').InterventionPerformed;
 const InterventionRecommended = require('./../../../app/assets/javascripts/InterventionRecommended.js').InterventionRecommended;
@@ -480,3 +481,9 @@ describe('CQLLibrary', () => {
   });
 });
 
+describe('IndividualResult', () => {
+  it('has empty observation_values by default', () => {
+    result = new IndividualResult();
+    expect(result.observation_values.length).toBe(0);
+  });
+});


### PR DESCRIPTION
`observation_values` was added to Individual Result because patient-based calculations allow for them and are needed in Bonnie.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1990
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
