### PR TITLE
Add QDM::Date as a basetype

### DIFF
--- a/app/assets/javascripts/basetypes/QDMDate.js
+++ b/app/assets/javascripts/basetypes/QDMDate.js
@@ -7,10 +7,29 @@ function QDMDate(key, options) {
 QDMDate.prototype = Object.create(mongoose.SchemaType.prototype);
 
 QDMDate.prototype.cast = (date) => {
-  if (!Date.parse(date)) {
-    throw new Error(`Date: ${date} is not a valid Date`);
+  if (date == null) {
+    return date;
   }
-  return cql.Date.fromJSDate(new Date(date));
+
+  // Already a CQL Date
+  if (date.isDate) {
+    return date;
+  }
+
+  // Object
+  if (typeof date === 'object') {
+    const keys = Object.keys(date);
+    if (keys.includes('year') && keys.includes('month') && keys.includes('day')) {
+      return new cql.Date(date.year, date.month, date.day);
+    }
+  }
+
+  // Date String
+  if (!cql.Date.parse(date)) {
+    throw new Error(`Date: ${date} is not a valid Date`);
+  } else {
+    return cql.Date.parse(date);
+  }
 };
 
 mongoose.Schema.Types.QDMDate = QDMDate;

--- a/app/models/models.rb
+++ b/app/models/models.rb
@@ -13,6 +13,7 @@ require_relative 'qdm/attributes/identifier'
 # base types
 require_relative 'qdm/basetypes/code'
 require_relative 'qdm/basetypes/data_element'
+require_relative 'qdm/basetypes/date'
 require_relative 'qdm/basetypes/interval'
 require_relative 'qdm/basetypes/quantity'
 require_relative 'qdm/basetypes/ratio'

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -95,7 +95,7 @@ module QDM
           if send(field).year + year_shift > 9999 || send(field).year + year_shift < 1
             raise RangeError, 'Year was shifted after 9999 or before 0001'
           end
-          if send(field).month == 2 && send(field).day == 29 && !Date.leap?(year_shift + send(field).year)
+          if send(field).month == 2 && send(field).day == 29 && !::Date.leap?(year_shift + send(field).year)
             send(field + '=', send(field).change(year: year_shift + send(field).year, day: 28))
           else
             send(field + '=', send(field).change(year: year_shift + send(field).year))

--- a/app/models/qdm/basetypes/date.rb
+++ b/app/models/qdm/basetypes/date.rb
@@ -1,0 +1,38 @@
+module QDM
+  # Represents a QDM/CQL Date
+  class Date
+    attr_accessor :year, :month, :day
+
+    def initialize(year = nil, month = nil, day = nil)
+      @year = year
+      @month = month
+      @day = day
+    end
+
+    # Converts an object of this instance into a database friendly value.
+    def mongoize
+      "#{format('%04d', year)}-#{format('%02d', month)}-#{format('%02d', day)}"
+    end
+
+    class << self
+      # Get the string as it was stored in the database, and instantiate
+      # this custom class from it.
+      def demongoize(date_str)
+        return nil unless date_str
+        year = date_str[0..3].to_i
+        month = date_str[5..6].to_i
+        day = date_str[8..10].to_i
+        QDM::Date.new(year, month, day)
+      end
+
+      # Converts the object that was supplied to a criteria and converts it
+      # into a database friendly form.
+      def evolve(object)
+        case object
+        when QDM::Date then object.mongoize
+        else object
+        end
+      end
+    end
+  end
+end

--- a/app/models/qdm/basetypes/interval.rb
+++ b/app/models/qdm/basetypes/interval.rb
@@ -38,7 +38,7 @@ module QDM
           raise RangeError, 'Year was shifted after 9999 or before 0001'
         end
         low_shift = @low.year + year_shift
-        @low = if @low.month == 2 && @low.day == 29 && !Date.leap?(low_shift)
+        @low = if @low.month == 2 && @low.day == 29 && !::Date.leap?(low_shift)
                  @low.change(year: low_shift, day: 28)
                else
                  @low.change(year: low_shift)
@@ -49,7 +49,7 @@ module QDM
           raise RangeError, 'Year was shifted after 9999 or before 0001'
         end
         high_shift = @high.year + year_shift
-        @high = if @high.month == 2 && @high.day == 29 && !Date.leap?(high_shift)
+        @high = if @high.month == 2 && @high.day == 29 && !::Date.leap?(high_shift)
                   @high.change(year: high_shift, day: 28)
                 else
                   @high.change(year: high_shift)

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3653,10 +3653,29 @@ function QDMDate(key, options) {
 QDMDate.prototype = Object.create(mongoose.SchemaType.prototype);
 
 QDMDate.prototype.cast = (date) => {
-  if (!Date.parse(date)) {
-    throw new Error(`Date: ${date} is not a valid Date`);
+  if (date == null) {
+    return date;
   }
-  return cql.Date.fromJSDate(new Date(date));
+
+  // Already a CQL Date
+  if (date.isDate) {
+    return date;
+  }
+
+  // Object
+  if (typeof date === 'object') {
+    const keys = Object.keys(date);
+    if (keys.includes('year') && keys.includes('month') && keys.includes('day')) {
+      return new cql.Date(date.year, date.month, date.day);
+    }
+  }
+
+  // Date String
+  if (!cql.Date.parse(date)) {
+    throw new Error(`Date: ${date} is not a valid Date`);
+  } else {
+    return cql.Date.parse(date);
+  }
 };
 
 mongoose.Schema.Types.QDMDate = QDMDate;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3653,10 +3653,29 @@ function QDMDate(key, options) {
 QDMDate.prototype = Object.create(mongoose.SchemaType.prototype);
 
 QDMDate.prototype.cast = (date) => {
-  if (!Date.parse(date)) {
-    throw new Error(`Date: ${date} is not a valid Date`);
+  if (date == null) {
+    return date;
   }
-  return cql.Date.fromJSDate(new Date(date));
+
+  // Already a CQL Date
+  if (date.isDate) {
+    return date;
+  }
+
+  // Object
+  if (typeof date === 'object') {
+    const keys = Object.keys(date);
+    if (keys.includes('year') && keys.includes('month') && keys.includes('day')) {
+      return new cql.Date(date.year, date.month, date.day);
+    }
+  }
+
+  // Date String
+  if (!cql.Date.parse(date)) {
+    throw new Error(`Date: ${date} is not a valid Date`);
+  } else {
+    return cql.Date.parse(date);
+  }
 };
 
 mongoose.Schema.Types.QDMDate = QDMDate;

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -320,6 +320,7 @@ Dir.glob(ruby_models_path + '*.rb').each do |file_name|
   contents = File.read(file_name)
   contents.gsub!('Qdm', 'QDM')
   contents.gsub!('Code', 'QDM::Code')
+  contents.gsub!('Date\n', 'QDM::Date\n') # \n so DateTime does not get overwritten
   contents.gsub!(' Identifier', ' QDM::Identifier')
   contents.gsub!('Interval', 'QDM::Interval')
   contents.gsub!('Quantity', 'QDM::Quantity')

--- a/spec/javascript/unit/basetype_spec.js
+++ b/spec/javascript/unit/basetype_spec.js
@@ -22,12 +22,17 @@ describe('basetype DateTime', () => {
 });
 
 describe('basetype Date', () => {
-  it('can create a Date from JS Date', () => {
-    const date = (new QDMDate()).cast(new Date());
+  it('can create a Date from Date String', () => {
+    const date = (new QDMDate()).cast('1984-02-03');
     expect(date.isDate).toBe(true);
   });
   it('can create a Date from cql Date', () => {
     const date = (new QDMDate()).cast(new cql.Date.fromJSDate(new Date()));
+    expect(date.isDate).toBe(true);
+  });
+
+  it('can create a Date from Date object', () => {
+    const date = (new QDMDate()).cast({year: 1984, month: 2, day: 3});
     expect(date.isDate).toBe(true);
   });
   it('throws if invalid DateTime passed to cast', () => {

--- a/templates/models_template.rb.erb
+++ b/templates/models_template.rb.erb
@@ -13,6 +13,7 @@ require_relative 'qdm/attributes/identifier'
 # base types
 require_relative 'qdm/basetypes/code'
 require_relative 'qdm/basetypes/data_element'
+require_relative 'qdm/basetypes/date'
 require_relative 'qdm/basetypes/interval'
 require_relative 'qdm/basetypes/quantity'
 require_relative 'qdm/basetypes/ratio'


### PR DESCRIPTION
Dates were being stored as Ruby `::Date`s rather than the CQL Date strings.

Fix issue where QDMDate cast was altering the day due to timezone issues:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/14879344/61313279-222a3500-a7c8-11e9-868b-d9169915b7a0.png">

Extend QDMDate casting to support Date, String, Object
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2076
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases (coverage drops due to mongoid functions which we don't test in this repo)
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
