### PR TITLE
Checking QDM Dates for Measure period shift years

### DIFF
--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -91,14 +91,25 @@ module QDM
     # back to the 28th in non leap years
     def shift_years(year_shift)
       fields.keys.each do |field|
-        if send(field).is_a? DateTime
+        if send(field).is_a?(QDM::Date) || send(field).is_a?(DateTime)
           # Do not shift Time values. They are stored as DateTimes with year 0.
           next if send(field).year.zero?
           if send(field).year + year_shift > 9999 || send(field).year + year_shift < 1
             raise RangeError, 'Year was shifted after 9999 or before 0001'
           end
           if send(field).month == 2 && send(field).day == 29 && !::Date.leap?(year_shift + send(field).year)
-            send(field + '=', send(field).change(year: year_shift + send(field).year, day: 28))
+            if send(field).is_a?(QDM::Date)
+              shifted_date = send(field)
+              shifted_date.year = shifted_date.year + year_shift
+              shifted_date.day = 28
+              send(field + '=', shifted_date)
+            else
+              send(field + '=', send(field).change(year: year_shift + send(field).year, day: 28))
+            end
+          elsif send(field).is_a?(QDM::Date)
+            shifted_date = send(field)
+            shifted_date.year = shifted_date.year + year_shift
+            send(field + '=', shifted_date)
           else
             send(field + '=', send(field).change(year: year_shift + send(field).year))
           end

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe QDM do
     @patient_big.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location1)
     @patient_big.qdmPatient.dataElements << QDM::LaboratoryTestPerformed.new(patient: @patient_big, authorDatetime: 3.years.ago, result: DateTime.new(0, 1, 1, 2, 2, 1), relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '34714-6')])
     @patient_big.qdmPatient.dataElements << QDM::CareGoal.new(relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], statusDate: QDM::Date.new(2010, 1, 12))
+    @patient_big.qdmPatient.dataElements << QDM::CareGoal.new(relevantPeriod: QDM::Interval.new(DateTime.new(2004, 1, 3, 4, 0, 0), DateTime.new(2004, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], statusDate: QDM::Date.new(2004, 2, 29))
 
     # Patient with some data elements
     bd = 70.years.ago
@@ -235,6 +236,8 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2014-02-28')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
     expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2012)
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal')[1].get('statusDate').year).to eq(2006)
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal')[1].get('statusDate').day).to eq(28)
   end
 
   it 'shift years backward' do
@@ -252,6 +255,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2010-02-28')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
     expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2008)
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal')[1].get('statusDate').year).to eq(2002)
   end
 
   it 'shift years too far backward' do
@@ -273,6 +277,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
     expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2010)
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal')[1].get('statusDate').year).to eq(2004)
   end
 
   it 'shift years too far forward' do
@@ -295,6 +300,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
     expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2010)
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal')[1].get('statusDate').year).to eq(2004)
   end
 
   it 'interval low and high get shifted out of range' do

--- a/spec/cqm/models_spec.rb
+++ b/spec/cqm/models_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe QDM do
     @patient_big.qdmPatient.dataElements << QDM::CommunicationPerformed.new(authorDatetime: 3.years.ago, dataElementCodes: [QDM::Code.new('SNOMEDCT', '428341000124108')])
     @patient_big.qdmPatient.dataElements << QDM::DiagnosticStudyPerformed.new(authorDatetime: 3.years.ago, relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], facilityLocation: facility_location1)
     @patient_big.qdmPatient.dataElements << QDM::LaboratoryTestPerformed.new(patient: @patient_big, authorDatetime: 3.years.ago, result: DateTime.new(0, 1, 1, 2, 2, 1), relevantPeriod: QDM::Interval.new(3.years.ago, 3.years.ago + 1.hour), dataElementCodes: [QDM::Code.new('LOINC', '34714-6')])
+    @patient_big.qdmPatient.dataElements << QDM::CareGoal.new(relevantPeriod: QDM::Interval.new(DateTime.new(2010, 1, 3, 4, 0, 0), DateTime.new(2010, 1, 3, 5, 0, 0)), dataElementCodes: [QDM::Code.new('LOINC', '32451-7')], statusDate: QDM::Date.new(2010, 1, 12))
 
     # Patient with some data elements
     bd = 70.years.ago
@@ -233,6 +234,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2014-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2014-02-28')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2012)
   end
 
   it 'shift years backward' do
@@ -249,6 +251,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2010-02-28')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2010-02-28')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2008)
   end
 
   it 'shift years too far backward' do
@@ -269,6 +272,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2010)
   end
 
   it 'shift years too far forward' do
@@ -290,6 +294,7 @@ RSpec.describe QDM do
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.low.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.diagnostic_studies.first.facilityLocation.locationPeriod.high.utc.to_s).to include('2012-02-29')
     expect(@patient_big.qdmPatient.get_data_elements('laboratory_test').first.get('result').utc.to_s).to include('0000-01-01')
+    expect(@patient_big.qdmPatient.get_data_elements('care_goal').first.get('statusDate').year).to eq(2010)
   end
 
   it 'interval low and high get shifted out of range' do


### PR DESCRIPTION
**The branch name is called `relevant_period_shift_fix'` but just to clarify in case this causes confusion, I meant to name it `measure_period_shift_fix` and didn't realize my mistake till I had already pushed. 

This PR addresses the issue of a StatusDate dataAttribute not having it's year shifted to reflect the new Measure Period. To test this PR, you can (1) run bonnie on the `model-update-rake-task` branch (which currently references this models branch) (2) load the 'MsrNewQDM_v5_8_Artifacts.zip' measure that JB previously emailed out (3) go into that measure and create and save a new patient with a 'StatusDate' attribute (remember the date) (4) go back to the measure view and change the Measurement Period (5) go back to the patient builder view and verify the StatusDate has been appropriately shifted to match the Measurement Period shift.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2092
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated: N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter: N/A

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
