### PR TITLE
Fix issues with Interval casting and add tests

### DIFF
--- a/app/assets/javascripts/basetypes/Interval.js
+++ b/app/assets/javascripts/basetypes/Interval.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const DateTime = require('./DateTime')
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');
@@ -23,17 +24,11 @@ Interval.prototype.cast = (interval) => {
 
   // Cast to DateTime if it is a string representing a DateTime
   if (casted.low) {
-    if (!Date.parse(casted.low)) {
-      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
-    }
-    casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
+    casted.low = DateTime.prototype.cast(casted.low);
   }
 
   if (casted.high) {
-    if (!Date.parse(casted.high)) {
-      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
-    }
-    casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
+    casted.high = DateTime.prototype.cast(casted.high);
   }
   return casted;
 };

--- a/app/assets/javascripts/basetypes/Interval.js
+++ b/app/assets/javascripts/basetypes/Interval.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
-const DateTime = require('./DateTime')
+const DateTime = require('./DateTime');
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');

--- a/app/assets/javascripts/basetypes/Interval.js
+++ b/app/assets/javascripts/basetypes/Interval.js
@@ -7,8 +7,8 @@ function Interval(key, options) {
 Interval.prototype = Object.create(mongoose.SchemaType.prototype);
 
 Interval.prototype.cast = (interval) => {
-  if (typeof interval.low === 'undefined' || interval.low === null) {
-    throw new Error(`Interval: ${interval} does not have a low value`);
+  if (interval.isInterval) {
+    return interval;
   }
   const casted = new cql.Interval(interval.low, interval.high, interval.lowClosed, interval.highClosed);
 
@@ -22,10 +22,17 @@ Interval.prototype.cast = (interval) => {
   }
 
   // Cast to DateTime if it is a string representing a DateTime
-  if (casted.low && Date.parse(casted.low)) {
+  if (casted.low) {
+    if (!Date.parse(casted.low)) {
+      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
+    }
     casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
   }
-  if (casted.high && Date.parse(casted.high)) {
+
+  if (casted.high) {
+    if (!Date.parse(casted.high)) {
+      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
+    }
     casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
   }
   return casted;

--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -64,7 +64,7 @@ const MeasureSchema = new mongoose.Schema(
     // HQMF/Tacoma-specific Measure-logic related data
     population_criteria: Mixed,
     source_data_criteria: [],
-    measure_period: Interval,
+    measure_period: Mixed,
     measure_attributes: [],
 
     population_sets: [PopulationSetSchema],

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3245,7 +3245,7 @@ const MeasureSchema = new mongoose.Schema(
     // HQMF/Tacoma-specific Measure-logic related data
     population_criteria: Mixed,
     source_data_criteria: [],
-    measure_period: Interval,
+    measure_period: Mixed,
     measure_attributes: [],
 
     population_sets: [PopulationSetSchema],

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3027,7 +3027,7 @@ module.exports = DateTime;
 },{"cql-execution":109,"mongoose/browser":247}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
-const DateTime = require('./DateTime')
+const DateTime = require('./DateTime');
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3027,6 +3027,7 @@ module.exports = DateTime;
 },{"cql-execution":109,"mongoose/browser":247}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const DateTime = require('./DateTime')
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');
@@ -3050,17 +3051,11 @@ Interval.prototype.cast = (interval) => {
 
   // Cast to DateTime if it is a string representing a DateTime
   if (casted.low) {
-    if (!Date.parse(casted.low)) {
-      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
-    }
-    casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
+    casted.low = DateTime.prototype.cast(casted.low);
   }
 
   if (casted.high) {
-    if (!Date.parse(casted.high)) {
-      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
-    }
-    casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
+    casted.high = DateTime.prototype.cast(casted.high);
   }
   return casted;
 };
@@ -3068,7 +3063,7 @@ Interval.prototype.cast = (interval) => {
 mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;
 
-},{"cql-execution":109,"mongoose/browser":247}],67:[function(require,module,exports){
+},{"./DateTime":65,"cql-execution":109,"mongoose/browser":247}],67:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3034,8 +3034,8 @@ function Interval(key, options) {
 Interval.prototype = Object.create(mongoose.SchemaType.prototype);
 
 Interval.prototype.cast = (interval) => {
-  if (typeof interval.low === 'undefined' || interval.low === null) {
-    throw new Error(`Interval: ${interval} does not have a low value`);
+  if (interval.isInterval) {
+    return interval;
   }
   const casted = new cql.Interval(interval.low, interval.high, interval.lowClosed, interval.highClosed);
 
@@ -3049,10 +3049,17 @@ Interval.prototype.cast = (interval) => {
   }
 
   // Cast to DateTime if it is a string representing a DateTime
-  if (casted.low && Date.parse(casted.low)) {
+  if (casted.low) {
+    if (!Date.parse(casted.low)) {
+      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
+    }
     casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
   }
-  if (casted.high && Date.parse(casted.high)) {
+
+  if (casted.high) {
+    if (!Date.parse(casted.high)) {
+      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
+    }
     casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
   }
   return casted;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3240,7 +3240,7 @@ const MeasureSchema = new mongoose.Schema(
     // HQMF/Tacoma-specific Measure-logic related data
     population_criteria: Mixed,
     source_data_criteria: [],
-    measure_period: Interval,
+    measure_period: Mixed,
     measure_attributes: [],
 
     population_sets: [PopulationSetSchema],

--- a/dist/index.js
+++ b/dist/index.js
@@ -3027,7 +3027,7 @@ module.exports = DateTime;
 },{"cql-execution":108,"mongoose/browser":246}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
-const DateTime = require('./DateTime')
+const DateTime = require('./DateTime');
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');

--- a/dist/index.js
+++ b/dist/index.js
@@ -3027,6 +3027,7 @@ module.exports = DateTime;
 },{"cql-execution":108,"mongoose/browser":246}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const DateTime = require('./DateTime')
 
 function Interval(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Interval');
@@ -3050,17 +3051,11 @@ Interval.prototype.cast = (interval) => {
 
   // Cast to DateTime if it is a string representing a DateTime
   if (casted.low) {
-    if (!Date.parse(casted.low)) {
-      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
-    }
-    casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
+    casted.low = DateTime.prototype.cast(casted.low);
   }
 
   if (casted.high) {
-    if (!Date.parse(casted.high)) {
-      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
-    }
-    casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
+    casted.high = DateTime.prototype.cast(casted.high);
   }
   return casted;
 };
@@ -3068,7 +3063,7 @@ Interval.prototype.cast = (interval) => {
 mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;
 
-},{"cql-execution":108,"mongoose/browser":246}],67:[function(require,module,exports){
+},{"./DateTime":65,"cql-execution":108,"mongoose/browser":246}],67:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3034,8 +3034,8 @@ function Interval(key, options) {
 Interval.prototype = Object.create(mongoose.SchemaType.prototype);
 
 Interval.prototype.cast = (interval) => {
-  if (typeof interval.low === 'undefined' || interval.low === null) {
-    throw new Error(`Interval: ${interval} does not have a low value`);
+  if (interval.isInterval) {
+    return interval;
   }
   const casted = new cql.Interval(interval.low, interval.high, interval.lowClosed, interval.highClosed);
 
@@ -3049,10 +3049,17 @@ Interval.prototype.cast = (interval) => {
   }
 
   // Cast to DateTime if it is a string representing a DateTime
-  if (casted.low && Date.parse(casted.low)) {
+  if (casted.low) {
+    if (!Date.parse(casted.low)) {
+      throw new Error(`DateTime: ${casted.low} is not a valid DateTime`);
+    }
     casted.low = cql.DateTime.fromJSDate(new Date(casted.low), 0);
   }
-  if (casted.high && Date.parse(casted.high)) {
+
+  if (casted.high) {
+    if (!Date.parse(casted.high)) {
+      throw new Error(`DateTime: ${casted.high} is not a valid DateTime`);
+    }
     casted.high = cql.DateTime.fromJSDate(new Date(casted.high), 0);
   }
   return casted;

--- a/spec/javascript/unit/basetype_spec.js
+++ b/spec/javascript/unit/basetype_spec.js
@@ -1,0 +1,69 @@
+const cql = require('cql-execution');
+
+const DateTime = require('./../../../app/assets/javascripts/basetypes/DateTime.js');
+const Interval = require('./../../../app/assets/javascripts/basetypes/Interval.js');
+
+describe('basetype DateTime', () => {
+  it('can create a DateTime from JS Date', () => {
+    const date = (new DateTime()).cast(new Date());
+    expect(date.isDateTime).toBe(true);
+  });
+
+  it('can create a DateTime from cql DateTime', () => {
+    const date = (new DateTime()).cast(new cql.DateTime(new Date()));
+    expect(date.isDateTime).toBe(true);
+  });
+  it('throws if invalid DateTime passed to cast', () => {
+    expect(() => { (new DateTime()).cast('some invalid DateTime arg'); }).toThrow();
+  });
+});
+
+describe('basetype Interval', () => {
+  it('can create an interval from cql.Interval of DateTime', () => {
+    const interval = (new Interval()).cast(new cql.Interval(new cql.DateTime(2012, 9, 9, 10, 45, 0, 0, 0), new cql.DateTime(2012, 10, 9, 10, 45, 0, 0, 0)));
+    expect(interval.highClosed).toBe(true);
+  });
+
+  it('can create an interval from cql.Interval[null,null]', () => {
+    const interval = (new Interval()).cast(new cql.Interval(null, null));
+    expect(interval.highClosed).toBe(true);
+  });
+
+  it('can create an interval from object with low: null, high: null]', () => {
+    const interval = (new Interval()).cast({ low: null, high: null });
+    expect(interval.lowClosed).toBe(true);
+    expect(interval.highClosed).toBe(true);
+    expect(interval.low).toBe(null);
+    expect(interval.high).toBe(null);
+  });
+
+  it('can create an interval of object with string high and low values', () => {
+    const interval = (new Interval()).cast({ low: '2019-06-11T20:14:55.000Z', high: '2019-06-11T20:15:00.000Z' });
+    expect(interval.low).toEqual(new cql.DateTime(2019, 6, 11, 20, 14, 55, 0, 0));
+    expect(interval.high).toEqual(new cql.DateTime(2019, 6, 11, 20, 15, 0, 0, 0));
+  });
+
+  it('throws error if invalid low date string is passed to cast', () => {
+    expect(() => { (new Interval()).cast({ low: 'not a date', high: '2019-06-11T20:15:00.000Z' }); }).toThrow();
+  });
+
+  it('throws error if invalid high date string is passed to cast', () => {
+    expect(() => { (new Interval()).cast({ low: '2019-06-11T20:14:55.000Z', high: 'not a date' }); }).toThrow();
+  });
+
+  it('can create an interval of quantities in object form', () => {
+    const interval = (new Interval()).cast({ low: { value: '30', unit: 'mg' }, high: { value: '60', unit: 'mg' } });
+    expect(interval.low).toEqual(new cql.Quantity({ value: '30', unit: 'mg' }));
+    expect(interval.high).toEqual(new cql.Quantity({ value: '60', unit: 'mg' }));
+  });
+
+  it('can create an interval of quantities in object form with no high value', () => {
+    const interval = (new Interval()).cast({ low: { value: '30', unit: 'mg' }, high: null });
+    expect(interval.low).toEqual(new cql.Quantity({ value: '30', unit: 'mg' }));
+    expect(interval.high).toEqual(null);
+  });
+
+  it('throws error if quantity in object has invalid unit', () => {
+    expect(() => { (new Interval()).cast({ low: { value: '30', unit: 'mcg' }, high: { value: '60', unit: 'mg' } }); }).toThrow();
+  });
+});

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -456,19 +456,6 @@ describe('PopulationSet', () => {
   });
 });
 
-describe('DateTime', () => {
-  it('can create a DateTime from JS Date', () => {
-    DateTime(new Date());
-  });
-
-  it('can create a DateTime from cql DateTime', () => {
-    DateTime(new cql.DateTime(new Date()));
-  });
-  it('throws if invalid DateTime passed to cast', () => {
-    expect(() => {DateTime.cast('some invalid DateTime arg')}).toThrow();
-  });
-});
-
 describe('CQLLibrary', () => {
   it('defaults to be top level', () => {
     library = new CQLLibrary();


### PR DESCRIPTION
- Fixes issues with Interval casting not allowing [null, null]
- Add short circuit for when it already is an Interval
- Fix minor issues with DateTime casting
- Added tests for DateTime and Interval casting in new file basetype_spec.js
- Moved existing tests for DateTime casting to basetype_spec.js and made them actual effective tests
- Fixed type def of Measure `measure_period` to match ruby side

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2033 https://jira.mitre.org/browse/BONNIE-2046
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] ~Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter~

**Bonnie Reviewer:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
