### PR TITLE
Add dataElements cache to findRecords

### DIFF
--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -101,10 +101,8 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
     QDMPatientSchema._dataElementCache = {};
     QDMPatientSchema._dataElementCachePatientId = this._id.toString();
-    console.log('cache reset');
   }
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    console.log('Cache hit');
     return QDMPatientSchema._dataElementCache[profile];
   }
   let profileStripped;
@@ -112,13 +110,11 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
     QDMPatientSchema._dataElementCache[profile] = [info];
-    console.log('Cache miss');
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
@@ -135,18 +131,15 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     }
     // No negation status, proceed normally
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   }
   return [];

--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -97,11 +97,13 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @param {String} profile - the data criteria requested by the execution engine
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
+  // Clear profile cache for this patient if there is no cache or the patient has changed
   if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
+    || QDMPatientSchema._dataElementCachePatientId != this._id) {
     QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id.toString();
+    QDMPatientSchema._dataElementCachePatientId = this._id;
   }
+  // If there is a cache 'hit', return it
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
     return QDMPatientSchema._dataElementCache[profile];
   }

--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -98,26 +98,26 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
   // Clear profile cache for this patient if there is no cache or the patient has changed
-  if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id) {
-    QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id;
+  if (QDMPatientSchema.dataElementCache == null
+    || QDMPatientSchema.dataElementCachePatientId !== this._id) {
+    QDMPatientSchema.dataElementCache = {};
+    QDMPatientSchema.dataElementCachePatientId = this._id;
   }
   // If there is a cache 'hit', return it
-  if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    return QDMPatientSchema._dataElementCache[profile];
+  if (Object.prototype.hasOwnProperty.call(QDMPatientSchema.dataElementCache, profile)) {
+    return QDMPatientSchema.dataElementCache[profile];
   }
   let profileStripped;
   if (profile === 'Patient') {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
-    QDMPatientSchema._dataElementCache[profile] = [info];
+    QDMPatientSchema.dataElementCache[profile] = [info];
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
 
@@ -132,17 +132,17 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     if (/Positive/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, false);
+      return QDMPatientSchema.dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, true);
+      return QDMPatientSchema.dataElementCache[profile];
     }
     // No negation status, proceed normally
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   }
   return [];
 };
@@ -261,6 +261,11 @@ QDMPatientSchema.methods.transfers = function transfers() {
 
 QDMPatientSchema.methods.vital_signs = function vital_signs() {
   return this.getDataElements({ qdmCategory: 'vital_sign' });
+};
+
+QDMPatientSchema.clearDataElementCache = function clearDataElementCache() {
+  QDMPatientSchema.dataElementCachePatientId = null;
+  QDMPatientSchema.dataElementCache = null;
 };
 
 module.exports.QDMPatientSchema = QDMPatientSchema;

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2556,26 +2556,26 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
   // Clear profile cache for this patient if there is no cache or the patient has changed
-  if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id) {
-    QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id;
+  if (QDMPatientSchema.dataElementCache == null
+    || QDMPatientSchema.dataElementCachePatientId !== this._id) {
+    QDMPatientSchema.dataElementCache = {};
+    QDMPatientSchema.dataElementCachePatientId = this._id;
   }
   // If there is a cache 'hit', return it
-  if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    return QDMPatientSchema._dataElementCache[profile];
+  if (Object.prototype.hasOwnProperty.call(QDMPatientSchema.dataElementCache, profile)) {
+    return QDMPatientSchema.dataElementCache[profile];
   }
   let profileStripped;
   if (profile === 'Patient') {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
-    QDMPatientSchema._dataElementCache[profile] = [info];
+    QDMPatientSchema.dataElementCache[profile] = [info];
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
 
@@ -2590,17 +2590,17 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     if (/Positive/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, false);
+      return QDMPatientSchema.dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, true);
+      return QDMPatientSchema.dataElementCache[profile];
     }
     // No negation status, proceed normally
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   }
   return [];
 };
@@ -2719,6 +2719,11 @@ QDMPatientSchema.methods.transfers = function transfers() {
 
 QDMPatientSchema.methods.vital_signs = function vital_signs() {
   return this.getDataElements({ qdmCategory: 'vital_sign' });
+};
+
+QDMPatientSchema.clearDataElementCache = function clearDataElementCache() {
+  QDMPatientSchema.dataElementCachePatientId = null;
+  QDMPatientSchema.dataElementCache = null;
 };
 
 module.exports.QDMPatientSchema = QDMPatientSchema;

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2559,10 +2559,8 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
     QDMPatientSchema._dataElementCache = {};
     QDMPatientSchema._dataElementCachePatientId = this._id.toString();
-    console.log('cache reset');
   }
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    console.log('Cache hit');
     return QDMPatientSchema._dataElementCache[profile];
   }
   let profileStripped;
@@ -2570,13 +2568,11 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
     QDMPatientSchema._dataElementCache[profile] = [info];
