### PR TITLE
do not shift Time values

### DIFF
--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -92,6 +92,8 @@ module QDM
     def shift_years(year_shift)
       fields.keys.each do |field|
         if send(field).is_a? DateTime
+          # Do not shift Time values. They are stored as DateTimes with year 0.
+          next if send(field).year == 0
           if send(field).year + year_shift > 9999 || send(field).year + year_shift < 1
             raise RangeError, 'Year was shifted after 9999 or before 0001'
           end

--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -93,7 +93,7 @@ module QDM
       fields.keys.each do |field|
         if send(field).is_a? DateTime
           # Do not shift Time values. They are stored as DateTimes with year 0.
-          next if send(field).year == 0
+          next if send(field).year.zero?
           if send(field).year + year_shift > 9999 || send(field).year + year_shift < 1
             raise RangeError, 'Year was shifted after 9999 or before 0001'
           end

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe QDM do
     @patient_big.qdmPatient.dataElements << QDM::EncounterPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('SNOMEDCT', '17436001'), QDM::Code.new('99241', 'CPT')], facilityLocations: [facility_location1, facility_location2])
     @patient_big.qdmPatient.dataElements << QDM::CommunicationPerformed.new(authorDatetime: 3.years.ago, dataElementCodes: [QDM::Code.new('SNOMEDCT', '428341000124108')])
     @patient_big.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location1)
-    @patient_big.qdmPatient.dataElements << QDM::LaboratoryTestPerformed.new(patient: @patient_big, authorDatetime: 3.years.ago, result: DateTime.new(0,1,1,2,2,1), relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '34714-6')])
+    @patient_big.qdmPatient.dataElements << QDM::LaboratoryTestPerformed.new(patient: @patient_big, authorDatetime: 3.years.ago, result: DateTime.new(0, 1, 1, 2, 2, 1), relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '34714-6')])
 
     # Patient with some data elements
     bd = 70.years.ago

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe QDM do
     @patient_big.qdmPatient.dataElements << QDM::EncounterPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('SNOMEDCT', '17436001'), QDM::Code.new('99241', 'CPT')], facilityLocations: [facility_location1, facility_location2])
     @patient_big.qdmPatient.dataElements << QDM::CommunicationPerformed.new(authorDatetime: 3.years.ago, dataElementCodes: [QDM::Code.new('SNOMEDCT', '428341000124108')])
     @patient_big.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location1)
+    @patient_big.qdmPatient.dataElements << QDM::LaboratoryTestPerformed.new(patient: @patient_big, authorDatetime: 3.years.ago, result: DateTime.new(0,1,1,2,2,1), relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '34714-6')])
 
     # Patient with some data elements
     bd = 70.years.ago
@@ -231,6 +232,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.get_data_elements('encounter').first.get('facilityLocations').first['locationPeriod'][:high].utc.to_s).to include('2014-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2014-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2014-02-28')
+    expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
   end
 
   it 'shift years backward' do
@@ -246,6 +248,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.get_data_elements('encounter').first.get('facilityLocations').first['locationPeriod'][:high].utc.to_s).to include('2010-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2010-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2010-02-28')
+    expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
   end
 
   it 'shift years too far backward' do
@@ -265,6 +268,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.get_data_elements('encounter').first.get('facilityLocations').first['locationPeriod'][:high].utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
+    expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
   end
 
   it 'shift years too far forward' do
@@ -285,6 +289,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.get_data_elements('encounter').first.get('facilityLocations').first['locationPeriod'][:high].utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
+    expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
   end
 
   it 'interval low and high get shifted out of range' do


### PR DESCRIPTION
Do not shift Time values that are stored as DateTimes with year == 0. Everything else should be shifted.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2081
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
