### PR TITLE
Data element code

### DIFF
--- a/app/assets/javascripts/attributes/Identifier.js
+++ b/app/assets/javascripts/attributes/Identifier.js
@@ -9,6 +9,7 @@ const IdentifierSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.5' },
+  _type: { type: String, default: 'QDM::Identifier' },
 
 }, { _id: false, id: false });
 
@@ -16,6 +17,7 @@ module.exports.IdentifierSchema = IdentifierSchema;
 class Identifier extends mongoose.Document {
   constructor(object) {
     super(object, IdentifierSchema);
+    this._type = 'QDM::Identifier';
   }
 }
 module.exports.Identifier = Identifier;

--- a/app/assets/javascripts/basetypes/DataElement.js
+++ b/app/assets/javascripts/basetypes/DataElement.js
@@ -7,7 +7,7 @@ const [Schema] = [mongoose.Schema];
 
 function DataElementSchema(add, options) {
   const extended = new Schema({
-    dataElementCodes: { type: [] },
+    dataElementCodes: { type: [Code] },
     description: { type: String },
     codeListId: { type: String },
     id: {

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3224,6 +3224,7 @@ const IdentifierSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.5' },
+  _type: { type: String, default: 'QDM::Identifier' },
 
 }, { _id: false, id: false });
 
@@ -3231,6 +3232,7 @@ module.exports.IdentifierSchema = IdentifierSchema;
 class Identifier extends mongoose.Document {
   constructor(object) {
     super(object, IdentifierSchema);
+    this._type = 'QDM::Identifier';
   }
 }
 module.exports.Identifier = Identifier;

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3536,7 +3536,7 @@ const [Schema] = [mongoose.Schema];
 
 function DataElementSchema(add, options) {
   const extended = new Schema({
-    dataElementCodes: { type: [] },
+    dataElementCodes: { type: [Code] },
     description: { type: String },
     codeListId: { type: String },
     id: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3224,6 +3224,7 @@ const IdentifierSchema = mongoose.Schema({
   namingSystem: String,
   value: String,
   qdmVersion: { type: String, default: '5.5' },
+  _type: { type: String, default: 'QDM::Identifier' },
 
 }, { _id: false, id: false });
 
@@ -3231,6 +3232,7 @@ module.exports.IdentifierSchema = IdentifierSchema;
 class Identifier extends mongoose.Document {
   constructor(object) {
     super(object, IdentifierSchema);
+    this._type = 'QDM::Identifier';
   }
 }
 module.exports.Identifier = Identifier;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3536,7 +3536,7 @@ const [Schema] = [mongoose.Schema];
 
 function DataElementSchema(add, options) {
   const extended = new Schema({
-    dataElementCodes: { type: [] },
+    dataElementCodes: { type: [Code] },
     description: { type: String },
     codeListId: { type: String },
     id: {

--- a/lib/generate_models.rb
+++ b/lib/generate_models.rb
@@ -208,8 +208,8 @@ datatypes.each do |datatype, info|
     renderer = ERB.new(File.read(datatype_custom_templates[datatype.to_sym]), nil, '-')
   end
   attrs_with_extras = info[:attributes] # this field gets used in the template
-  # Custom datatypes don't need _type
-  unless datatype_custom_templates.key?(datatype.to_sym)
+  # QDMPatients don't need _type
+  unless datatype.to_s == 'QDMPatient'
     attrs_with_extras << { name: '_type', type: 'System.String', default: "QDM::#{datatype.underscore.camelize}" } # Add Class
   end
   puts '  ' + file_path + datatype + '.js'

--- a/templates/identifier_template.js.erb
+++ b/templates/identifier_template.js.erb
@@ -15,6 +15,7 @@ module.exports.IdentifierSchema = IdentifierSchema;
 class Identifier extends mongoose.Document {
   constructor(object) {
     super(object, IdentifierSchema);
+    this._type = 'QDM::<%= datatype %>';
   }
 }
 module.exports.Identifier = Identifier;


### PR DESCRIPTION
2 Changes:

Add type [Code] to dataElementCodes
add _type QDM::Identifier to Identifier

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2106 https://jira.mitre.org/browse/BONNIE-2104
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter NOTE: converter was run and there were differences, but none were related to this PR.

**Bonnie Reviewer:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
