### PR TITLE
Codesystemoid

### DIFF
--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -10,20 +10,19 @@ function RecursiveCast(any) {
   if (any && any.value && any.unit) {
     return new cql.Quantity(any);
   }
-  if (any && any.code && any.codeSystem) {
+  if (any && any.code && (any.codeSystemOid || any.system)) {
     if (typeof any.code === 'undefined') {
       throw new Error(`Code: ${any} does not have a code`);
-    } else if (typeof any.codeSystem === 'undefined') {
-      throw new Error(`Code: ${any} does not have a codeSystem`);
+    } else if (typeof any.codeSystemOid === 'undefined' && typeof any.system === 'undefined') {
+      throw new Error(`Code: ${any} does not have a code system oid`);
     }
 
-    const val = { code: any.code, codeSystem: any.codeSystem };
+    const val = { code: any.code, codeSystemOid: any.codeSystemOid || any.system };
 
     val.descriptor = (typeof any.descriptor !== 'undefined') ? any.descriptor : null;
-    val.codeSystemOid = (typeof any.codeSystemOid !== 'undefined') ? any.codeSystemOid : null;
     val.version = (typeof any.version !== 'undefined') ? any.version : null;
 
-    return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+    return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
   }
   if (any && any.low) {
     const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);

--- a/app/assets/javascripts/basetypes/Code.js
+++ b/app/assets/javascripts/basetypes/Code.js
@@ -9,20 +9,19 @@ Code.prototype = Object.create(mongoose.SchemaType.prototype);
 Code.prototype.cast = (code) => {
   if (code != null) {
     // handles codes that have not yet been cast to a code and those that have already been cast to a code
-    if (code.code && (code.codeSystem || code.system)) {
+    if (code.code && (code.codeSystemOid || code.system)) {
       if (typeof code.code === 'undefined') {
         throw new Error(`Code: ${code} does not have a code`);
-      } else if (typeof code.codeSystem === 'undefined' && typeof code.system === 'undefined') {
-        throw new Error(`Code: ${code} does not have a system`);
+      } else if (typeof code.codeSystemOid === 'undefined' && typeof code.system === 'undefined') {
+        throw new Error(`Code: ${code} does not have a system oid`);
       }
 
-      const val = { code: code.code, codeSystem: code.codeSystem || code.system };
+      const val = { code: code.code, codeSystemOid: code.codeSystemOid || code.system };
 
       val.descriptor = (typeof code.descriptor !== 'undefined') ? code.descriptor : null;
-      val.codeSystemOid = (typeof code.codeSystemOid !== 'undefined') ? code.codeSystemOid : null;
       val.version = (typeof code.version !== 'undefined') ? code.version : null;
 
-      return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+      return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
     }
     throw new Error(`Expected a code. Received ${code}.`);
   } else {

--- a/app/assets/javascripts/basetypes/DataElement.js
+++ b/app/assets/javascripts/basetypes/DataElement.js
@@ -25,7 +25,7 @@ function DataElementSchema(add, options) {
   // Returns all of the codes on this data element in a format usable by
   // the cql-execution framework.
   extended.methods.getCode = function getCode() {
-    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystem, code.version, code.descriptor));
+    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystemOid, code.version, code.descriptor));
   };
 
   // Return the first code on this data element in a format usable by
@@ -33,7 +33,7 @@ function DataElementSchema(add, options) {
   extended.methods.code = function code() {
     if (this.dataElementCodes && this.dataElementCodes[0]) {
       const qdmCode = this.dataElementCodes[0];
-      return new cql.Code(qdmCode.code, qdmCode.codeSystem, qdmCode.version, qdmCode.descriptor);
+      return new cql.Code(qdmCode.code, qdmCode.codeSystemOid, qdmCode.version, qdmCode.descriptor);
     }
     return null;
   };

--- a/app/models/qdm/basetypes/code.rb
+++ b/app/models/qdm/basetypes/code.rb
@@ -4,7 +4,7 @@ module QDM
     attr_accessor :code, :codeSystem, :descriptor, :codeSystemOid, :version
 
     # Code and code system are required (at minimum).
-    def initialize(code, codeSystem, descriptor = nil, codeSystemOid = nil, version = nil)
+    def initialize(code, codeSystemOid, descriptor = nil, codeSystem = nil, version = nil)
       @code = code
       @codeSystem = codeSystem
       @descriptor = descriptor
@@ -14,7 +14,7 @@ module QDM
 
     # Converts an object of this instance into a database friendly value.
     def mongoize
-      { code: @code, codeSystem: @codeSystem, descriptor: @descriptor, codeSystemOid: @codeSystemOid, version: @version, _type: 'QDM::Code' }
+      { code: @code, codeSystemOid: @codeSystemOid, descriptor: @descriptor, codeSystem: @codeSystem, version: @version, _type: 'QDM::Code' }
     end
 
     class << self
@@ -26,7 +26,7 @@ module QDM
       def demongoize(object)
         return nil unless object
         object = object.symbolize_keys
-        QDM::Code.new(object[:code], object[:codeSystem], object[:descriptor], object[:codeSystemOid], object[:version])
+        QDM::Code.new(object[:code], object[:codeSystemOid], object[:descriptor], object[:codeSystem], object[:version])
       end
 
       # Takes any possible object and converts it to how it would be
@@ -37,8 +37,8 @@ module QDM
         when QDM::Code then object.mongoize
         when Hash
           object = object.symbolize_keys
-          codeSystem = object[:system] ? object[:system] : object[:codeSystem]
-          QDM::Code.new(object[:code], codeSystem, object[:descriptor], object[:codeSystemOid], object[:version]).mongoize
+          codeSystemOid = object[:system] ? object[:system] : object[:codeSystemOid]
+          QDM::Code.new(object[:code], codeSystemOid, object[:descriptor], object[:codeSystem], object[:version]).mongoize
         else object
         end
       end

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -31,7 +31,7 @@ module QDM
     # to the CQL execution engine.
     def code_system_pairs
       codes.collect do |code|
-        { code: code.code, system: code.codeSystem }
+        { code: code.code, system: code.codeSystemOid }
       end
     end
 

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2795,20 +2795,19 @@ function RecursiveCast(any) {
   if (any && any.value && any.unit) {
     return new cql.Quantity(any);
   }
-  if (any && any.code && any.codeSystem) {
+  if (any && any.code && (any.codeSystemOid || any.system)) {
     if (typeof any.code === 'undefined') {
       throw new Error(`Code: ${any} does not have a code`);
-    } else if (typeof any.codeSystem === 'undefined') {
-      throw new Error(`Code: ${any} does not have a codeSystem`);
+    } else if (typeof any.codeSystemOid === 'undefined' && typeof any.system === 'undefined') {
+      throw new Error(`Code: ${any} does not have a code system oid`);
     }
 
-    const val = { code: any.code, codeSystem: any.codeSystem };
+    const val = { code: any.code, codeSystemOid: any.codeSystemOid || any.system };
 
     val.descriptor = (typeof any.descriptor !== 'undefined') ? any.descriptor : null;
-    val.codeSystemOid = (typeof any.codeSystemOid !== 'undefined') ? any.codeSystemOid : null;
     val.version = (typeof any.version !== 'undefined') ? any.version : null;
 
-    return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+    return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
   }
   if (any && any.low) {
     const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);
@@ -2864,20 +2863,19 @@ Code.prototype = Object.create(mongoose.SchemaType.prototype);
 Code.prototype.cast = (code) => {
   if (code != null) {
     // handles codes that have not yet been cast to a code and those that have already been cast to a code
-    if (code.code && (code.codeSystem || code.system)) {
+    if (code.code && (code.codeSystemOid || code.system)) {
       if (typeof code.code === 'undefined') {
         throw new Error(`Code: ${code} does not have a code`);
-      } else if (typeof code.codeSystem === 'undefined' && typeof code.system === 'undefined') {
-        throw new Error(`Code: ${code} does not have a system`);
+      } else if (typeof code.codeSystemOid === 'undefined' && typeof code.system === 'undefined') {
+        throw new Error(`Code: ${code} does not have a system oid`);
       }
 
-      const val = { code: code.code, codeSystem: code.codeSystem || code.system };
+      const val = { code: code.code, codeSystemOid: code.codeSystemOid || code.system };
 
       val.descriptor = (typeof code.descriptor !== 'undefined') ? code.descriptor : null;
-      val.codeSystemOid = (typeof code.codeSystemOid !== 'undefined') ? code.codeSystemOid : null;
       val.version = (typeof code.version !== 'undefined') ? code.version : null;
 
-      return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+      return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
     }
     throw new Error(`Expected a code. Received ${code}.`);
   } else {
@@ -2917,7 +2915,7 @@ function DataElementSchema(add, options) {
   // Returns all of the codes on this data element in a format usable by
   // the cql-execution framework.
   extended.methods.getCode = function getCode() {
-    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystem, code.version, code.descriptor));
+    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystemOid, code.version, code.descriptor));
   };
 
   // Return the first code on this data element in a format usable by
@@ -2925,7 +2923,7 @@ function DataElementSchema(add, options) {
   extended.methods.code = function code() {
     if (this.dataElementCodes && this.dataElementCodes[0]) {
       const qdmCode = this.dataElementCodes[0];
-      return new cql.Code(qdmCode.code, qdmCode.codeSystem, qdmCode.version, qdmCode.descriptor);
+      return new cql.Code(qdmCode.code, qdmCode.codeSystemOid, qdmCode.version, qdmCode.descriptor);
     }
     return null;
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -2795,20 +2795,19 @@ function RecursiveCast(any) {
   if (any && any.value && any.unit) {
     return new cql.Quantity(any);
   }
-  if (any && any.code && any.codeSystem) {
+  if (any && any.code && (any.codeSystemOid || any.system)) {
     if (typeof any.code === 'undefined') {
       throw new Error(`Code: ${any} does not have a code`);
-    } else if (typeof any.codeSystem === 'undefined') {
-      throw new Error(`Code: ${any} does not have a codeSystem`);
+    } else if (typeof any.codeSystemOid === 'undefined' && typeof any.system === 'undefined') {
+      throw new Error(`Code: ${any} does not have a code system oid`);
     }
 
-    const val = { code: any.code, codeSystem: any.codeSystem };
+    const val = { code: any.code, codeSystemOid: any.codeSystemOid || any.system };
 
     val.descriptor = (typeof any.descriptor !== 'undefined') ? any.descriptor : null;
-    val.codeSystemOid = (typeof any.codeSystemOid !== 'undefined') ? any.codeSystemOid : null;
     val.version = (typeof any.version !== 'undefined') ? any.version : null;
 
-    return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+    return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
   }
   if (any && any.low) {
     const casted = new cql.Interval(any.low, any.high, any.lowClosed, any.highClosed);
@@ -2864,20 +2863,19 @@ Code.prototype = Object.create(mongoose.SchemaType.prototype);
 Code.prototype.cast = (code) => {
   if (code != null) {
     // handles codes that have not yet been cast to a code and those that have already been cast to a code
-    if (code.code && (code.codeSystem || code.system)) {
+    if (code.code && (code.codeSystemOid || code.system)) {
       if (typeof code.code === 'undefined') {
         throw new Error(`Code: ${code} does not have a code`);
-      } else if (typeof code.codeSystem === 'undefined' && typeof code.system === 'undefined') {
-        throw new Error(`Code: ${code} does not have a system`);
+      } else if (typeof code.codeSystemOid === 'undefined' && typeof code.system === 'undefined') {
+        throw new Error(`Code: ${code} does not have a system oid`);
       }
 
-      const val = { code: code.code, codeSystem: code.codeSystem || code.system };
+      const val = { code: code.code, codeSystemOid: code.codeSystemOid || code.system };
 
       val.descriptor = (typeof code.descriptor !== 'undefined') ? code.descriptor : null;
-      val.codeSystemOid = (typeof code.codeSystemOid !== 'undefined') ? code.codeSystemOid : null;
       val.version = (typeof code.version !== 'undefined') ? code.version : null;
 
-      return new cql.Code(val.code, val.codeSystem, val.version, val.descriptor);
+      return new cql.Code(val.code, val.codeSystemOid, val.version, val.descriptor);
     }
     throw new Error(`Expected a code. Received ${code}.`);
   } else {
@@ -2917,7 +2915,7 @@ function DataElementSchema(add, options) {
   // Returns all of the codes on this data element in a format usable by
   // the cql-execution framework.
   extended.methods.getCode = function getCode() {
-    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystem, code.version, code.descriptor));
+    return this.dataElementCodes.map(code => new cql.Code(code.code, code.codeSystemOid, code.version, code.descriptor));
   };
 
   // Return the first code on this data element in a format usable by
@@ -2925,7 +2923,7 @@ function DataElementSchema(add, options) {
   extended.methods.code = function code() {
     if (this.dataElementCodes && this.dataElementCodes[0]) {
       const qdmCode = this.dataElementCodes[0];
-      return new cql.Code(qdmCode.code, qdmCode.codeSystem, qdmCode.version, qdmCode.descriptor);
+      return new cql.Code(qdmCode.code, qdmCode.codeSystemOid, qdmCode.version, qdmCode.descriptor);
     }
     return null;
   };

--- a/lib/generate_types.rb
+++ b/lib/generate_types.rb
@@ -20,7 +20,7 @@ module QDM
 
     def self.generate_code_field
       # TODO: use code with all parameters, possibly randomize parameter values and optional information
-      QDM::Code.new('1234', 'SNOMEDCT')
+      QDM::Code.new('1234', '2.16.840.1.113883.6.96')
     end
 
     def self.generate_datetime


### PR DESCRIPTION
Use codesystem oid for primary identifier instead of name
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-519
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