-    console.log('Cache miss');
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
@@ -2593,18 +2589,15 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     }
     // No negation status, proceed normally
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   }
   return [];

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2555,15 +2555,29 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @param {String} profile - the data criteria requested by the execution engine
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
+  if (QDMPatientSchema._dataElementCache == null
+    || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
+    QDMPatientSchema._dataElementCache = {};
+    QDMPatientSchema._dataElementCachePatientId = this._id.toString();
+    console.log('cache reset');
+  }
+  if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
+    console.log('Cache hit');
+    return QDMPatientSchema._dataElementCache[profile];
+  }
   let profileStripped;
   if (profile === 'Patient') {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
+    QDMPatientSchema._dataElementCache[profile] = [info];
+    console.log('Cache miss');
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
-    return this.getByProfile(profileStripped);
+    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
+    console.log('Cache miss');
+    return QDMPatientSchema._dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
 
@@ -2578,14 +2592,20 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     if (/Positive/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
-      return this.getByProfile(profileStripped, false);
+      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
+      console.log('Cache miss');
+      return QDMPatientSchema._dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
-      return this.getByProfile(profileStripped, true);
+      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
+      console.log('Cache miss');
+      return QDMPatientSchema._dataElementCache[profile];
     }
     // No negation status, proceed normally
-    return this.getByProfile(profileStripped);
+    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
+    console.log('Cache miss');
+    return QDMPatientSchema._dataElementCache[profile];
   }
   return [];
 };

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -2555,11 +2555,13 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @param {String} profile - the data criteria requested by the execution engine
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
+  // Clear profile cache for this patient if there is no cache or the patient has changed
   if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
+    || QDMPatientSchema._dataElementCachePatientId != this._id) {
     QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id.toString();
+    QDMPatientSchema._dataElementCachePatientId = this._id;
   }
+  // If there is a cache 'hit', return it
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
     return QDMPatientSchema._dataElementCache[profile];
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2556,26 +2556,26 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
   // Clear profile cache for this patient if there is no cache or the patient has changed
-  if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id) {
-    QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id;
+  if (QDMPatientSchema.dataElementCache == null
+    || QDMPatientSchema.dataElementCachePatientId !== this._id) {
+    QDMPatientSchema.dataElementCache = {};
+    QDMPatientSchema.dataElementCachePatientId = this._id;
   }
   // If there is a cache 'hit', return it
-  if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    return QDMPatientSchema._dataElementCache[profile];
+  if (Object.prototype.hasOwnProperty.call(QDMPatientSchema.dataElementCache, profile)) {
+    return QDMPatientSchema.dataElementCache[profile];
   }
   let profileStripped;
   if (profile === 'Patient') {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
-    QDMPatientSchema._dataElementCache[profile] = [info];
+    QDMPatientSchema.dataElementCache[profile] = [info];
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
 
@@ -2590,17 +2590,17 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     if (/Positive/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, false);
+      return QDMPatientSchema.dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
-      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      return QDMPatientSchema._dataElementCache[profile];
+      QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped, true);
+      return QDMPatientSchema.dataElementCache[profile];
     }
     // No negation status, proceed normally
-    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    return QDMPatientSchema._dataElementCache[profile];
+    QDMPatientSchema.dataElementCache[profile] = this.getByProfile(profileStripped);
+    return QDMPatientSchema.dataElementCache[profile];
   }
   return [];
 };
@@ -2719,6 +2719,11 @@ QDMPatientSchema.methods.transfers = function transfers() {
 
 QDMPatientSchema.methods.vital_signs = function vital_signs() {
   return this.getDataElements({ qdmCategory: 'vital_sign' });
+};
+
+QDMPatientSchema.clearDataElementCache = function clearDataElementCache() {
+  QDMPatientSchema.dataElementCachePatientId = null;
+  QDMPatientSchema.dataElementCache = null;
 };
 
 module.exports.QDMPatientSchema = QDMPatientSchema;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2559,10 +2559,8 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
     QDMPatientSchema._dataElementCache = {};
     QDMPatientSchema._dataElementCachePatientId = this._id.toString();
-    console.log('cache reset');
   }
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
-    console.log('Cache hit');
     return QDMPatientSchema._dataElementCache[profile];
   }
   let profileStripped;
@@ -2570,13 +2568,11 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
     QDMPatientSchema._dataElementCache[profile] = [info];
-    console.log('Cache miss');
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
@@ -2593,18 +2589,15 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
       QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
-      console.log('Cache miss');
       return QDMPatientSchema._dataElementCache[profile];
     }
     // No negation status, proceed normally
     QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
-    console.log('Cache miss');
     return QDMPatientSchema._dataElementCache[profile];
   }
   return [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -2555,15 +2555,29 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @param {String} profile - the data criteria requested by the execution engine
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
+  if (QDMPatientSchema._dataElementCache == null
+    || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
+    QDMPatientSchema._dataElementCache = {};
+    QDMPatientSchema._dataElementCachePatientId = this._id.toString();
+    console.log('cache reset');
+  }
+  if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
+    console.log('Cache hit');
+    return QDMPatientSchema._dataElementCache[profile];
+  }
   let profileStripped;
   if (profile === 'Patient') {
     // Requested generic patient info
     const info = { birthDatetime: this.birthDatetime };
+    QDMPatientSchema._dataElementCache[profile] = [info];
+    console.log('Cache miss');
     return [info];
   } else if (/PatientCharacteristic/.test(profile)) {
     // Requested a patient characteristic
     profileStripped = profile.replace(/ *\{[^)]*\} */g, '');
-    return this.getByProfile(profileStripped);
+    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
+    console.log('Cache miss');
+    return QDMPatientSchema._dataElementCache[profile];
   } else if (profile != null) {
     // Requested something else (probably a QDM data type).
 
@@ -2578,14 +2592,20 @@ QDMPatientSchema.methods.findRecords = function findRecords(profile) {
     if (/Positive/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Positive/, '');
       // Since the data criteria is 'Positive', it is not negated.
-      return this.getByProfile(profileStripped, false);
+      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, false);
+      console.log('Cache miss');
+      return QDMPatientSchema._dataElementCache[profile];
     } else if (/Negative/.test(profileStripped)) {
       profileStripped = profileStripped.replace(/Negative/, '');
       // Since the data criteria is 'Negative', it is negated.
-      return this.getByProfile(profileStripped, true);
+      QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped, true);
+      console.log('Cache miss');
+      return QDMPatientSchema._dataElementCache[profile];
     }
     // No negation status, proceed normally
-    return this.getByProfile(profileStripped);
+    QDMPatientSchema._dataElementCache[profile] = this.getByProfile(profileStripped);
+    console.log('Cache miss');
+    return QDMPatientSchema._dataElementCache[profile];
   }
   return [];
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -2555,11 +2555,13 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
 // @param {String} profile - the data criteria requested by the execution engine
 // @returns {Object}
 QDMPatientSchema.methods.findRecords = function findRecords(profile) {
+  // Clear profile cache for this patient if there is no cache or the patient has changed
   if (QDMPatientSchema._dataElementCache == null
-    || QDMPatientSchema._dataElementCachePatientId != this._id.toString()) {
+    || QDMPatientSchema._dataElementCachePatientId != this._id) {
     QDMPatientSchema._dataElementCache = {};
-    QDMPatientSchema._dataElementCachePatientId = this._id.toString();
+    QDMPatientSchema._dataElementCachePatientId = this._id;
   }
+  // If there is a cache 'hit', return it
   if (QDMPatientSchema._dataElementCache.hasOwnProperty(profile)) {
     return QDMPatientSchema._dataElementCache[profile];
   }

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -65,6 +65,7 @@ const ProcedureOrder = require('./../../../app/assets/javascripts/ProcedureOrder
 const ProcedurePerformed = require('./../../../app/assets/javascripts/ProcedurePerformed.js').ProcedurePerformed;
 const ProcedureRecommended = require('./../../../app/assets/javascripts/ProcedureRecommended.js').ProcedureRecommended;
 const QDMPatient = require('./../../../app/assets/javascripts/QDMPatient.js').QDMPatient;
+const QDMPatientSchema = require('./../../../app/assets/javascripts/QDMPatient.js').QDMPatientSchema;
 const ResultComponent = require('./../../../app/assets/javascripts/attributes/ResultComponent.js').ResultComponent;
 const Stratification = require('./../../../app/assets/javascripts/cqm/PopulationSet.js').Stratification;
 const SubstanceAdministered = require('./../../../app/assets/javascripts/SubstanceAdministered.js').SubstanceAdministered;
@@ -397,6 +398,19 @@ describe('QDMPatient', () => {
       expect(qdmPatient.findRecords('EncounterPerformed').length).toEqual(3);
       expect(qdmPatient.findRecords('PositiveEncounterPerformed').length).toEqual(2);
       expect(qdmPatient.findRecords('NegativeEncounterPerformed').length).toEqual(1);
+    });
+
+    it('can clear dataElementCache on request', () => {
+      // run a findRecords call so cache is made
+      expect(qdmPatient.findRecords('EncounterPerformed').length).toEqual(3);
+      expect(QDMPatientSchema.dataElementCache).toBeDefined()
+      expect(Object.keys(QDMPatientSchema.dataElementCache).length).toBe(1);
+      expect(QDMPatientSchema.dataElementCachePatientId).toBeDefined()
+
+      // clear cache
+      QDMPatientSchema.clearDataElementCache();
+      expect(QDMPatientSchema.dataElementCache).toBeNull();
+      expect(QDMPatientSchema.dataElementCachePatientId).toBeNull();
     });
   });
 


### PR DESCRIPTION
Reduces the repeated conversion of data elements into execution engine friendly objects.

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2068 https://jira.mitre.org/browse/BONNIE-2118
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [x] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A

**Bonnie Reviewer:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
