### PR TITLE
update cql-execution reference

### DIFF
--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cqm-models'
-  spec.version       = '2.0.0'
+  spec.version       = '2.0.1'
   spec.authors       = ['aholmes@mitre.org', 'mokeefe@mitre.org', 'lades@mitre.org']
 
   spec.summary       = 'Mongo models that correspond to the QDM specification.'

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -40,7 +40,7 @@ class AdverseEvent extends mongoose.Document {
 }
 module.exports.AdverseEvent = AdverseEvent;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],2:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],2:[function(require,module,exports){
 module.exports.Id = require('./Id.js').Id;
 module.exports.IdSchema = require('./Id.js').IdSchema;
 module.exports.PhysicalExamOrder = require('./PhysicalExamOrder.js').PhysicalExamOrder;
@@ -200,7 +200,7 @@ class AllergyIntolerance extends mongoose.Document {
 }
 module.exports.AllergyIntolerance = AllergyIntolerance;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],4:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],4:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -241,7 +241,7 @@ class AssessmentOrder extends mongoose.Document {
 }
 module.exports.AssessmentOrder = AssessmentOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],5:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],5:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -286,7 +286,7 @@ class AssessmentPerformed extends mongoose.Document {
 }
 module.exports.AssessmentPerformed = AssessmentPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],6:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],6:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -327,7 +327,7 @@ class AssessmentRecommended extends mongoose.Document {
 }
 module.exports.AssessmentRecommended = AssessmentRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],7:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],7:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -367,7 +367,7 @@ class CareGoal extends mongoose.Document {
 }
 module.exports.CareGoal = CareGoal;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],8:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],8:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -413,7 +413,7 @@ class CommunicationPerformed extends mongoose.Document {
 }
 module.exports.CommunicationPerformed = CommunicationPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],9:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],9:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -456,7 +456,7 @@ class DeviceApplied extends mongoose.Document {
 }
 module.exports.DeviceApplied = DeviceApplied;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],10:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],10:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -497,7 +497,7 @@ class DeviceOrder extends mongoose.Document {
 }
 module.exports.DeviceOrder = DeviceOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],11:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],11:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -538,7 +538,7 @@ class DeviceRecommended extends mongoose.Document {
 }
 module.exports.DeviceRecommended = DeviceRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],12:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],12:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -580,7 +580,7 @@ class Diagnosis extends mongoose.Document {
 }
 module.exports.Diagnosis = Diagnosis;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],13:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],13:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -621,7 +621,7 @@ class DiagnosticStudyOrder extends mongoose.Document {
 }
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],14:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],14:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -669,7 +669,7 @@ class DiagnosticStudyPerformed extends mongoose.Document {
 }
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],15:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],15:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -710,7 +710,7 @@ class DiagnosticStudyRecommended extends mongoose.Document {
 }
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],16:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],16:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -752,7 +752,7 @@ class EncounterOrder extends mongoose.Document {
 }
 module.exports.EncounterOrder = EncounterOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],17:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],17:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -799,7 +799,7 @@ class EncounterPerformed extends mongoose.Document {
 }
 module.exports.EncounterPerformed = EncounterPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],18:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],18:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -841,7 +841,7 @@ class EncounterRecommended extends mongoose.Document {
 }
 module.exports.EncounterRecommended = EncounterRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],19:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],19:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -881,7 +881,7 @@ class FamilyHistory extends mongoose.Document {
 }
 module.exports.FamilyHistory = FamilyHistory;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],20:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],20:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [Number, String] = [
@@ -904,7 +904,7 @@ class Id extends mongoose.Document {
 }
 module.exports.Id = Id;
 
-},{"mongoose/browser":249}],21:[function(require,module,exports){
+},{"mongoose/browser":248}],21:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -948,7 +948,7 @@ class ImmunizationAdministered extends mongoose.Document {
 }
 module.exports.ImmunizationAdministered = ImmunizationAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],22:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],22:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -993,7 +993,7 @@ class ImmunizationOrder extends mongoose.Document {
 }
 module.exports.ImmunizationOrder = ImmunizationOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],23:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],23:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1034,7 +1034,7 @@ class InterventionOrder extends mongoose.Document {
 }
 module.exports.InterventionOrder = InterventionOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],24:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],24:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1078,7 +1078,7 @@ class InterventionPerformed extends mongoose.Document {
 }
 module.exports.InterventionPerformed = InterventionPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],25:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],25:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1119,7 +1119,7 @@ class InterventionRecommended extends mongoose.Document {
 }
 module.exports.InterventionRecommended = InterventionRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],26:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],26:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1160,7 +1160,7 @@ class LaboratoryTestOrder extends mongoose.Document {
 }
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],27:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],27:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1208,7 +1208,7 @@ class LaboratoryTestPerformed extends mongoose.Document {
 }
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],28:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],28:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1249,7 +1249,7 @@ class LaboratoryTestRecommended extends mongoose.Document {
 }
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],29:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],29:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1291,7 +1291,7 @@ class MedicationActive extends mongoose.Document {
 }
 module.exports.MedicationActive = MedicationActive;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],30:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],30:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1336,7 +1336,7 @@ class MedicationAdministered extends mongoose.Document {
 }
 module.exports.MedicationAdministered = MedicationAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],31:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],31:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1382,7 +1382,7 @@ class MedicationDischarge extends mongoose.Document {
 }
 module.exports.MedicationDischarge = MedicationDischarge;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],32:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],32:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1431,7 +1431,7 @@ class MedicationDispensed extends mongoose.Document {
 }
 module.exports.MedicationDispensed = MedicationDispensed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],33:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],33:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1481,7 +1481,7 @@ class MedicationOrder extends mongoose.Document {
 }
 module.exports.MedicationOrder = MedicationOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],34:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],34:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1519,7 +1519,7 @@ class Participation extends mongoose.Document {
 }
 module.exports.Participation = Participation;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],35:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],35:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1557,7 +1557,7 @@ class PatientCareExperience extends mongoose.Document {
 }
 module.exports.PatientCareExperience = PatientCareExperience;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],36:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],36:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1595,7 +1595,7 @@ class PatientCharacteristic extends mongoose.Document {
 }
 module.exports.PatientCharacteristic = PatientCharacteristic;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],37:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],37:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1634,7 +1634,7 @@ class PatientCharacteristicBirthdate extends mongoose.Document {
 }
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],38:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],38:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1675,7 +1675,7 @@ class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
 }
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],39:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],39:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1713,7 +1713,7 @@ class PatientCharacteristicEthnicity extends mongoose.Document {
 }
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],40:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],40:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1753,7 +1753,7 @@ class PatientCharacteristicExpired extends mongoose.Document {
 }
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],41:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],41:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1792,7 +1792,7 @@ class PatientCharacteristicPayer extends mongoose.Document {
 }
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],42:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],42:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1830,7 +1830,7 @@ class PatientCharacteristicRace extends mongoose.Document {
 }
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],43:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],43:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1868,7 +1868,7 @@ class PatientCharacteristicSex extends mongoose.Document {
 }
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],44:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],44:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1910,7 +1910,7 @@ class PhysicalExamOrder extends mongoose.Document {
 }
 module.exports.PhysicalExamOrder = PhysicalExamOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],45:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],45:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1956,7 +1956,7 @@ class PhysicalExamPerformed extends mongoose.Document {
 }
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],46:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],46:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1998,7 +1998,7 @@ class PhysicalExamRecommended extends mongoose.Document {
 }
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],47:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],47:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2041,7 +2041,7 @@ class ProcedureOrder extends mongoose.Document {
 }
 module.exports.ProcedureOrder = ProcedureOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],48:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],48:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2090,7 +2090,7 @@ class ProcedurePerformed extends mongoose.Document {
 }
 module.exports.ProcedurePerformed = ProcedurePerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],49:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],49:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2133,7 +2133,7 @@ class ProcedureRecommended extends mongoose.Document {
 }
 module.exports.ProcedureRecommended = ProcedureRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],50:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],50:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2171,7 +2171,7 @@ class ProviderCareExperience extends mongoose.Document {
 }
 module.exports.ProviderCareExperience = ProviderCareExperience;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],51:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],51:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2209,7 +2209,7 @@ class ProviderCharacteristic extends mongoose.Document {
 }
 module.exports.ProviderCharacteristic = ProviderCharacteristic;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],52:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],52:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
@@ -2473,7 +2473,7 @@ class QDMPatient extends mongoose.Document {
 }
 module.exports.QDMPatient = QDMPatient;
 
-},{"./AllDataElements":2,"./basetypes/Code":62,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],53:[function(require,module,exports){
+},{"./AllDataElements":2,"./basetypes/Code":62,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],53:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const PlaceholderResultSchema = mongoose.Schema({
@@ -2508,7 +2508,7 @@ class PlaceholderResult extends mongoose.Document {
 }
 module.exports.PlaceholderResult = PlaceholderResult;
 
-},{"mongoose/browser":249}],54:[function(require,module,exports){
+},{"mongoose/browser":248}],54:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2543,7 +2543,7 @@ class ResultComponent extends mongoose.Document {
 }
 module.exports.ResultComponent = ResultComponent;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],55:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],55:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2587,7 +2587,7 @@ class SubstanceAdministered extends mongoose.Document {
 }
 module.exports.SubstanceAdministered = SubstanceAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],56:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],56:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2633,7 +2633,7 @@ class SubstanceOrder extends mongoose.Document {
 }
 module.exports.SubstanceOrder = SubstanceOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],57:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],57:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2678,7 +2678,7 @@ class SubstanceRecommended extends mongoose.Document {
 }
 module.exports.SubstanceRecommended = SubstanceRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],58:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],58:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2718,7 +2718,7 @@ class Symptom extends mongoose.Document {
 }
 module.exports.Symptom = Symptom;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":249}],59:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],59:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -2750,7 +2750,7 @@ class Component extends mongoose.Document {
 }
 module.exports.Component = Component;
 
-},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":249}],60:[function(require,module,exports){
+},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":248}],60:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -2782,7 +2782,7 @@ class FacilityLocation extends mongoose.Document {
 }
 module.exports.FacilityLocation = FacilityLocation;
 
-},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":249}],61:[function(require,module,exports){
+},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":248}],61:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2851,7 +2851,7 @@ Any.prototype.cast = any => RecursiveCast(any);
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;
 
-},{"cql-execution":111,"mongoose/browser":249}],62:[function(require,module,exports){
+},{"cql-execution":111,"mongoose/browser":248}],62:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2887,7 +2887,7 @@ Code.prototype.cast = (code) => {
 mongoose.Schema.Types.Code = Code;
 module.exports = Code;
 
-},{"cql-execution":111,"mongoose/browser":249}],63:[function(require,module,exports){
+},{"cql-execution":111,"mongoose/browser":248}],63:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('./Code.js');
 const cql = require('cql-execution');
@@ -2933,7 +2933,7 @@ function DataElementSchema(add, options) {
 
 module.exports.DataElementSchema = DataElementSchema;
 
-},{"../Id":20,"./Code.js":62,"cql-execution":111,"mongoose/browser":249}],64:[function(require,module,exports){
+},{"../Id":20,"./Code.js":62,"cql-execution":111,"mongoose/browser":248}],64:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2957,7 +2957,7 @@ DateTime.prototype.cast = (dateTime) => {
 mongoose.Schema.Types.DateTime = DateTime;
 module.exports = DateTime;
 
-},{"cql-execution":111,"mongoose/browser":249}],65:[function(require,module,exports){
+},{"cql-execution":111,"mongoose/browser":248}],65:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 const DateTime = require('./DateTime');
@@ -2996,7 +2996,7 @@ Interval.prototype.cast = (interval) => {
 mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;
 
-},{"./DateTime":64,"cql-execution":111,"mongoose/browser":249}],66:[function(require,module,exports){
+},{"./DateTime":64,"cql-execution":111,"mongoose/browser":248}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -3018,7 +3018,7 @@ Quantity.prototype.cast = (quantity) => {
 mongoose.Schema.Types.Quantity = Quantity;
 module.exports = Quantity;
 
-},{"cql-execution":111,"mongoose/browser":249}],67:[function(require,module,exports){
+},{"cql-execution":111,"mongoose/browser":248}],67:[function(require,module,exports){
 window.cqm = window.cqm || {};
 window.cqm.models = require('./index');
 
@@ -3057,7 +3057,7 @@ class CQLLibrary extends mongoose.Document {
 }
 module.exports.CQLLibrary = CQLLibrary;
 
-},{"./CQLStatementDependency":69,"mongoose/browser":249}],69:[function(require,module,exports){
+},{"./CQLStatementDependency":69,"mongoose/browser":248}],69:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const StatementReferenceSchema = new mongoose.Schema({
@@ -3087,7 +3087,7 @@ class StatementDependency extends mongoose.Document {
 }
 module.exports.StatementDependency = StatementDependency;
 
-},{"mongoose/browser":249}],70:[function(require,module,exports){
+},{"mongoose/browser":248}],70:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -3117,7 +3117,7 @@ class ClauseResult extends mongoose.Document {
 }
 module.exports.ClauseResult = ClauseResult;
 
-},{"mongoose/browser":249}],71:[function(require,module,exports){
+},{"mongoose/browser":248}],71:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const ConceptSchema = new mongoose.Schema({
@@ -3136,7 +3136,7 @@ class Concept extends mongoose.Document {
 }
 module.exports.Concept = Concept;
 
-},{"mongoose/browser":249}],72:[function(require,module,exports){
+},{"mongoose/browser":248}],72:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { ClauseResultSchema } = require('./ClauseResult');
 const { StatementResultSchema } = require('./StatementResult');
@@ -3226,7 +3226,7 @@ class IndividualResult extends mongoose.Document {
 }
 module.exports.IndividualResult = IndividualResult;
 
-},{"./ClauseResult":70,"./StatementResult":78,"mongoose/browser":249}],73:[function(require,module,exports){
+},{"./ClauseResult":70,"./StatementResult":78,"mongoose/browser":248}],73:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -3336,7 +3336,7 @@ class Measure extends mongoose.Document {
 }
 module.exports.Measure = Measure;
 
-},{"../AllDataElements":2,"../basetypes/Code":62,"../basetypes/DataElement":63,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./CQLLibrary":68,"./PopulationSet":76,"mongoose/browser":249}],74:[function(require,module,exports){
+},{"../AllDataElements":2,"../basetypes/Code":62,"../basetypes/DataElement":63,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./CQLLibrary":68,"./PopulationSet":76,"mongoose/browser":248}],74:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 // using mBuffer to not conflict with system Buffer
@@ -3364,7 +3364,7 @@ class MeasurePackage extends mongoose.Document {
 }
 module.exports.MeasurePackage = MeasurePackage;
 
-},{"mongoose/browser":249}],75:[function(require,module,exports){
+},{"mongoose/browser":248}],75:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -3404,7 +3404,7 @@ class Patient extends mongoose.Document {
 }
 module.exports.Patient = Patient;
 
-},{"../QDMPatient":52,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./Provider":77,"mongoose/browser":249}],76:[function(require,module,exports){
+},{"../QDMPatient":52,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./Provider":77,"mongoose/browser":248}],76:[function(require,module,exports){
 /* eslint-disable no-unused-vars, no-param-reassign */
 const mongoose = require('mongoose/browser');
 const { StatementReferenceSchema } = require('./CQLStatementDependency');
@@ -3494,7 +3494,7 @@ class PopulationSet extends mongoose.Document {
 }
 module.exports.PopulationSet = PopulationSet;
 
-},{"./CQLStatementDependency":69,"mongoose/browser":249}],77:[function(require,module,exports){
+},{"./CQLStatementDependency":69,"mongoose/browser":248}],77:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Id = require('../Id');
 
@@ -3540,7 +3540,7 @@ class Provider extends mongoose.Document {
 }
 module.exports.Provider = Provider;
 
-},{"../Id":20,"mongoose/browser":249}],78:[function(require,module,exports){
+},{"../Id":20,"mongoose/browser":248}],78:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -3583,7 +3583,7 @@ class StatementResult extends mongoose.Document {
 }
 module.exports.StatementResult = StatementResult;
 
-},{"mongoose/browser":249}],79:[function(require,module,exports){
+},{"mongoose/browser":248}],79:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Concept = require('./Concept.js');
 
@@ -3611,7 +3611,7 @@ class ValueSet extends mongoose.Document {
 }
 module.exports.ValueSet = ValueSet;
 
-},{"./Concept.js":71,"mongoose/browser":249}],80:[function(require,module,exports){
+},{"./Concept.js":71,"mongoose/browser":248}],80:[function(require,module,exports){
 module.exports = require('./AllDataElements.js');
 module.exports.CQL = require('cql-execution');
 module.exports.Result = require('./Result.js').Result;
@@ -3644,6 +3644,8 @@ module.exports.StatementResultSchema = require('./cqm/StatementResult.js').State
 },{"./AllDataElements.js":2,"./Result.js":53,"./cqm/CQLLibrary.js":68,"./cqm/CQLStatementDependency.js":69,"./cqm/ClauseResult.js":70,"./cqm/Concept.js":71,"./cqm/IndividualResult.js":72,"./cqm/Measure.js":73,"./cqm/MeasurePackage.js":74,"./cqm/Patient.js":75,"./cqm/PopulationSet.js":76,"./cqm/Provider.js":77,"./cqm/StatementResult.js":78,"./cqm/ValueSet.js":79,"cql-execution":111}],81:[function(require,module,exports){
 (function (global){
 'use strict';
+
+var objectAssign = require('object-assign');
 
 // compare and isBuffer taken from https://github.com/feross/buffer/blob/680e9e5e488f22aac27599a57dc844a6315928dd/index.js
 // original notice:
@@ -3686,6 +3688,8 @@ function isBuffer(b) {
 }
 
 // based on node assert, original notice:
+// NB: The URL to the CommonJS spec is kept just for tradition.
+//     node-assert has evolved a lot since then, both in API and behavior.
 
 // http://wiki.commonjs.org/wiki/Unit_Testing/1.0
 //
@@ -4126,6 +4130,18 @@ assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
 
 assert.ifError = function(err) { if (err) throw err; };
 
+// Expose a strict only variant of assert
+function strict(value, message) {
+  if (!value) fail(value, true, message, '==', strict);
+}
+assert.strict = objectAssign(strict, assert, {
+  equal: assert.strictEqual,
+  deepEqual: assert.deepStrictEqual,
+  notEqual: assert.notStrictEqual,
+  notDeepEqual: assert.notDeepStrictEqual
+});
+assert.strict.strict = assert.strict;
+
 var objectKeys = Object.keys || function (obj) {
   var keys = [];
   for (var key in obj) {
@@ -4135,7 +4151,7 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"util/":84}],82:[function(require,module,exports){
+},{"object-assign":366,"util/":84}],82:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -4757,7 +4773,7 @@ function hasOwnProperty(obj, prop) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":83,"_process":352,"inherits":82}],85:[function(require,module,exports){
+},{"./support/isBuffer":83,"_process":367,"inherits":82}],85:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -4825,7 +4841,8 @@ function toByteArray (b64) {
     ? validLen - 4
     : validLen
 
-  for (var i = 0; i < len; i += 4) {
+  var i
+  for (i = 0; i < len; i += 4) {
     tmp =
       (revLookup[b64.charCodeAt(i)] << 18) |
       (revLookup[b64.charCodeAt(i + 1)] << 12) |
@@ -10536,7 +10553,7 @@ module.exports = ret;
 },{"./es5":13}]},{},[4])(4)
 });                    ;if (typeof window !== 'undefined' && window !== null) {                               window.P = window.Promise;                                                     } else if (typeof self !== 'undefined' && self !== null) {                             self.P = self.Promise;                                                         }
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
-},{"_process":352,"timers":356}],87:[function(require,module,exports){
+},{"_process":367,"timers":370}],87:[function(require,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -10548,6 +10565,8 @@ module.exports = ret;
 if (typeof global !== 'undefined') {
   var Buffer = require('buffer').Buffer; // TODO just use global Buffer
 }
+
+var utils = require('./parser/utils');
 
 /**
  * A class representation of the BSON Binary type.
@@ -10593,7 +10612,7 @@ function Binary(buffer, subType) {
     if (typeof buffer === 'string') {
       // Different ways of writing the length of the string for the different types
       if (typeof Buffer !== 'undefined') {
-        this.buffer = new Buffer(buffer);
+        this.buffer = utils.toBuffer(buffer);
       } else if (
         typeof Uint8Array !== 'undefined' ||
         Object.prototype.toString.call(buffer) === '[object Array]'
@@ -10608,7 +10627,7 @@ function Binary(buffer, subType) {
     this.position = buffer.length;
   } else {
     if (typeof Buffer !== 'undefined') {
-      this.buffer = new Buffer(Binary.BUFFER_SIZE);
+      this.buffer = utils.allocBuffer(Binary.BUFFER_SIZE);
     } else if (typeof Uint8Array !== 'undefined') {
       this.buffer = new Uint8Array(new ArrayBuffer(Binary.BUFFER_SIZE));
     } else {
@@ -10647,7 +10666,7 @@ Binary.prototype.put = function put(byte_value) {
   } else {
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(this.buffer)) {
       // Create additional overflow buffer
-      var buffer = new Buffer(Binary.BUFFER_SIZE + this.buffer.length);
+      var buffer = utils.allocBuffer(Binary.BUFFER_SIZE + this.buffer.length);
       // Combine the two buffers together
       this.buffer.copy(buffer, 0, 0, this.buffer.length);
       this.buffer = buffer;
@@ -10690,7 +10709,7 @@ Binary.prototype.write = function write(string, offset) {
     var buffer = null;
     // If we are in node.js
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(this.buffer)) {
-      buffer = new Buffer(this.buffer.length + string.length);
+      buffer = utils.allocBuffer(this.buffer.length + string.length);
       this.buffer.copy(buffer, 0, 0, this.buffer.length);
     } else if (Object.prototype.toString.call(this.buffer) === '[object Uint8Array]') {
       // Create a new buffer
@@ -10922,8 +10941,7 @@ module.exports = Binary;
 module.exports.Binary = Binary;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"buffer":107}],88:[function(require,module,exports){
-(function (Buffer){
+},{"./parser/utils":103,"buffer":107}],88:[function(require,module,exports){
 'use strict';
 
 var Map = require('./map'),
@@ -10944,7 +10962,8 @@ var Map = require('./map'),
 // Parts of the parser
 var deserialize = require('./parser/deserializer'),
   serializer = require('./parser/serializer'),
-  calculateObjectSize = require('./parser/calculate_size');
+  calculateObjectSize = require('./parser/calculate_size'),
+  utils = require('./parser/utils');
 
 /**
  * @ignore
@@ -10954,7 +10973,7 @@ var deserialize = require('./parser/deserializer'),
 var MAXSIZE = 1024 * 1024 * 17;
 
 // Current Internal Temporary Serialization Buffer
-var buffer = new Buffer(MAXSIZE);
+var buffer = utils.allocBuffer(MAXSIZE);
 
 var BSON = function() {};
 
@@ -10982,7 +11001,7 @@ BSON.prototype.serialize = function serialize(object, options) {
   
   // Resize the internal serialization buffer if needed
   if (buffer.length < minInternalBufferSize) {
-    buffer = new Buffer(minInternalBufferSize);
+    buffer = utils.allocBuffer(minInternalBufferSize);
   }
 
   // Attempt to serialize
@@ -10997,7 +11016,7 @@ BSON.prototype.serialize = function serialize(object, options) {
     []
   );
   // Create the final buffer
-  var finishedBuffer = new Buffer(serializationIndex);
+  var finishedBuffer = utils.allocBuffer(serializationIndex);
   // Copy into the finished buffer
   buffer.copy(finishedBuffer, 0, 0, finishedBuffer.length);
   // Return the buffer
@@ -11310,8 +11329,7 @@ module.exports.MaxKey = MaxKey;
 module.exports.BSONRegExp = BSONRegExp;
 module.exports.Decimal128 = Decimal128;
 
-}).call(this,require("buffer").Buffer)
-},{"./binary":87,"./code":89,"./db_ref":90,"./decimal128":91,"./double":92,"./int_32":94,"./long":95,"./map":96,"./max_key":97,"./min_key":98,"./objectid":99,"./parser/calculate_size":100,"./parser/deserializer":101,"./parser/serializer":102,"./regexp":104,"./symbol":105,"./timestamp":106,"buffer":107}],89:[function(require,module,exports){
+},{"./binary":87,"./code":89,"./db_ref":90,"./decimal128":91,"./double":92,"./int_32":94,"./long":95,"./map":96,"./max_key":97,"./min_key":98,"./objectid":99,"./parser/calculate_size":100,"./parser/deserializer":101,"./parser/serializer":102,"./parser/utils":103,"./regexp":104,"./symbol":105,"./timestamp":106}],89:[function(require,module,exports){
 /**
  * A class representation of the BSON Code type.
  *
@@ -11372,7 +11390,6 @@ module.exports = DBRef;
 module.exports.DBRef = DBRef;
 
 },{}],91:[function(require,module,exports){
-(function (Buffer){
 'use strict';
 
 var Long = require('./long');
@@ -11444,6 +11461,8 @@ var INF_POSITIVE_BUFFER = [
 ].reverse();
 
 var EXPONENT_REGEX = /^([-+])?(\d+)?$/;
+
+var utils = require('./parser/utils');
 
 // Detect if the value is a digit
 var isDigit = function(value) {
@@ -11518,7 +11537,7 @@ var lessThan = function(left, right) {
 };
 
 // var longtoHex = function(value) {
-//   var buffer = new Buffer(8);
+//   var buffer = utils.allocBuffer(8);
 //   var index = 0;
 //   // Encode the low 64 bits of the decimal
 //   // Encode low bits
@@ -11535,7 +11554,7 @@ var lessThan = function(left, right) {
 // };
 
 // var int32toHex = function(value) {
-//   var buffer = new Buffer(4);
+//   var buffer = utils.allocBuffer(4);
 //   var index = 0;
 //   // Encode the low 64 bits of the decimal
 //   // Encode low bits
@@ -11640,9 +11659,9 @@ Decimal128.fromString = function(string) {
   // Check if user passed Infinity or NaN
   if (!isDigit(string[index]) && string[index] !== '.') {
     if (string[index] === 'i' || string[index] === 'I') {
-      return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+      return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
     } else if (string[index] === 'N') {
-      return new Decimal128(new Buffer(NAN_BUFFER));
+      return new Decimal128(utils.toBuffer(NAN_BUFFER));
     }
   }
 
@@ -11650,7 +11669,7 @@ Decimal128.fromString = function(string) {
   while (isDigit(string[index]) || string[index] === '.') {
     if (string[index] === '.') {
       if (sawRadix) {
-        return new Decimal128(new Buffer(NAN_BUFFER));
+        return new Decimal128(utils.toBuffer(NAN_BUFFER));
       }
 
       sawRadix = true;
@@ -11695,7 +11714,7 @@ Decimal128.fromString = function(string) {
 
     // No digits read
     if (!match || !match[2]) {
-      return new Decimal128(new Buffer(NAN_BUFFER));
+      return new Decimal128(utils.toBuffer(NAN_BUFFER));
     }
 
     // Get exponent
@@ -11707,7 +11726,7 @@ Decimal128.fromString = function(string) {
 
   // Return not a number
   if (string[index]) {
-    return new Decimal128(new Buffer(NAN_BUFFER));
+    return new Decimal128(utils.toBuffer(NAN_BUFFER));
   }
 
   // Done reading input
@@ -11755,7 +11774,7 @@ Decimal128.fromString = function(string) {
         exponent = EXPONENT_MAX;
         break;
       } else {
-        return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+        return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
       }
     }
 
@@ -11787,7 +11806,7 @@ Decimal128.fromString = function(string) {
         exponent = EXPONENT_MAX;
         break;
       } else {
-        return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+        return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
       }
     }
   }
@@ -11837,7 +11856,7 @@ Decimal128.fromString = function(string) {
               digits[dIdx] = 1;
             } else {
               return new Decimal128(
-                new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER)
+                utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER)
               );
             }
           }
@@ -11922,7 +11941,7 @@ Decimal128.fromString = function(string) {
   }
 
   // Encode into a buffer
-  var buffer = new Buffer(16);
+  var buffer = utils.allocBuffer(16);
   index = 0;
 
   // Encode the low 64 bits of the decimal
@@ -12192,8 +12211,7 @@ Decimal128.prototype.toJSON = function() {
 module.exports = Decimal128;
 module.exports.Decimal128 = Decimal128;
 
-}).call(this,require("buffer").Buffer)
-},{"./long":95,"buffer":107}],92:[function(require,module,exports){
+},{"./long":95,"./parser/utils":103}],92:[function(require,module,exports){
 /**
  * A class representation of the BSON Double type.
  *
@@ -13411,6 +13429,8 @@ module.exports.MinKey = MinKey;
 // Custom inspect property name / symbol.
 var inspect = 'inspect';
 
+var utils = require('./parser/utils');
+
 /**
  * Machine id.
  *
@@ -13468,7 +13488,7 @@ var ObjectID = function ObjectID(id) {
       'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
     );
   } else if (valid && typeof id === 'string' && id.length === 24 && hasBufferType) {
-    return new ObjectID(new Buffer(id, 'hex'));
+    return new ObjectID(utils.toBuffer(id, 'hex'));
   } else if (valid && typeof id === 'string' && id.length === 24) {
     return ObjectID.createFromHexString(id);
   } else if (id != null && id.length === 12) {
@@ -13568,7 +13588,7 @@ ObjectID.prototype.generate = function(time) {
       : process.pid) % 0xffff;
   var inc = this.get_inc();
   // Buffer used
-  var buffer = new Buffer(12);
+  var buffer = utils.allocBuffer(12);
   // Encode time
   buffer[3] = time & 0xff;
   buffer[2] = (time >> 8) & 0xff;
@@ -13687,7 +13707,7 @@ ObjectID.createPk = function createPk() {
 * @return {ObjectID} return the created ObjectID
 */
 ObjectID.createFromTime = function createFromTime(time) {
-  var buffer = new Buffer([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  var buffer = utils.toBuffer([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
   // Encode time into first 4 bytes
   buffer[3] = time & 0xff;
   buffer[2] = (time >> 8) & 0xff;
@@ -13725,7 +13745,7 @@ ObjectID.createFromHexString = function createFromHexString(string) {
   }
 
   // Use Buffer.from method if available
-  if (hasBufferType) return new ObjectID(new Buffer(string, 'hex'));
+  if (hasBufferType) return new ObjectID(utils.toBuffer(string, 'hex'));
 
   // Calculate lengths
   var array = new _Buffer(12);
@@ -13797,7 +13817,7 @@ module.exports.ObjectID = ObjectID;
 module.exports.ObjectId = ObjectID;
 
 }).call(this,require('_process'),require("buffer").Buffer)
-},{"_process":352,"buffer":107,"util":366}],100:[function(require,module,exports){
+},{"./parser/utils":103,"_process":367,"buffer":107,"util":381}],100:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -13893,7 +13913,7 @@ function calculateElement(name, value, serializeFunctions, isArray, ignoreUndefi
         value['_bsontype'] === 'MaxKey'
       ) {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + 1;
-      } else if (value instanceof ObjectID || value['_bsontype'] === 'ObjectID') {
+      } else if (value instanceof ObjectID || value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (12 + 1);
       } else if (value instanceof Date || isDate(value)) {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (8 + 1);
@@ -14057,7 +14077,6 @@ module.exports = calculateObjectSize;
 
 }).call(this,require("buffer").Buffer)
 },{"../binary":87,"../code":89,"../db_ref":90,"../decimal128":91,"../double":92,"../long":95,"../max_key":97,"../min_key":98,"../objectid":99,"../regexp":104,"../symbol":105,"../timestamp":106,"./utils":103,"buffer":107}],101:[function(require,module,exports){
-(function (Buffer){
 'use strict';
 
 var Long = require('../long').Long,
@@ -14073,6 +14092,8 @@ var Long = require('../long').Long,
   DBRef = require('../db_ref').DBRef,
   BSONRegExp = require('../regexp').BSONRegExp,
   Binary = require('../binary').Binary;
+
+var utils = require('./utils');
 
 var deserialize = function(buffer, options, isArray) {
   options = options == null ? {} : options;
@@ -14175,7 +14196,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       object[name] = buffer.toString('utf8', index, index + stringSize - 1);
       index = index + stringSize;
     } else if (elementType === BSON.BSON_DATA_OID) {
-      var oid = new Buffer(12);
+      var oid = utils.allocBuffer(12);
       buffer.copy(oid, 0, index, index + 12);
       object[name] = new ObjectID(oid);
       index = index + 12;
@@ -14280,7 +14301,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       }
     } else if (elementType === BSON.BSON_DATA_DECIMAL128) {
       // Buffer to contain the decimal bytes
-      var bytes = new Buffer(16);
+      var bytes = utils.allocBuffer(16);
       // Copy the next 16 bytes into the bytes buffer
       buffer.copy(bytes, 0, index, index + 16);
       // Update index
@@ -14580,7 +14601,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       index = index + stringSize;
 
       // Read the oid
-      var oidBuffer = new Buffer(12);
+      var oidBuffer = utils.allocBuffer(12);
       buffer.copy(oidBuffer, 0, index, index + 12);
       oid = new ObjectID(oidBuffer);
 
@@ -14839,14 +14860,12 @@ var JS_INT_MIN_LONG = Long.fromNumber(-0x20000000000000); // Any integer down to
 
 module.exports = deserialize;
 
-}).call(this,require("buffer").Buffer)
-},{"../binary":87,"../code":89,"../db_ref":90,"../decimal128":91,"../double":92,"../int_32":94,"../long":95,"../max_key":97,"../min_key":98,"../objectid":99,"../regexp":104,"../symbol":105,"../timestamp":106,"buffer":107}],102:[function(require,module,exports){
+},{"../binary":87,"../code":89,"../db_ref":90,"../decimal128":91,"../double":92,"../int_32":94,"../long":95,"../max_key":97,"../min_key":98,"../objectid":99,"../regexp":104,"../symbol":105,"../timestamp":106,"./utils":103}],102:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
 var writeIEEE754 = require('../float_parser').writeIEEE754,
   Long = require('../long').Long,
-  MinKey = require('../min_key').MinKey,
   Map = require('../map'),
   Binary = require('../binary').Binary;
 
@@ -15095,7 +15114,7 @@ var serializeMinMax = function(buffer, key, value, index, isArray) {
   // Write the type of either min or max key
   if (value === null) {
     buffer[index++] = BSON.BSON_DATA_NULL;
-  } else if (value instanceof MinKey) {
+  } else if (value._bsontype === 'MinKey') {
     buffer[index++] = BSON.BSON_DATA_MIN_KEY;
   } else {
     buffer[index++] = BSON.BSON_DATA_MAX_KEY;
@@ -15562,7 +15581,7 @@ var serializeInto = function serializeInto(
         index = serializeNull(buffer, key, value, index, true);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index, true);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index, true);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index, true);
@@ -15670,7 +15689,7 @@ var serializeInto = function serializeInto(
         // } else if (value === undefined && ignoreUndefined === true) {
       } else if (value === null || (value === undefined && ignoreUndefined === false)) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);
@@ -15772,7 +15791,7 @@ var serializeInto = function serializeInto(
         if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);
@@ -16027,7 +16046,8 @@ BSON.JS_INT_MIN = -0x20000000000000; // Any integer down to -2^53 can be precise
 module.exports = serializeInto;
 
 }).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":246,"../binary":87,"../float_parser":93,"../long":95,"../map":96,"../min_key":98,"./utils":103}],103:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":245,"../binary":87,"../float_parser":93,"../long":95,"../map":96,"./utils":103}],103:[function(require,module,exports){
+(function (Buffer){
 'use strict';
 
 /**
@@ -16038,12 +16058,27 @@ function normalizedFunctionString(fn) {
   return fn.toString().replace(/function *\(/, 'function (');
 }
 
+function newBuffer(item, encoding) {
+  return new Buffer(item, encoding);
+}
+
+function allocBuffer() {
+  return Buffer.alloc.apply(Buffer, arguments);
+}
+
+function toBuffer() {
+  return Buffer.from.apply(Buffer, arguments);
+}
+
 module.exports = {
-  normalizedFunctionString: normalizedFunctionString
+  normalizedFunctionString: normalizedFunctionString,
+  allocBuffer: typeof Buffer.alloc === 'function' ? allocBuffer : newBuffer,
+  toBuffer: typeof Buffer.from === 'function' ? toBuffer : newBuffer
 };
 
 
-},{}],104:[function(require,module,exports){
+}).call(this,require("buffer").Buffer)
+},{"buffer":107}],104:[function(require,module,exports){
 /**
  * A class representation of the BSON RegExp type.
  *
@@ -16132,7 +16167,7 @@ module.exports = Symbol;
 module.exports.Symbol = Symbol;
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":107,"util":366}],106:[function(require,module,exports){
+},{"buffer":107,"util":381}],106:[function(require,module,exports){
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16989,6 +17024,7 @@ module.exports = Timestamp;
 module.exports.Timestamp = Timestamp;
 
 },{}],107:[function(require,module,exports){
+(function (Buffer){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -17001,6 +17037,10 @@ module.exports.Timestamp = Timestamp;
 
 var base64 = require('base64-js')
 var ieee754 = require('ieee754')
+var customInspectSymbol =
+  (typeof Symbol === 'function' && typeof Symbol.for === 'function')
+    ? Symbol.for('nodejs.util.inspect.custom')
+    : null
 
 exports.Buffer = Buffer
 exports.SlowBuffer = SlowBuffer
@@ -17037,7 +17077,9 @@ function typedArraySupport () {
   // Can typed array instances can be augmented?
   try {
     var arr = new Uint8Array(1)
-    arr.__proto__ = { __proto__: Uint8Array.prototype, foo: function () { return 42 } }
+    var proto = { foo: function () { return 42 } }
+    Object.setPrototypeOf(proto, Uint8Array.prototype)
+    Object.setPrototypeOf(arr, proto)
     return arr.foo() === 42
   } catch (e) {
     return false
@@ -17066,7 +17108,7 @@ function createBuffer (length) {
   }
   // Return an augmented `Uint8Array` instance
   var buf = new Uint8Array(length)
-  buf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(buf, Buffer.prototype)
   return buf
 }
 
@@ -17116,7 +17158,7 @@ function from (value, encodingOrOffset, length) {
   }
 
   if (value == null) {
-    throw TypeError(
+    throw new TypeError(
       'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
       'or Array-like Object. Received type ' + (typeof value)
     )
@@ -17168,8 +17210,8 @@ Buffer.from = function (value, encodingOrOffset, length) {
 
 // Note: Change prototype *after* Buffer.from is defined to workaround Chrome bug:
 // https://github.com/feross/buffer/pull/148
-Buffer.prototype.__proto__ = Uint8Array.prototype
-Buffer.__proto__ = Uint8Array
+Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype)
+Object.setPrototypeOf(Buffer, Uint8Array)
 
 function assertSize (size) {
   if (typeof size !== 'number') {
@@ -17273,7 +17315,8 @@ function fromArrayBuffer (array, byteOffset, length) {
   }
 
   // Return an augmented `Uint8Array` instance
-  buf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(buf, Buffer.prototype)
+
   return buf
 }
 
@@ -17595,6 +17638,9 @@ Buffer.prototype.inspect = function inspect () {
   if (this.length > max) str += ' ... '
   return '<Buffer ' + str + '>'
 }
+if (customInspectSymbol) {
+  Buffer.prototype[customInspectSymbol] = Buffer.prototype.inspect
+}
 
 Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
   if (isInstance(target, Uint8Array)) {
@@ -17720,7 +17766,7 @@ function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
         return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset)
       }
     }
-    return arrayIndexOf(buffer, [ val ], byteOffset, encoding, dir)
+    return arrayIndexOf(buffer, [val], byteOffset, encoding, dir)
   }
 
   throw new TypeError('val must be string, number or Buffer')
@@ -18049,7 +18095,7 @@ function hexSlice (buf, start, end) {
 
   var out = ''
   for (var i = start; i < end; ++i) {
-    out += toHex(buf[i])
+    out += hexSliceLookupTable[buf[i]]
   }
   return out
 }
@@ -18086,7 +18132,8 @@ Buffer.prototype.slice = function slice (start, end) {
 
   var newBuf = this.subarray(start, end)
   // Return an augmented `Uint8Array` instance
-  newBuf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(newBuf, Buffer.prototype)
+
   return newBuf
 }
 
@@ -18575,6 +18622,8 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
     }
   } else if (typeof val === 'number') {
     val = val & 255
+  } else if (typeof val === 'boolean') {
+    val = Number(val)
   }
 
   // Invalid ranges are not set to a default, so can range check early.
@@ -18630,11 +18679,6 @@ function base64clean (str) {
     str = str + '='
   }
   return str
-}
-
-function toHex (n) {
-  if (n < 16) return '0' + n.toString(16)
-  return n.toString(16)
 }
 
 function utf8ToBytes (string, units) {
@@ -18767,7 +18811,22 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":85,"ieee754":244}],108:[function(require,module,exports){
+// Create lookup table for `toString('hex')`
+// See: https://github.com/feross/buffer/issues/219
+var hexSliceLookupTable = (function () {
+  var alphabet = '0123456789abcdef'
+  var table = new Array(256)
+  for (var i = 0; i < 16; ++i) {
+    var i16 = i * 16
+    for (var j = 0; j < 16; ++j) {
+      table[i16 + j] = alphabet[i] + alphabet[j]
+    }
+  }
+  return table
+})()
+
+}).call(this,require("buffer").Buffer)
+},{"base64-js":85,"buffer":107,"ieee754":244}],108:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Code, CodeService, ValueSet, ref;
@@ -19142,35 +19201,41 @@ function numberIsNaN (obj) {
 
   module.exports.Repository = repository.Repository;
 
+  module.exports.Expression = expression.Expression;
+
   module.exports.Context = context.Context;
+
+  module.exports.Executor = exec.Executor;
 
   module.exports.PatientContext = context.PatientContext;
 
   module.exports.PopulationContext = context.PopulationContext;
 
-  module.exports.Executor = exec.Executor;
-
   module.exports.Results = results.Results;
-
-  module.exports.Code = datatypes.Code;
-
-  module.exports.Quantity = quantity.Quantity;
-
-  module.exports.Ratio = ratio.Ratio;
-
-  module.exports.Expression = expression.Expression;
-
-  module.exports.ValueSet = datatypes.ValueSet;
-
-  module.exports.DateTime = datatypes.DateTime;
-
-  module.exports.Interval = datatypes.Interval;
 
   module.exports.Patient = patient.Patient;
 
   module.exports.PatientSource = patient.PatientSource;
 
   module.exports.CodeService = codeservice.CodeService;
+
+  module.exports.Code = datatypes.Code;
+
+  module.exports.CodeSystem = datatypes.CodeSystem;
+
+  module.exports.Concept = datatypes.Concept;
+
+  module.exports.Date = datatypes.Date;
+
+  module.exports.DateTime = datatypes.DateTime;
+
+  module.exports.Interval = datatypes.Interval;
+
+  module.exports.Quantity = quantity.Quantity;
+
+  module.exports.Ratio = ratio.Ratio;
+
+  module.exports.ValueSet = datatypes.ValueSet;
 
 }).call(this);
 
@@ -20516,7 +20581,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../util/util":242,"./uncertainty":118,"moment":248}],115:[function(require,module,exports){
+},{"../util/util":242,"./uncertainty":118,"moment":247}],115:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Exception;
@@ -22232,7 +22297,7 @@ function numberIsNaN (obj) {
 },{"../util/util":242,"./expressions":128}],122:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
-  var AnyInValueSet, CalculateAge, CalculateAgeAt, CodeDef, CodeRef, CodeSystemDef, Concept, ConceptDef, ConceptRef, Expression, InValueSet, ValueSetDef, ValueSetRef, build, dt,
+  var AnyInValueSet, CalculateAge, CalculateAgeAt, Code, CodeDef, CodeRef, CodeSystemDef, Concept, ConceptDef, ConceptRef, Expression, InValueSet, ValueSetDef, ValueSetRef, build, dt,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
@@ -22269,11 +22334,12 @@ function numberIsNaN (obj) {
     function ValueSetRef(json) {
       ValueSetRef.__super__.constructor.apply(this, arguments);
       this.name = json.name;
+      this.libraryName = json.libraryName;
     }
 
     ValueSetRef.prototype.exec = function(ctx) {
       var valueset;
-      valueset = ctx.getValueSet(this.name);
+      valueset = ctx.getValueSet(this.name, this.libraryName);
       if (valueset instanceof Expression) {
         valueset = valueset.execute(ctx);
       }
@@ -22400,6 +22466,35 @@ function numberIsNaN (obj) {
     };
 
     return CodeRef;
+
+  })(Expression);
+
+  module.exports.Code = Code = (function(superClass) {
+    extend(Code, superClass);
+
+    function Code(json) {
+      Code.__super__.constructor.apply(this, arguments);
+      this.code = json.code;
+      this.systemName = json.system.name;
+      this.version = json.version;
+      this.display = json.display;
+    }
+
+    Object.defineProperties(Code.prototype, {
+      isCode: {
+        get: function() {
+          return true;
+        }
+      }
+    });
+
+    Code.prototype.exec = function(ctx) {
+      var ref, system;
+      system = (ref = ctx.getCodeSystem(this.systemName)) != null ? ref.id : void 0;
+      return new dt.Code(this.code, system, this.version, this.display);
+    };
+
+    return Code;
 
   })(Expression);
 
@@ -23392,6 +23487,9 @@ function numberIsNaN (obj) {
       codes = this.codes;
       if (this.codes && typeof this.codes.exec === 'function') {
         codes = this.codes.execute(ctx);
+        if (codes == null) {
+          return [];
+        }
       }
       if (codes) {
         records = records.filter((function(_this) {
@@ -24312,8 +24410,12 @@ function numberIsNaN (obj) {
       return this.expressions[identifier] || this.includes[identifier];
     };
 
-    Library.prototype.getValueSet = function(identifier) {
-      return this.valuesets[identifier];
+    Library.prototype.getValueSet = function(identifier, libraryName) {
+      var ref;
+      if (this.valuesets[identifier] != null) {
+        return this.valuesets[identifier];
+      }
+      return (ref = this.includes[libraryName]) != null ? ref.valuesets[identifier] : void 0;
     };
 
     Library.prototype.getCodeSystem = function(identifier) {
@@ -26018,7 +26120,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../datatypes/datatypes":113,"../datatypes/exception":115,"../util/math":241,"./builder":121,"./expression":127,"./reusable":142,"ucum":364}],140:[function(require,module,exports){
+},{"../datatypes/datatypes":113,"../datatypes/exception":115,"../util/math":241,"./builder":121,"./expression":127,"./reusable":142,"ucum":378}],140:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var AliasRef, AliasedQuerySource, ByColumn, ByDirection, ByExpression, Context, Expression, LetClause, MultiSource, Query, QueryLetRef, ReturnClause, Sort, SortClause, UnimplementedExpression, With, Without, allTrue, build, equals, ref, ref1, toDistinctList, typeIsArray,
@@ -63920,9 +64022,9 @@ function numberIsNaN (obj) {
       }
     };
 
-    Context.prototype.getValueSet = function(name) {
+    Context.prototype.getValueSet = function(name, library) {
       var ref;
-      return (ref = this.parent) != null ? ref.getValueSet(name) : void 0;
+      return (ref = this.parent) != null ? ref.getValueSet(name, library) : void 0;
     };
 
     Context.prototype.getCodeSystem = function(name) {
@@ -64077,6 +64179,8 @@ function numberIsNaN (obj) {
           return typeof val === "string";
         case "{urn:hl7-org:elm-types:r1}Concept":
           return val != null ? val.isConcept : void 0;
+        case "{urn:hl7-org:elm-types:r1}Code":
+          return val != null ? val.isCode : void 0;
         case "{urn:hl7-org:elm-types:r1}DateTime":
           return val != null ? val.isDateTime : void 0;
         case "{urn:hl7-org:elm-types:r1}Date":
@@ -64100,6 +64204,8 @@ function numberIsNaN (obj) {
           return typeof val === "number" && Math.floor(val) === val;
         case !inst.isStringLiteral:
           return typeof val === "string";
+        case !inst.isCode:
+          return val != null ? val.isCode : void 0;
         case !inst.isConcept:
           return val != null ? val.isConcept : void 0;
         case !inst.isDateTime:
@@ -64225,7 +64331,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../datatypes/datatypes":113,"../datatypes/exception":115,"../elm/library":132,"../util/util":242,"util":366}],237:[function(require,module,exports){
+},{"../datatypes/datatypes":113,"../datatypes/exception":115,"../elm/library":132,"../util/util":242,"util":381}],237:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Executor, PatientContext, PopulationContext, Results, ref;
@@ -65564,8 +65670,6 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 }
 
 },{}],245:[function(require,module,exports){
-arguments[4][82][0].apply(exports,arguments)
-},{"dup":82}],246:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -65588,7 +65692,7 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],247:[function(require,module,exports){
+},{}],246:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -65987,6 +66091,10 @@ Kareem.prototype.pre = function(name, isAsync, fn, error, unshift) {
     ++pres.numAsync;
   }
 
+  if (typeof fn !== 'function') {
+    throw new Error('pre() requires a function, got "' + typeof fn + '"');
+  }
+
   if (unshift) {
     pres.unshift(Object.assign({}, options, { fn: fn, isAsync: isAsync }));
   } else {
@@ -66003,6 +66111,10 @@ Kareem.prototype.post = function(name, options, fn, unshift) {
     unshift = !!fn;
     fn = options;
     options = {};
+  }
+
+  if (typeof fn !== 'function') {
+    throw new Error('post() requires a function, got "' + typeof fn + '"');
   }
 
   if (unshift) {
@@ -66095,7 +66207,7 @@ function decorateNextFn(fn) {
 module.exports = Kareem;
 
 }).call(this,require('_process'))
-},{"_process":352}],248:[function(require,module,exports){
+},{"_process":367}],247:[function(require,module,exports){
 //! moment.js
 
 ;(function (global, factory) {
@@ -70699,7 +70811,7 @@ module.exports = Kareem;
 
 })));
 
-},{}],249:[function(require,module,exports){
+},{}],248:[function(require,module,exports){
 /**
  * Export lib/mongoose
  *
@@ -70709,7 +70821,7 @@ module.exports = Kareem;
 
 module.exports = require('./lib/browser');
 
-},{"./lib/browser":250}],250:[function(require,module,exports){
+},{"./lib/browser":249}],249:[function(require,module,exports){
 (function (Buffer){
 /* eslint-env browser */
 
@@ -70754,7 +70866,7 @@ exports.PromiseProvider = PromiseProvider;
  * @api public
  */
 
-exports.Error = require('./error');
+exports.Error = require('./error/index');
 
 /**
  * The Mongoose [Schema](#schema_Schema) constructor
@@ -70836,6 +70948,17 @@ exports.utils = require('./utils.js');
  */
 exports.Document = DocumentProvider();
 
+/**
+ * function stub for model
+ *
+ * @method model
+ * @api public
+ * @return null
+ */
+exports.model = function() {
+  return null;
+};
+
 /*!
  * Module exports.
  */
@@ -70846,7 +70969,7 @@ if (typeof window !== 'undefined') {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./document_provider.js":260,"./driver":261,"./drivers/browser":265,"./error":269,"./promise_provider":303,"./schema":305,"./schematype.js":326,"./types":333,"./utils.js":337,"./virtualtype":338,"buffer":107}],251:[function(require,module,exports){
+},{"./document_provider.js":259,"./driver":260,"./drivers/browser":264,"./error/index":268,"./promise_provider":314,"./schema":316,"./schematype.js":337,"./types":345,"./utils.js":349,"./virtualtype":350,"buffer":107}],250:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -70855,7 +70978,7 @@ if (typeof window !== 'undefined') {
 
 const NodeJSDocument = require('./document');
 const EventEmitter = require('events').EventEmitter;
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
 const Schema = require('./schema');
 const ObjectId = require('./types/objectid');
 const ValidationError = MongooseError.ValidationError;
@@ -70950,7 +71073,7 @@ utils.each(
 Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
-},{"./document":259,"./error":269,"./helpers/model/applyHooks":288,"./schema":305,"./types/objectid":335,"./utils":337,"events":243}],252:[function(require,module,exports){
+},{"./document":258,"./error/index":268,"./helpers/model/applyHooks":289,"./schema":316,"./types/objectid":347,"./utils":349,"events":243}],251:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -70978,6 +71101,12 @@ const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
 module.exports = function cast(schema, obj, options, context) {
   if (Array.isArray(obj)) {
     throw new Error('Query filter must be an object, got an array ', util.inspect(obj));
+  }
+
+  // bson 1.x has the unfortunate tendency to remove filters that have a top-level
+  // `_bsontype` property. Should remove this when we upgrade to bson 4.x. See gh-8222
+  if (obj.hasOwnProperty('_bsontype')) {
+    delete obj._bsontype;
   }
 
   const paths = Object.keys(obj);
@@ -71190,7 +71319,7 @@ module.exports = function cast(schema, obj, options, context) {
             'schema, strict mode is `true`, and upsert is `true`.');
         } else if (options.strictQuery === 'throw') {
           throw new StrictModeError(path, 'Path "' + path + '" is not in ' +
-            'schema and strictQuery is true.');
+            'schema and strictQuery is \'throw\'.');
         } else if (options.strictQuery) {
           delete obj[path];
         }
@@ -71198,7 +71327,7 @@ module.exports = function cast(schema, obj, options, context) {
         continue;
       } else if (val.constructor.name === 'Object') {
         any$conditionals = Object.keys(val).some(function(k) {
-          return k.charAt(0) === '$' && k !== '$id' && k !== '$ref';
+          return k.startsWith('$') && k !== '$id' && k !== '$ref';
         });
 
         if (!any$conditionals) {
@@ -71219,7 +71348,7 @@ module.exports = function cast(schema, obj, options, context) {
             if ($cond === '$not') {
               if (nested && schematype && !schematype.caster) {
                 _keys = Object.keys(nested);
-                if (_keys.length && _keys[0].charAt(0) === '$') {
+                if (_keys.length && _keys[0].startsWith('$')) {
                   for (const key in nested) {
                     nested[key] = schematype.castForQueryWrapper({
                       $conditional: key,
@@ -71291,7 +71420,7 @@ function _cast(val, numbertype, context) {
     }
   }
 }
-},{"./error/strict":278,"./helpers/get":286,"./schema/index":313,"./schema/operators/text":322,"./utils":337,"util":366}],253:[function(require,module,exports){
+},{"./error/strict":277,"./helpers/get":287,"./schema/index":324,"./schema/operators/text":333,"./utils":349,"util":381}],252:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -71324,7 +71453,7 @@ module.exports = function castBoolean(value, path) {
 module.exports.convertToTrue = new Set([true, 'true', 1, '1', 'yes']);
 module.exports.convertToFalse = new Set([false, 'false', 0, '0', 'no']);
 
-},{"../error/cast":267}],254:[function(require,module,exports){
+},{"../error/cast":266}],253:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71366,7 +71495,7 @@ module.exports = function castDate(value) {
 
   assert.ok(false);
 };
-},{"assert":81}],255:[function(require,module,exports){
+},{"assert":81}],254:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -71405,7 +71534,7 @@ module.exports = function castDecimal128(value) {
   assert.ok(false);
 };
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../types/decimal128":330,"assert":81}],256:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../types/decimal128":342,"assert":81}],255:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71437,7 +71566,7 @@ module.exports = function castNumber(val) {
 
   assert.ok(!isNaN(val));
   if (val instanceof Number) {
-    return val;
+    return val.valueOf();
   }
   if (typeof val === 'number') {
     return val;
@@ -71446,13 +71575,13 @@ module.exports = function castNumber(val) {
     return Number(val.valueOf());
   }
   if (val.toString && !Array.isArray(val) && val.toString() == Number(val)) {
-    return new Number(val);
+    return Number(val);
   }
 
   assert.ok(false);
 };
 
-},{"assert":81}],257:[function(require,module,exports){
+},{"assert":81}],256:[function(require,module,exports){
 'use strict';
 
 const ObjectId = require('../driver').get().ObjectId;
@@ -71482,7 +71611,7 @@ module.exports = function castObjectId(value) {
 
   assert.ok(false);
 };
-},{"../driver":261,"assert":81}],258:[function(require,module,exports){
+},{"../driver":260,"assert":81}],257:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -71512,14 +71641,16 @@ module.exports = function castString(value, path) {
   // Re: gh-647 and gh-3030, we're ok with casting using `toString()`
   // **unless** its the default Object.toString, because "[object Object]"
   // doesn't really qualify as useful data
-  if (value.toString && value.toString !== Object.prototype.toString) {
+  if (value.toString &&
+      value.toString !== Object.prototype.toString &&
+      !Array.isArray(value)) {
     return value.toString();
   }
 
   throw new CastError('string', value, path);
 };
 
-},{"../error/cast":267}],259:[function(require,module,exports){
+},{"../error/cast":266}],258:[function(require,module,exports){
 (function (Buffer,process){
 'use strict';
 
@@ -71529,7 +71660,7 @@ module.exports = function castString(value, path) {
 
 const EventEmitter = require('events').EventEmitter;
 const InternalCache = require('./internal');
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
 const MixedSchema = require('./schema/mixed');
 const ObjectExpectedError = require('./error/objectExpected');
 const ObjectParameterError = require('./error/objectParameter');
@@ -71555,8 +71686,11 @@ const clone = utils.clone;
 const deepEqual = utils.deepEqual;
 const isMongooseObject = utils.isMongooseObject;
 
+const arrayAtomicsSymbol = require('./helpers/symbols').arrayAtomicsSymbol;
 const documentArrayParent = require('./helpers/symbols').documentArrayParent;
+const documentSchemaSymbol = require('./helpers/symbols').documentSchemaSymbol;
 const getSymbol = require('./helpers/symbols').getSymbol;
+const populateModelSymbol = require('./helpers/symbols').populateModelSymbol;
 
 let DocumentArray;
 let MongooseArray;
@@ -71623,13 +71757,15 @@ function Document(obj, fields, skipId, options) {
     $__hasIncludedChildren(fields) :
     {};
 
-  this.$__buildDoc(obj, fields, skipId, exclude, hasIncludedChildren, false);
+  if (this._doc == null) {
+    this.$__buildDoc(obj, fields, skipId, exclude, hasIncludedChildren, false);
 
-  // By default, defaults get applied **before** setting initial values
-  // Re: gh-6155
-  $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, true, {
-    isNew: this.isNew
-  });
+    // By default, defaults get applied **before** setting initial values
+    // Re: gh-6155
+    $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, true, {
+      isNew: this.isNew
+    });
+  }
 
   if (obj) {
     if (obj instanceof Document) {
@@ -71647,7 +71783,7 @@ function Document(obj, fields, skipId, options) {
   // see the full doc rather than an empty one, unless they opt out.
   // Re: gh-3781, gh-6155
   if (options.willInit) {
-    this.once('init', () => {
+    EventEmitter.prototype.once.call(this, 'init', () => {
       $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, false, options.skipDefaults, {
         isNew: this.isNew
       });
@@ -71659,6 +71795,7 @@ function Document(obj, fields, skipId, options) {
   }
 
   this.$__._id = this._id;
+  this.$locals = {};
 
   if (!schema.options.strict && obj) {
     const _this = this;
@@ -71699,6 +71836,35 @@ Document.prototype.constructor = Document;
  */
 
 Document.prototype.schema;
+
+/**
+ * Empty object that you can use for storing properties on the document. This
+ * is handy for passing data to middleware without conflicting with Mongoose
+ * internals.
+ *
+ * ####Example:
+ *
+ *     schema.pre('save', function() {
+ *       // Mongoose will set `isNew` to `false` if `save()` succeeds
+ *       this.$locals.wasNew = this.isNew;
+ *     });
+ *
+ *     schema.post('save', function() {
+ *       // Prints true if `isNew` was set before `save()`
+ *       console.log(this.$locals.wasNew);
+ *     });
+ *
+ * @api public
+ * @property $locals
+ * @memberOf Document
+ * @instance
+ */
+
+Object.defineProperty(Document.prototype, '$locals', {
+  configurable: false,
+  enumerable: false,
+  writable: true
+});
 
 /**
  * Boolean flag specifying if the document is new.
@@ -71970,11 +72136,12 @@ Document.prototype.init = function(doc, opts, fn) {
 Document.prototype.$__init = function(doc, opts) {
   this.isNew = false;
   this.$init = true;
+  opts = opts || {};
 
   // handle docs with populated paths
   // If doc._id is not null or undefined
   if (doc._id !== null && doc._id !== undefined &&
-    opts && opts.populated && opts.populated.length) {
+    opts.populated && opts.populated.length) {
     const id = String(doc._id);
     for (let i = 0; i < opts.populated.length; ++i) {
       const item = opts.populated[i];
@@ -71986,7 +72153,7 @@ Document.prototype.$__init = function(doc, opts) {
     }
   }
 
-  init(this, doc, this._doc);
+  init(this, doc, this._doc, opts);
 
   this.emit('init', this);
   this.constructor.emit('init', this);
@@ -72005,7 +72172,7 @@ Document.prototype.$__init = function(doc, opts) {
  * @api private
  */
 
-function init(self, obj, doc, prefix) {
+function init(self, obj, doc, opts, prefix) {
   prefix = prefix || '';
 
   const keys = Object.keys(obj);
@@ -72036,7 +72203,7 @@ function init(self, obj, doc, prefix) {
       if (!doc[i]) {
         doc[i] = {};
       }
-      init(self, obj[i], doc[i], path + '.');
+      init(self, obj[i], doc[i], opts, path + '.');
     } else if (!schema) {
       doc[i] = obj[i];
     } else {
@@ -72045,6 +72212,7 @@ function init(self, obj, doc, prefix) {
       } else if (obj[i] !== undefined) {
         const intCache = obj[i].$__ || {};
         const wasPopulated = intCache.wasPopulated || null;
+
         if (schema && !wasPopulated) {
           try {
             doc[i] = schema.cast(obj[i], self, true);
@@ -72209,6 +72377,36 @@ Document.prototype.$session = function $session(session) {
 };
 
 /**
+ * Overwrite all values in this document with the values of `obj`, except
+ * for immutable properties. Behaves similarly to `set()`, except for it
+ * unsets all properties that aren't in `obj`.
+ *
+ * @param {Object} obj the object to overwrite this document with
+ * @method overwrite
+ * @name overwrite
+ * @memberOf Document
+ * @instance
+ * @api public
+ */
+
+Document.prototype.overwrite = function overwrite(obj) {
+  const keys = Array.from(new Set(Object.keys(this._doc).concat(Object.keys(obj))));
+
+  for (const key of keys) {
+    if (key === '_id') {
+      continue;
+    }
+    // Explicitly skip version key
+    if (this.schema.options.versionKey && key === this.schema.options.versionKey) {
+      continue;
+    }
+    this.$set(key, obj[key]);
+  }
+
+  return this;
+};
+
+/**
  * Alias for `set()`, used internally to avoid conflicts
  *
  * @param {String|Object} path path or object of key/vals to set
@@ -72281,6 +72479,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
       return this;
     }
+  } else {
+    this.$__.$setCalled.add(path);
   }
 
   function _handleIndex(i) {
@@ -72299,14 +72499,18 @@ Document.prototype.$set = function $set(path, val, type, options) {
       delete this._doc[key];
     }
 
-    if (utils.isPOJO(path[key]) &&
+    if (typeof path[key] === 'object' &&
+        !utils.isNativeObject(path[key]) &&
+        !utils.isMongooseType(path[key]) &&
+        path[key] != null &&
         pathtype !== 'virtual' &&
         pathtype !== 'real' &&
         !(this.$__path(pathName) instanceof MixedSchema) &&
         !(this.schema.paths[pathName] &&
         this.schema.paths[pathName].options &&
         this.schema.paths[pathName].options.ref)) {
-      this.$set(path[key], prefix + key, constructing);
+      this.$__.$setCalled.add(prefix + key);
+      this.$set(path[key], prefix + key, constructing, options);
     } else if (strict) {
       // Don't overwrite defaults with undefined keys (gh-3981)
       if (constructing && path[key] === void 0 &&
@@ -72326,10 +72530,10 @@ Document.prototype.$set = function $set(path, val, type, options) {
             path[key] instanceof Document) {
           p = p.toObject({ virtuals: false, transform: false });
         }
-        this.$set(prefix + key, p, constructing);
+        this.$set(prefix + key, p, constructing, options);
       } else if (pathtype === 'nested' && path[key] instanceof Document) {
         this.$set(prefix + key,
-          path[key].toObject({transform: false}), constructing);
+          path[key].toObject({transform: false}), constructing, options);
       } else if (strict === 'throw') {
         if (pathtype === 'nested') {
           throw new ObjectExpectedError(key, path[key]);
@@ -72338,22 +72542,32 @@ Document.prototype.$set = function $set(path, val, type, options) {
         }
       }
     } else if (path[key] !== void 0) {
-      this.$set(prefix + key, path[key], constructing);
+      this.$set(prefix + key, path[key], constructing, options);
     }
   }
 
-  const pathType = this.schema.pathType(path);
+  let pathType = this.schema.pathType(path);
+  if (pathType === 'adhocOrUndefined') {
+    pathType = getEmbeddedDiscriminatorPath(this, path, { typeOnly: true });
+  }
+
+  // Assume this is a Mongoose document that was copied into a POJO using
+  // `Object.assign()` or `{...doc}`
+  if (utils.isPOJO(val) && val.$__ != null && val._doc != null) {
+    val = val._doc;
+  }
+
   if (pathType === 'nested' && val) {
-    if (utils.isPOJO(val)) {
+    if (typeof val === 'object' && val != null) {
       if (!merge) {
-        this.setValue(path, null);
+        this.$__setValue(path, null);
         cleanModifiedSubpaths(this, path);
       } else {
         return this.$set(val, path, constructing);
       }
 
       const keys = Object.keys(val);
-      this.setValue(path, {});
+      this.$__setValue(path, {});
       for (const key of keys) {
         this.$set(path + '.' + key, val[key], constructing);
       }
@@ -72367,6 +72581,11 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
   let schema;
   const parts = path.split('.');
+
+  // Might need to change path for top-level alias
+  if (typeof this.schema.aliases[parts[0]] == 'string') {
+    parts[0] = this.schema.aliases[parts[0]];
+  }
 
   if (pathType === 'adhocOrUndefined' && strict) {
     // check for roots that are Mixed types
@@ -72428,7 +72647,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
       if (!this.isSelected(curPath)) {
         this.unmarkModified(curPath);
       }
-      cur = this.getValue(curPath);
+      cur = this.$__getValue(curPath);
     }
   }
 
@@ -72442,7 +72661,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
   } else {
     for (i = 0; i < parts.length; ++i) {
       const subpath = parts.slice(0, i + 1).join('.');
-      if (this.get(subpath) === null) {
+      if (this.get(subpath, null, { getters: false }) === null) {
         pathToMark = subpath;
         break;
       }
@@ -72456,16 +72675,28 @@ Document.prototype.$set = function $set(path, val, type, options) {
   // if this doc is being constructed we should not trigger getters
   const priorVal = (() => {
     if (this.$__.$options.priorDoc != null) {
-      return this.$__.$options.priorDoc.getValue(path);
+      return this.$__.$options.priorDoc.$__getValue(path);
     }
     if (constructing) {
       return void 0;
     }
-    return this.getValue(path);
+    return this.$__getValue(path);
   })();
 
   if (!schema) {
     this.$__set(pathToMark, path, constructing, parts, schema, val, priorVal);
+    return this;
+  }
+
+  if (schema.$isSingleNested && val != null && merge) {
+    if (val instanceof Document) {
+      val = val.toObject({ virtuals: false, transform: false });
+    }
+    const keys = Object.keys(val);
+    for (const key of keys) {
+      this.$set(path + '.' + key, val[key], constructing, options);
+    }
+
     return this;
   }
 
@@ -72504,9 +72735,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
     if (refMatches && val instanceof Document) {
       if (this.ownerDocument) {
         this.ownerDocument().populated(this.$__fullPath(path),
-          val._id, {model: val.constructor});
+          val._id, { [populateModelSymbol]: val.constructor });
       } else {
-        this.populated(path, val._id, {model: val.constructor});
+        this.populated(path, val._id, { [populateModelSymbol]: val.constructor });
       }
       didPopulate = true;
     }
@@ -72522,25 +72753,22 @@ Document.prototype.$set = function $set(path, val, type, options) {
         val[0].constructor.modelName &&
         (schema.options[this.schema.options.typeKey][0].ref === val[0].constructor.baseModelName || schema.options[this.schema.options.typeKey][0].ref === val[0].constructor.modelName)) {
       if (this.ownerDocument) {
-        popOpts = { model: val[0].constructor };
+        popOpts = { [populateModelSymbol]: val[0].constructor };
         this.ownerDocument().populated(this.$__fullPath(path),
           val.map(function(v) { return v._id; }), popOpts);
       } else {
-        popOpts = { model: val[0].constructor };
+        popOpts = { [populateModelSymbol]: val[0].constructor };
         this.populated(path, val.map(function(v) { return v._id; }), popOpts);
       }
       didPopulate = true;
     }
 
-    // If this path is underneath a single nested schema, we'll call the setter
-    // later in `$__set()` because we don't take `_doc` when we iterate through
-    // a single nested doc. That's to make sure we get the correct context.
-    // Otherwise we would double-call the setter, see gh-7196.
     if (this.schema.singleNestedPaths[path] == null) {
-      const setterContext = constructing && this.$__.$options.priorDoc ?
-        this.$__.$options.priorDoc :
-        this;
-      val = schema.applySetters(val, setterContext, false, priorVal);
+      // If this path is underneath a single nested schema, we'll call the setter
+      // later in `$__set()` because we don't take `_doc` when we iterate through
+      // a single nested doc. That's to make sure we get the correct context.
+      // Otherwise we would double-call the setter, see gh-7196.
+      val = schema.applySetters(val, this, false, priorVal);
     }
 
     if (!didPopulate && this.$__.populated) {
@@ -72549,8 +72777,12 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
     this.$markValid(path);
   } catch (e) {
-    this.invalidate(path,
-      new MongooseError.CastError(schema.instance, val, path, e));
+    if (e instanceof MongooseError.StrictModeError && e.isImmutableError) {
+      this.invalidate(path, e);
+    } else {
+      this.invalidate(path,
+        new MongooseError.CastError(schema.instance, val, path, e));
+    }
     shouldSet = false;
   }
 
@@ -72693,7 +72925,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
       // Small hack for gh-1638: if we're overwriting the entire array, ignore
       // paths that were modified before the array overwrite
       this.$__.activePaths.forEach(function(modifiedPath) {
-        if (modifiedPath.indexOf(path + '.') === 0) {
+        if (modifiedPath.startsWith(path + '.')) {
           _this.$__.activePaths.ignore(modifiedPath);
         }
       });
@@ -72743,7 +72975,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
  * @api private
  */
 
-Document.prototype.getValue = function(path) {
+Document.prototype.$__getValue = function(path) {
   return utils.getValue(path, this._doc);
 };
 
@@ -72755,7 +72987,7 @@ Document.prototype.getValue = function(path) {
  * @api private
  */
 
-Document.prototype.setValue = function(path, val) {
+Document.prototype.$__setValue = function(path, val) {
   utils.setValue(path, val, this._doc);
   return this;
 };
@@ -72773,6 +73005,9 @@ Document.prototype.setValue = function(path, val) {
  *
  * @param {String} path
  * @param {Schema|String|Number|Buffer|*} [type] optionally specify a type for on-the-fly attributes
+ * @param {Object} [options]
+ * @param {Boolean} [options.virtuals=false] Apply virtuals before getting this path
+ * @param {Boolean} [options.getters=true] If false, skip applying getters and just get the raw value
  * @api public
  */
 
@@ -72783,7 +73018,16 @@ Document.prototype.get = function(path, type, options) {
     adhoc = this.schema.interpretAsType(path, type, this.schema.options);
   }
 
-  const schema = this.$__path(path) || this.schema.virtualpath(path);
+  let schema = this.$__path(path);
+  if (schema == null) {
+    schema = this.schema.virtualpath(path);
+  }
+  if (schema instanceof MixedSchema) {
+    const virtual = this.schema.virtualpath(path);
+    if (virtual != null) {
+      schema = virtual;
+    }
+  }
   const pieces = path.split('.');
   let obj = this._doc;
 
@@ -72792,6 +73036,11 @@ Document.prototype.get = function(path, type, options) {
       return void 0;
     }
     return schema.applyGetters(null, this);
+  }
+
+  // Might need to change path for top-level alias
+  if (typeof this.schema.aliases[pieces[0]] == 'string') {
+    pieces[0] = this.schema.aliases[pieces[0]];
   }
 
   for (let i = 0, l = pieces.length; i < l; i++) {
@@ -72814,11 +73063,11 @@ Document.prototype.get = function(path, type, options) {
     obj = adhoc.cast(obj);
   }
 
-  if (schema != null) {
+  if (schema != null && options.getters !== false) {
     obj = schema.applyGetters(obj, this);
   } else if (this.schema.nested[path] && options.virtuals) {
     // Might need to apply virtuals if this is a nested path
-    return applyGetters(this, utils.clone(obj), 'virtuals', { path: path });
+    return applyVirtuals(this, utils.clone(obj) || {}, { path: path });
   }
 
   return obj;
@@ -72912,6 +73161,95 @@ Document.prototype.$ignore = function(path) {
 };
 
 /**
+ * Returns the list of paths that have been directly modified. A direct
+ * modified path is a path that you explicitly set, whether via `doc.foo = 'bar'`,
+ * `Object.assign(doc, { foo: 'bar' })`, or `doc.set('foo', 'bar')`.
+ *
+ * A path `a` may be in `modifiedPaths()` but not in `directModifiedPaths()`
+ * because a child of `a` was directly modified.
+ *
+ * ####Example
+ *     const schema = new Schema({ foo: String, nested: { bar: String } });
+ *     const Model = mongoose.model('Test', schema);
+ *     await Model.create({ foo: 'original', nested: { bar: 'original' } });
+ *
+ *     const doc = await Model.findOne();
+ *     doc.nested.bar = 'modified';
+ *     doc.directModifiedPaths(); // ['nested.bar']
+ *     doc.modifiedPaths(); // ['nested', 'nested.bar']
+ *
+ * @return {Array}
+ * @api public
+ */
+
+Document.prototype.directModifiedPaths = function() {
+  return Object.keys(this.$__.activePaths.states.modify);
+};
+
+/**
+ * Returns true if the given path is nullish or only contains empty objects.
+ * Useful for determining whether this subdoc will get stripped out by the
+ * [minimize option](/docs/guide.html#minimize).
+ *
+ * ####Example:
+ *     const schema = new Schema({ nested: { foo: String } });
+ *     const Model = mongoose.model('Test', schema);
+ *     const doc = new Model({});
+ *     doc.$isEmpty('nested'); // true
+ *     doc.nested.$isEmpty(); // true
+ *
+ *     doc.nested.foo = 'bar';
+ *     doc.$isEmpty('nested'); // false
+ *     doc.nested.$isEmpty(); // false
+ *
+ * @memberOf Document
+ * @instance
+ * @api public
+ * @method $isEmpty
+ * @return {Boolean}
+ */
+
+Document.prototype.$isEmpty = function(path) {
+  const isEmptyOptions = {
+    minimize: true,
+    virtuals: false,
+    getters: false,
+    transform: false
+  };
+
+  if (arguments.length > 0) {
+    const v = this.get(path);
+    if (v == null) {
+      return true;
+    }
+    if (typeof v !== 'object') {
+      return false;
+    }
+    if (utils.isPOJO(v)) {
+      return _isEmpty(v);
+    }
+    return Object.keys(v.toObject(isEmptyOptions)).length === 0;
+  }
+
+  return Object.keys(this.toObject(isEmptyOptions)).length === 0;
+};
+
+function _isEmpty(v) {
+  if (v == null) {
+    return true;
+  }
+  if (typeof v !== 'object' || Array.isArray(v)) {
+    return false;
+  }
+  for (const key of Object.keys(v)) {
+    if (!_isEmpty(v[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Returns the list of paths that have been modified.
  *
  * @param {Object} [options]
@@ -73000,7 +73338,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
     });
     return isModifiedChild || paths.some(function(path) {
       return directModifiedPaths.some(function(mod) {
-        return mod === path || path.indexOf(mod + '.') === 0;
+        return mod === path || path.startsWith(mod + '.');
       });
     });
   }
@@ -73148,11 +73486,11 @@ Document.prototype.isSelected = function isSelected(path) {
         continue;
       }
 
-      if (cur.indexOf(pathDot) === 0) {
+      if (cur.startsWith(pathDot)) {
         return inclusive || cur !== pathDot;
       }
 
-      if (pathDot.indexOf(cur + '.') === 0) {
+      if (pathDot.startsWith(cur + '.')) {
         return inclusive;
       }
     }
@@ -73248,9 +73586,11 @@ Document.prototype.validate = function(options, callback) {
     options = null;
   }
 
-  return utils.promiseOrCallback(callback, cb => this.$__validate(function(error) {
-    cb(error);
-  }), this.constructor.events);
+  return utils.promiseOrCallback(callback, cb => {
+    this.$__validate(options, function(error) {
+      cb(error);
+    });
+  }, this.constructor.events);
 };
 
 /*!
@@ -73330,11 +73670,19 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
-    if (val) {
+    const val = doc.$__getValue(path);
+    _pushNestedArrayPaths(val, paths, path);
+  }
+
+  function _pushNestedArrayPaths(val, paths, path) {
+    if (val != null) {
       const numElements = val.length;
       for (let j = 0; j < numElements; ++j) {
-        paths.push(path + '.' + j);
+        if (Array.isArray(val[j])) {
+          _pushNestedArrayPaths(val[j], paths, path + '.' + j);
+        } else {
+          paths.push(path + '.' + j);
+        }
       }
     }
   }
@@ -73344,15 +73692,12 @@ function _getPathsToValidate(doc) {
   for (i = 0; i < len; ++i) {
     const pathToCheck = paths[i];
     if (doc.schema.nested[pathToCheck]) {
-      let _v = doc.getValue(pathToCheck);
+      let _v = doc.$__getValue(pathToCheck);
       if (isMongooseObject(_v)) {
         _v = _v.toObject({ transform: false });
       }
-      const flat = flatten(_v, '', flattenOptions);
-      const _subpaths = Object.keys(flat).map(function(p) {
-        return pathToCheck + '.' + p;
-      });
-      paths = paths.concat(_subpaths);
+      const flat = flatten(_v, pathToCheck, flattenOptions, doc.schema);
+      paths = paths.concat(Object.keys(flat));
     }
   }
 
@@ -73364,7 +73709,7 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
+    const val = doc.$__getValue(path);
     if (val == null) {
       continue;
     }
@@ -73380,11 +73725,41 @@ function _getPathsToValidate(doc) {
  * ignore
  */
 
-Document.prototype.$__validate = function(callback) {
+Document.prototype.$__validate = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
+
   const _this = this;
   const _complete = () => {
-    const err = this.$__.validationError;
+    let err = this.$__.validationError;
     this.$__.validationError = undefined;
+
+    if (shouldValidateModifiedOnly && err != null) {
+      // Remove any validation errors that aren't from modified paths
+      const errors = Object.keys(err.errors);
+      for (const errPath of errors) {
+        if (!this.isModified(errPath)) {
+          delete err.errors[errPath];
+        }
+      }
+      if (Object.keys(err.errors).length === 0) {
+        err = void 0;
+      }
+    }
+
     this.$__.cachedRequired = {};
     this.emit('validate', _this);
     this.constructor.emit('validate', _this);
@@ -73402,7 +73777,9 @@ Document.prototype.$__validate = function(callback) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  const paths = pathDetails[0];
+  const paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (paths.length === 0) {
@@ -73451,7 +73828,15 @@ Document.prototype.$__validate = function(callback) {
         return;
       }
 
-      const val = _this.getValue(path);
+      let val = _this.$__getValue(path);
+
+      // If you `populate()` and get back a null value, required validators
+      // shouldn't fail (gh-8018). We should always fall back to the populated
+      // value.
+      let pop;
+      if (val == null && (pop = _this.populated(path))) {
+        val = pop;
+      }
       const scope = path in _this.$__.pathsToScopes ?
         _this.$__.pathsToScopes[path] :
         _this;
@@ -73466,7 +73851,7 @@ Document.prototype.$__validate = function(callback) {
           _this.invalidate(path, err, undefined, true);
         }
         --total || complete();
-      }, scope, { skipSchemaValidators: skipSchemaValidators[path] });
+      }, scope, { skipSchemaValidators: skipSchemaValidators[path], path: path });
     });
   };
 
@@ -73497,8 +73882,19 @@ Document.prototype.$__validate = function(callback) {
  * @api public
  */
 
-Document.prototype.validateSync = function(pathsToValidate) {
+Document.prototype.validateSync = function(pathsToValidate, options) {
   const _this = this;
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
 
   if (typeof pathsToValidate === 'string') {
     pathsToValidate = pathsToValidate.split(' ');
@@ -73506,7 +73902,9 @@ Document.prototype.validateSync = function(pathsToValidate) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  let paths = pathDetails[0];
+  let paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (pathsToValidate && pathsToValidate.length) {
@@ -73536,9 +73934,10 @@ Document.prototype.validateSync = function(pathsToValidate) {
       return;
     }
 
-    const val = _this.getValue(path);
+    const val = _this.$__getValue(path);
     const err = p.doValidateSync(val, _this, {
-      skipSchemaValidators: skipSchemaValidators[path]
+      skipSchemaValidators: skipSchemaValidators[path],
+      path: path
     });
     if (err && (!p.$isMongooseDocumentArray || err.$isArrayValidatorError)) {
       if (p.$isSingleNested &&
@@ -73708,7 +74107,7 @@ Document.prototype.$__reset = function reset() {
 
   this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     })
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;
@@ -73723,14 +74122,14 @@ Document.prototype.$__reset = function reset() {
         doc.$__reset();
       }
 
-      _this.$__.activePaths.init(array._path);
+      _this.$__.activePaths.init(array.$path());
 
-      array._atomics = {};
+      array[arrayAtomicsSymbol] = {};
     });
 
   this.$__.activePaths.
     map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     }).
     filter(function(val) {
       return val && val.$isSingleNested;
@@ -73744,8 +74143,8 @@ Document.prototype.$__reset = function reset() {
   this.$__dirty().forEach(function(dirt) {
     const type = dirt.value;
 
-    if (type && type._atomics) {
-      type._atomics = {};
+    if (type && type[arrayAtomicsSymbol]) {
+      type[arrayAtomicsSymbol] = {};
     }
   });
 
@@ -73777,7 +74176,7 @@ Document.prototype.$__dirty = function() {
   let all = this.$__.activePaths.map('modify', function(path) {
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   });
@@ -73785,12 +74184,12 @@ Document.prototype.$__dirty = function() {
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {
-    if (path === '_id' || _this.getValue(path) == null) {
+    if (path === '_id' || _this.$__getValue(path) == null) {
       return;
     }
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   }));
@@ -73809,19 +74208,20 @@ Document.prototype.$__dirty = function() {
     if (!item) {
       return;
     }
-    if (item.path.indexOf(lastPath) !== 0) {
+    if (lastPath == null || item.path.indexOf(lastPath) !== 0) {
       lastPath = item.path + '.';
       minimal.push(item);
       top = item;
-    } else {
+    } else if (top != null &&
+        top.value != null &&
+        top.value[arrayAtomicsSymbol] != null &&
+        top.value.hasAtomics()) {
       // special case for top level MongooseArrays
-      if (top.value && top.value._atomics && top.value.hasAtomics()) {
-        // the `top` array itself and a sub path of `top` are being modified.
-        // the only way to honor all of both modifications is through a $set
-        // of entire array.
-        top.value._atomics = {};
-        top.value._atomics.$set = top.value;
-      }
+      // the `top` array itself and a sub path of `top` are being modified.
+      // the only way to honor all of both modifications is through a $set
+      // of entire array.
+      top.value[arrayAtomicsSymbol] = {};
+      top.value[arrayAtomicsSymbol].$set = top.value;
     }
   });
 
@@ -73849,6 +74249,7 @@ Document.prototype.$__setSchema = function(schema) {
   }
 
   this.schema = schema;
+  this[documentSchemaSymbol] = schema;
 };
 
 
@@ -73867,7 +74268,7 @@ Document.prototype.$__getArrayPathsToValidate = function() {
   // validate all document arrays.
   return this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return this.getValue(i);
+      return this.$__getValue(i);
     }.bind(this))
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;
@@ -73894,39 +74295,41 @@ Document.prototype.$__getAllSubdocs = function() {
   Embedded = Embedded || require('./types/embedded');
 
   function docReducer(doc, seed, path) {
-    const val = path ? doc[path] : doc;
+    let val = doc;
+    if (path) {
+      if (doc instanceof Document && doc[documentSchemaSymbol].paths[path]) {
+        val = doc._doc[path];
+      } else {
+        val = doc[path];
+      }
+    }
     if (val instanceof Embedded) {
       seed.push(val);
-    }
-    else if (val instanceof Map) {
+    } else if (val instanceof Map) {
       seed = Array.from(val.keys()).reduce(function(seed, path) {
         return docReducer(val.get(path), seed, null);
       }, seed);
-    }
-    else if (val && val.$isSingleNested) {
+    } else if (val && val.$isSingleNested) {
       seed = Object.keys(val._doc).reduce(function(seed, path) {
         return docReducer(val._doc, seed, path);
       }, seed);
       seed.push(val);
-    }
-    else if (val && val.isMongooseDocumentArray) {
+    } else if (val && val.isMongooseDocumentArray) {
       val.forEach(function _docReduce(doc) {
         if (!doc || !doc._doc) {
           return;
         }
-        if (doc instanceof Embedded) {
-          seed.push(doc);
-        }
         seed = Object.keys(doc._doc).reduce(function(seed, path) {
           return docReducer(doc._doc, seed, path);
         }, seed);
+        if (doc instanceof Embedded) {
+          seed.push(doc);
+        }
       });
     } else if (val instanceof Document && val.$__isNested) {
-      if (val) {
-        seed = Object.keys(val).reduce(function(seed, path) {
-          return docReducer(val, seed, path);
-        }, seed);
-      }
+      seed = Object.keys(val).reduce(function(seed, path) {
+        return docReducer(val, seed, path);
+      }, seed);
     }
     return seed;
   }
@@ -74046,7 +74449,7 @@ Document.prototype.$toObject = function(options, json) {
   let ret = clone(this._doc, cloneOptions) || {};
 
   if (options.getters) {
-    applyGetters(this, ret, 'paths', cloneOptions);
+    applyGetters(this, ret, cloneOptions);
     // applyGetters for paths will add nested empty objects;
     // if minimize is set, we need to remove them.
     if (options.minimize) {
@@ -74055,7 +74458,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   if (options.virtuals || options.getters && options.virtuals !== false) {
-    applyGetters(this, ret, 'virtuals', cloneOptions);
+    applyVirtuals(this, ret, cloneOptions, options);
   }
 
   if (options.versionKey === false && this.schema.options.versionKey) {
@@ -74193,7 +74596,7 @@ Document.prototype.$toObject = function(options, json) {
  *
  * Transforms are applied _only to the document and are not applied to sub-documents_.
  *
- * Transforms, like all of these options, are also available for `toJSON`.
+ * Transforms, like all of these options, are also available for `toJSON`. See [this guide to `JSON.stringify()`](https://thecodebarbarian.com/the-80-20-guide-to-json-stringify-in-javascript.html) to learn why `toJSON()` and `toObject()` are separate functions.
  *
  * See [schema options](/docs/guide.html#toObject) for some more details.
  *
@@ -74201,7 +74604,8 @@ Document.prototype.$toObject = function(options, json) {
  *
  * @param {Object} [options]
  * @param {Boolean} [options.getters=false] if true, apply all getters, including virtuals
- * @param {Boolean} [options.virtuals=false] if true, apply virtuals. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals
+ * @param {Boolean} [options.virtuals=false] if true, apply virtuals, including aliases. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals
+ * @param {Boolean} [options.aliases=true] if `options.virtuals = true`, you can set `options.aliases = false` to skip applying aliases. This option is a no-op if `options.virtuals = false`.
  * @param {Boolean} [options.minimize=true] if true, omit any empty objects from the output
  * @param {Function|null} [options.transform=null] if set, mongoose will call this function to allow you to transform the returned object
  * @param {Boolean} [options.depopulate=false] if true, replace any conventionally populated paths with the original id in the output. Has no affect on virtual populated paths.
@@ -74255,55 +74659,76 @@ function minimize(obj) {
 
 /*!
  * Applies virtuals properties to `json`.
- *
- * @param {Document} self
- * @param {Object} json
- * @param {String} type either `virtuals` or `paths`
- * @return {Object} `json`
  */
 
-function applyGetters(self, json, type, options) {
+function applyVirtuals(self, json, options, toObjectOptions) {
   const schema = self.schema;
-  const paths = Object.keys(schema[type]);
+  const paths = Object.keys(schema.virtuals);
   let i = paths.length;
   const numPaths = i;
   let path;
   let assignPath;
   let cur = self._doc;
   let v;
+  const aliases = get(toObjectOptions, 'aliases', true);
 
   if (!cur) {
     return json;
   }
 
-  if (type === 'virtuals') {
-    options = options || {};
-    for (i = 0; i < numPaths; ++i) {
-      path = paths[i];
-      // We may be applying virtuals to a nested object, for example if calling
-      // `doc.nestedProp.toJSON()`. If so, the path we assign to, `assignPath`,
-      // will be a trailing substring of the `path`.
-      assignPath = path;
-      if (options.path != null) {
-        if (!path.startsWith(options.path + '.')) {
-          continue;
-        }
-        assignPath = path.substr(options.path.length + 1);
-      }
-      const parts = assignPath.split('.');
-      v = clone(self.get(path), options);
-      if (v === void 0) {
-        continue;
-      }
-      const plen = parts.length;
-      cur = json;
-      for (let j = 0; j < plen - 1; ++j) {
-        cur[parts[j]] = cur[parts[j]] || {};
-        cur = cur[parts[j]];
-      }
-      cur[parts[plen - 1]] = v;
+  options = options || {};
+  for (i = 0; i < numPaths; ++i) {
+    path = paths[i];
+
+    // Allow skipping aliases with `toObject({ virtuals: true, aliases: false })`
+    if (!aliases && schema.aliases.hasOwnProperty(path)) {
+      continue;
     }
 
+    // We may be applying virtuals to a nested object, for example if calling
+    // `doc.nestedProp.toJSON()`. If so, the path we assign to, `assignPath`,
+    // will be a trailing substring of the `path`.
+    assignPath = path;
+    if (options.path != null) {
+      if (!path.startsWith(options.path + '.')) {
+        continue;
+      }
+      assignPath = path.substr(options.path.length + 1);
+    }
+    const parts = assignPath.split('.');
+    v = clone(self.get(path), options);
+    if (v === void 0) {
+      continue;
+    }
+    const plen = parts.length;
+    cur = json;
+    for (let j = 0; j < plen - 1; ++j) {
+      cur[parts[j]] = cur[parts[j]] || {};
+      cur = cur[parts[j]];
+    }
+    cur[parts[plen - 1]] = v;
+  }
+
+  return json;
+}
+
+/*!
+ * Applies virtuals properties to `json`.
+ *
+ * @param {Document} self
+ * @param {Object} json
+ * @return {Object} `json`
+ */
+
+function applyGetters(self, json, options) {
+  const schema = self.schema;
+  const paths = Object.keys(schema.paths);
+  let i = paths.length;
+  let path;
+  let cur = self._doc;
+  let v;
+
+  if (!cur) {
     return json;
   }
 
@@ -74316,6 +74741,10 @@ function applyGetters(self, json, type, options) {
     let branch = json;
     let part;
     cur = self._doc;
+
+    if (!self.isSelected(path)) {
+      continue;
+    }
 
     for (let ii = 0; ii < plen; ++ii) {
       part = parts[ii];
@@ -74355,6 +74784,7 @@ function applyGetters(self, json, type, options) {
  * @param {Object} options
  * @return {Object}
  * @see Document#toObject #document_Document-toObject
+ * @see JSON.stringify() in JavaScript https://thecodebarbarian.com/the-80-20-guide-to-json-stringify-in-javascript.html
  * @api public
  * @memberOf Document
  * @instance
@@ -74380,7 +74810,15 @@ Document.prototype.inspect = function(options) {
     opts = options;
     opts.minimize = false;
   }
-  return this.toObject(opts);
+  const ret = this.toObject(opts);
+
+  if (ret == null) {
+    // If `toObject()` returns null, `this` is still an object, so if `inspect()`
+    // prints out null this can cause some serious confusion. See gh-7942.
+    return 'MongooseDocument { ' + ret + ' }';
+  }
+
+  return ret;
 };
 
 if (inspect.custom) {
@@ -74401,7 +74839,11 @@ if (inspect.custom) {
  */
 
 Document.prototype.toString = function() {
-  return inspect(this.inspect());
+  const ret = this.inspect();
+  if (typeof ret === 'string') {
+    return ret;
+  }
+  return inspect(ret);
 };
 
 /**
@@ -74601,7 +75043,6 @@ Document.prototype.populated = function(path, val, options) {
   }
 
   // internal
-
   if (val === true) {
     if (!this.$__.populated) {
       return undefined;
@@ -74611,6 +75052,22 @@ Document.prototype.populated = function(path, val, options) {
 
   this.$__.populated || (this.$__.populated = {});
   this.$__.populated[path] = {value: val, options: options};
+
+  // If this was a nested populate, make sure each populated doc knows
+  // about its populated children (gh-7685)
+  const pieces = path.split('.');
+  for (let i = 0; i < pieces.length - 1; ++i) {
+    const subpath = pieces.slice(0, i + 1).join('.');
+    const subdoc = this.get(subpath);
+    if (subdoc != null && subdoc.$__ != null && this.populated(subpath)) {
+      const rest = pieces.slice(i + 1).join('.');
+      subdoc.populated(rest, val, options);
+      // No need to continue because the above recursion should take care of
+      // marking the rest of the docs as populated
+      break;
+    }
+  }
+
   return val;
 };
 
@@ -74671,7 +75128,7 @@ Document.prototype.depopulate = function(path) {
     if (virtualKeys.indexOf(path[i]) !== -1) {
       delete this.$$populatedVirtuals[path[i]];
       delete this._doc[path[i]];
-    } else {
+    } else if (populatedIds) {
       this.$set(path[i], populatedIds);
     }
   }
@@ -74703,7 +75160,7 @@ Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")},require('_process'))
-},{"../../is-buffer/index.js":246,"./error":269,"./error/objectExpected":274,"./error/objectParameter":275,"./error/strict":278,"./helpers/common":282,"./helpers/document/cleanModifiedSubpaths":283,"./helpers/document/compile":284,"./helpers/document/getEmbeddedDiscriminatorPath":285,"./helpers/get":286,"./helpers/projection/isDefiningProjection":291,"./helpers/projection/isExclusive":292,"./helpers/symbols":297,"./internal":300,"./options":301,"./plugins/idGetter":302,"./schema/mixed":315,"./schematype":326,"./types/array":328,"./types/documentarray":331,"./types/embedded":332,"./utils":337,"./virtualtype":338,"_process":352,"events":243,"mpath":340,"util":366}],260:[function(require,module,exports){
+},{"../../is-buffer/index.js":245,"./error/index":268,"./error/objectExpected":273,"./error/objectParameter":274,"./error/strict":277,"./helpers/common":281,"./helpers/document/cleanModifiedSubpaths":284,"./helpers/document/compile":285,"./helpers/document/getEmbeddedDiscriminatorPath":286,"./helpers/get":287,"./helpers/projection/isDefiningProjection":292,"./helpers/projection/isExclusive":293,"./helpers/symbols":300,"./internal":303,"./options":304,"./plugins/idGetter":313,"./schema/mixed":326,"./schematype":337,"./types/array":339,"./types/documentarray":343,"./types/embedded":344,"./utils":349,"./virtualtype":350,"_process":367,"events":243,"mpath":353,"util":381}],259:[function(require,module,exports){
 'use strict';
 
 /* eslint-env browser */
@@ -74735,7 +75192,7 @@ module.exports.setBrowser = function(flag) {
   isBrowser = flag;
 };
 
-},{"./browserDocument.js":251,"./document.js":259}],261:[function(require,module,exports){
+},{"./browserDocument.js":250,"./document.js":258}],260:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -74752,7 +75209,7 @@ module.exports.set = function(v) {
   driver = v;
 };
 
-},{}],262:[function(require,module,exports){
+},{}],261:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -74761,7 +75218,7 @@ module.exports.set = function(v) {
 
 module.exports = function() {};
 
-},{}],263:[function(require,module,exports){
+},{}],262:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -74777,7 +75234,7 @@ const Binary = require('bson').Binary;
 
 module.exports = exports = Binary;
 
-},{"bson":88}],264:[function(require,module,exports){
+},{"bson":88}],263:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -74786,7 +75243,7 @@ module.exports = exports = Binary;
 
 module.exports = require('bson').Decimal128;
 
-},{"bson":88}],265:[function(require,module,exports){
+},{"bson":88}],264:[function(require,module,exports){
 /*!
  * Module exports.
  */
@@ -74801,7 +75258,7 @@ exports.Decimal128 = require('./decimal128');
 exports.ObjectId = require('./objectid');
 exports.ReadPreference = require('./ReadPreference');
 
-},{"./ReadPreference":262,"./binary":263,"./decimal128":264,"./objectid":266}],266:[function(require,module,exports){
+},{"./ReadPreference":261,"./binary":262,"./decimal128":263,"./objectid":265}],265:[function(require,module,exports){
 
 /*!
  * [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) ObjectId
@@ -74831,7 +75288,7 @@ Object.defineProperty(ObjectId.prototype, '_id', {
 
 module.exports = exports = ObjectId;
 
-},{"bson":88}],267:[function(require,module,exports){
+},{"bson":88}],266:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -74853,7 +75310,7 @@ const util = require('util');
 function CastError(type, value, path, reason) {
   let stringValue = util.inspect(value);
   stringValue = stringValue.replace(/^'/, '"').replace(/'$/, '"');
-  if (stringValue.charAt(0) !== '"') {
+  if (!stringValue.startsWith('"')) {
     stringValue = '"' + stringValue + '"';
   }
   MongooseError.call(this, 'Cast to ' + type + ' failed for value ' +
@@ -74895,7 +75352,7 @@ CastError.prototype.setModel = function(model) {
 
 module.exports = CastError;
 
-},{"./mongooseError":272,"util":366}],268:[function(require,module,exports){
+},{"./mongooseError":271,"util":381}],267:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -74945,10 +75402,52 @@ DivergentArrayError.prototype.constructor = MongooseError;
 
 module.exports = DivergentArrayError;
 
-},{"./":269}],269:[function(require,module,exports){
+},{"./":268}],268:[function(require,module,exports){
 'use strict';
 
+/**
+ * MongooseError constructor. MongooseError is the base class for all
+ * Mongoose-specific errors.
+ *
+ * ####Example:
+ *     const Model = mongoose.model('Test', new Schema({ answer: Number }));
+ *     const doc = new Model({ answer: 'not a number' });
+ *     const err = doc.validateSync();
+ *
+ *     err instanceof mongoose.Error; // true
+ *
+ * @constructor Error
+ * @param {String} msg Error message
+ * @inherits Error https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
+ */
+
 const MongooseError = require('./mongooseError');
+
+/**
+ * The name of the error. The name uniquely identifies this Mongoose error. The
+ * possible values are:
+ *
+ * - `MongooseError`: general Mongoose error
+ * - `CastError`: Mongoose could not convert a value to the type defined in the schema path. May be in a `ValidationError` class' `errors` property.
+ * - `DisconnectedError`: This [connection](connections.html) timed out in trying to reconnect to MongoDB and will not successfully reconnect to MongoDB unless you explicitly reconnect.
+ * - `DivergentArrayError`: You attempted to `save()` an array that was modified after you loaded it with a `$elemMatch` or similar projection
+ * - `MissingSchemaError`: You tried to access a model with [`mongoose.model()`](api.html#mongoose_Mongoose-model) that was not defined
+ * - `DocumentNotFoundError`: The document you tried to [`save()`](api.html#document_Document-save) was not found
+ * - `ValidatorError`: error from an individual schema path's validator
+ * - `ValidationError`: error returned from [`validate()`](api.html#document_Document-validate) or [`validateSync()`](api.html#document_Document-validateSync). Contains zero or more `ValidatorError` instances in `.errors` property.
+ * - `MissingSchemaError`: You called `mongoose.Document()` without a schema
+ * - `ObjectExpectedError`: Thrown when you set a nested path to a non-object value with [strict mode set](guide.html#strict).
+ * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a paramter
+ * - `OverwriteModelError`: Thrown when you call [`mongoose.model()`](api.html#mongoose_Mongoose-model) to re-define a model that was already defined.
+ * - `ParallelSaveError`: Thrown when you call [`save()`](api.html#model_Model-save) on a document when the same document instance is already saving.
+ * - `StrictModeError`: Thrown when you set a path that isn't the schema and [strict mode](guide.html#strict) is set to `throw`.
+ * - `VersionError`: Thrown when the [document is out of sync](guide.html#versionKey)
+ *
+ * @api public
+ * @property {String} name
+ * @memberOf Error
+ * @instance
+ */
 
 /*!
  * Module exports.
@@ -74961,6 +75460,8 @@ module.exports = exports = MongooseError;
  *
  * @see Error.messages #error_messages_MongooseError-messages
  * @api public
+ * @memberOf Error
+ * @static messages
  */
 
 MongooseError.messages = require('./messages');
@@ -74976,6 +75477,8 @@ MongooseError.Messages = MongooseError.messages;
  * the document.
  *
  * @api public
+ * @memberOf Error
+ * @static DocumentNotFoundError
  */
 
 MongooseError.DocumentNotFoundError = require('./notFound');
@@ -74985,6 +75488,8 @@ MongooseError.DocumentNotFoundError = require('./notFound');
  * cast a value.
  *
  * @api public
+ * @memberOf Error
+ * @static CastError
  */
 
 MongooseError.CastError = require('./cast');
@@ -74995,6 +75500,8 @@ MongooseError.CastError = require('./cast');
  * instances of CastError or ValidationError.
  *
  * @api public
+ * @memberOf Error
+ * @static ValidationError
  */
 
 MongooseError.ValidationError = require('./validation');
@@ -75003,6 +75510,8 @@ MongooseError.ValidationError = require('./validation');
  * A `ValidationError` has a hash of `errors` that contain individual `ValidatorError` instances
  *
  * @api public
+ * @memberOf Error
+ * @static ValidatorError
  */
 
 MongooseError.ValidatorError = require('./validator');
@@ -75013,6 +75522,8 @@ MongooseError.ValidatorError = require('./validator');
  * the [`versionKey` option](/docs/guide.html#versionKey) for more information.
  *
  * @api public
+ * @memberOf Error
+ * @static VersionError
  */
 
 MongooseError.VersionError = require('./version');
@@ -75023,6 +75534,8 @@ MongooseError.VersionError = require('./version');
  * information.
  *
  * @api public
+ * @memberOf Error
+ * @static ParallelSaveError
  */
 
 MongooseError.ParallelSaveError = require('./parallelSave');
@@ -75032,6 +75545,8 @@ MongooseError.ParallelSaveError = require('./parallelSave');
  * See [the FAQ about `OverwriteModelError`](/docs/faq.html#overwrite-model-error).
  *
  * @api public
+ * @memberOf Error
+ * @static OverwriteModelError
  */
 
 MongooseError.OverwriteModelError = require('./overwriteModel');
@@ -75040,6 +75555,8 @@ MongooseError.OverwriteModelError = require('./overwriteModel');
  * Thrown when you try to access a model that has not been registered yet
  *
  * @api public
+ * @memberOf Error
+ * @static MissingSchemaError
  */
 
 MongooseError.MissingSchemaError = require('./missingSchema');
@@ -75049,11 +75566,25 @@ MongooseError.MissingSchemaError = require('./missingSchema');
  * and then modified the array in an unsafe way.
  *
  * @api public
+ * @memberOf Error
+ * @static DivergentArrayError
  */
 
 MongooseError.DivergentArrayError = require('./divergentArray');
 
-},{"./cast":267,"./divergentArray":268,"./messages":270,"./missingSchema":271,"./mongooseError":272,"./notFound":273,"./overwriteModel":276,"./parallelSave":277,"./validation":279,"./validator":280,"./version":281}],270:[function(require,module,exports){
+/**
+ * Thrown when your try to pass values to model contrtuctor that
+ * were not specified in schema or change immutable properties when
+ * `strict` mode is `"throw"`
+ *
+ * @api public
+ * @memberOf Error
+ * @static StrictModeError
+ */
+
+MongooseError.StrictModeError = require('./strict');
+
+},{"./cast":266,"./divergentArray":267,"./messages":269,"./missingSchema":270,"./mongooseError":271,"./notFound":272,"./overwriteModel":275,"./parallelSave":276,"./strict":277,"./validation":278,"./validator":279,"./version":280}],269:[function(require,module,exports){
 
 /**
  * The default built-in validator error messages. These may be customized.
@@ -75101,7 +75632,7 @@ msg.String.match = 'Path `{PATH}` is invalid ({VALUE}).';
 msg.String.minlength = 'Path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).';
 msg.String.maxlength = 'Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length ({MAXLENGTH}).';
 
-},{}],271:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -75142,15 +75673,11 @@ MissingSchemaError.prototype.constructor = MongooseError;
 
 module.exports = MissingSchemaError;
 
-},{"./":269}],272:[function(require,module,exports){
+},{"./":268}],271:[function(require,module,exports){
 'use strict';
 
-/**
- * MongooseError constructor. MongooseError is the base class for all
- * Mongoose-specific errors.
- *
- * @param {String} msg Error message
- * @inherits Error https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
+/*!
+ * ignore
  */
 
 function MongooseError(msg) {
@@ -75171,35 +75698,8 @@ function MongooseError(msg) {
 MongooseError.prototype = Object.create(Error.prototype);
 MongooseError.prototype.constructor = Error;
 
-/**
- * The name of the error. The name uniquely identifies this Mongoose error. The
- * possible values are:
- *
- * - `MongooseError`: general Mongoose error
- * - `CastError`: Mongoose could not convert a value to the type defined in the schema path. May be in a `ValidationError` class' `errors` property.
- * - `DisconnectedError`: This [connection](connections.html) timed out in trying to reconnect to MongoDB and will not successfully reconnect to MongoDB unless you explicitly reconnect.
- * - `DivergentArrayError`: You attempted to `save()` an array that was modified after you loaded it with a `$elemMatch` or similar projection
- * - `MissingSchemaError`: You tried to access a model with [`mongoose.model()`](api.html#mongoose_Mongoose-model) that was not defined
- * - `DocumentNotFoundError`: The document you tried to [`save()`](api.html#document_Document-save) was not found
- * - `ValidatorError`: error from an individual schema path's validator
- * - `ValidationError`: error returned from [`validate()`](api.html#document_Document-validate) or [`validateSync()`](api.html#document_Document-validateSync). Contains zero or more `ValidatorError` instances in `.errors` property.
- * - `MissingSchemaError`: You called `mongoose.Document()` without a schema
- * - `ObjectExpectedError`: Thrown when you set a nested path to a non-object value with [strict mode set](guide.html#strict).
- * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a paramter
- * - `OverwriteModelError`: Thrown when you call [`mongoose.model()`](api.html#mongoose_Mongoose-model) to re-define a model that was already defined.
- * - `ParallelSaveError`: Thrown when you call [`save()`](api.html#model_Model-save) on a document when the same document instance is already saving.
- * - `StrictModeError`: Thrown when you set a path that isn't the schema and [strict mode](guide.html#strict) is set to `throw`.
- * - `VersionError`: Thrown when the [document is out of sync](guide.html#versionKey)
- *
- * @api public
- * @property name
- * @memberOf MongooseError
- * @instance
- */
-
 module.exports = MongooseError;
-
-},{}],273:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75215,20 +75715,23 @@ const util = require('util');
  * @inherits MongooseError
  */
 
-function DocumentNotFoundError(filter) {
+function DocumentNotFoundError(filter, model, numAffected, result) {
   let msg;
   const messages = MongooseError.messages;
   if (messages.DocumentNotFoundError != null) {
     msg = typeof messages.DocumentNotFoundError === 'function' ?
-      messages.DocumentNotFoundError(filter) :
+      messages.DocumentNotFoundError(filter, model) :
       messages.DocumentNotFoundError;
   } else {
-    msg = 'No document found for query "' + util.inspect(filter) + '"';
+    msg = 'No document found for query "' + util.inspect(filter) +
+      '" on model "' + model + '"';
   }
 
   MongooseError.call(this, msg);
 
   this.name = 'DocumentNotFoundError';
+  this.result = result;
+  this.numAffected = numAffected;
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
@@ -75253,7 +75756,7 @@ DocumentNotFoundError.prototype.constructor = MongooseError;
 
 module.exports = DocumentNotFoundError;
 
-},{"./":269,"util":366}],274:[function(require,module,exports){
+},{"./":268,"util":381}],273:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75272,8 +75775,9 @@ const MongooseError = require('./');
  */
 
 function ObjectExpectedError(path, val) {
+  const typeDescription = Array.isArray(val) ? 'array' : 'primitive value';
   MongooseError.call(this, 'Tried to set nested object field `' + path +
-    '` to primitive value `' + val + '` and strict mode is set to throw.');
+    `\` to ${typeDescription} \`` + val + '` and strict mode is set to throw.');
   this.name = 'ObjectExpectedError';
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
@@ -75292,7 +75796,7 @@ ObjectExpectedError.prototype.constructor = MongooseError;
 
 module.exports = ObjectExpectedError;
 
-},{"./":269}],275:[function(require,module,exports){
+},{"./":268}],274:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75332,7 +75836,7 @@ ObjectParameterError.prototype.constructor = MongooseError;
 
 module.exports = ObjectParameterError;
 
-},{"./":269}],276:[function(require,module,exports){
+},{"./":268}],275:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -75371,7 +75875,7 @@ OverwriteModelError.prototype.constructor = MongooseError;
 
 module.exports = OverwriteModelError;
 
-},{"./":269}],277:[function(require,module,exports){
+},{"./":268}],276:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75406,7 +75910,7 @@ ParallelSaveError.prototype.constructor = MongooseError;
 
 module.exports = ParallelSaveError;
 
-},{"./":269}],278:[function(require,module,exports){
+},{"./":268}],277:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75424,11 +75928,12 @@ const MongooseError = require('./');
  * @api private
  */
 
-function StrictModeError(path, msg) {
+function StrictModeError(path, msg, immutable) {
   msg = msg || 'Field `' + path + '` is not in schema and strict ' +
     'mode is set to throw.';
   MongooseError.call(this, msg);
   this.name = 'StrictModeError';
+  this.isImmutableError = !!immutable;
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
@@ -75446,7 +75951,7 @@ StrictModeError.prototype.constructor = MongooseError;
 
 module.exports = StrictModeError;
 
-},{"./":269}],279:[function(require,module,exports){
+},{"./":268}],278:[function(require,module,exports){
 /*!
  * Module requirements
  */
@@ -75467,19 +75972,21 @@ const util = require('util');
 function ValidationError(instance) {
   this.errors = {};
   this._message = '';
+
+  MongooseError.call(this, this._message);
   if (instance && instance.constructor.name === 'model') {
     this._message = instance.constructor.modelName + ' validation failed';
-    MongooseError.call(this, this._message);
   } else {
     this._message = 'Validation failed';
-    MongooseError.call(this, this._message);
   }
   this.name = 'ValidationError';
+
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
     this.stack = new Error().stack;
   }
+
   if (instance) {
     instance.errors = this.errors;
   }
@@ -75560,7 +76067,7 @@ function _generateMessage(err) {
 
 module.exports = exports = ValidationError;
 
-},{"./":269,"util":366}],280:[function(require,module,exports){
+},{"./":268,"util":381}],279:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75651,7 +76158,7 @@ ValidatorError.prototype.toString = function() {
 
 module.exports = ValidatorError;
 
-},{"./":269}],281:[function(require,module,exports){
+},{"./":268}],280:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75689,7 +76196,7 @@ VersionError.prototype.constructor = MongooseError;
 
 module.exports = VersionError;
 
-},{"./":269}],282:[function(require,module,exports){
+},{"./":268}],281:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -75697,6 +76204,7 @@ module.exports = VersionError;
  * Module dependencies.
  */
 
+const Decimal128 = require('../types/decimal128');
 const ObjectId = require('../types/objectid');
 const utils = require('../utils');
 
@@ -75707,7 +76215,7 @@ exports.modifiedPaths = modifiedPaths;
  * ignore
  */
 
-function flatten(update, path, options) {
+function flatten(update, path, options, schema) {
   let keys;
   if (update && utils.isMongooseObject(update) && !Buffer.isBuffer(update)) {
     keys = Object.keys(update.toObject({ transform: false, virtuals: false }));
@@ -75723,11 +76231,16 @@ function flatten(update, path, options) {
     const key = keys[i];
     const val = update[key];
     result[path + key] = val;
+
+    // Avoid going into mixed paths if schema is specified
+    const keySchema = schema && schema.path && schema.path(path + key);
+    if (keySchema && keySchema.instance === 'Mixed') continue;
+
     if (shouldFlatten(val)) {
       if (options && options.skipArrays && Array.isArray(val)) {
         continue;
       }
-      const flat = flatten(val, path + key, options);
+      const flat = flatten(val, path + key, options, schema);
       for (const k in flat) {
         result[k] = flat[k];
       }
@@ -75776,11 +76289,51 @@ function shouldFlatten(val) {
     !(val instanceof Date) &&
     !(val instanceof ObjectId) &&
     (!Array.isArray(val) || val.length > 0) &&
-    !(val instanceof Buffer);
+    !(val instanceof Buffer) &&
+    !(val instanceof Decimal128);
 }
 
 }).call(this,require("buffer").Buffer)
-},{"../types/objectid":335,"../utils":337,"buffer":107}],283:[function(require,module,exports){
+},{"../types/decimal128":342,"../types/objectid":347,"../utils":349,"buffer":107}],282:[function(require,module,exports){
+'use strict';
+
+module.exports = function checkEmbeddedDiscriminatorKeyProjection(userProjection, path, schema, selected, addedPaths) {
+  const userProjectedInPath = Object.keys(userProjection).
+    reduce((cur, key) => cur || key.startsWith(path + '.'), false);
+  const _discriminatorKey = path + '.' + schema.options.discriminatorKey;
+  if (!userProjectedInPath &&
+      addedPaths.length === 1 &&
+      addedPaths[0] === _discriminatorKey) {
+    selected.splice(selected.indexOf(_discriminatorKey), 1);
+  }
+};
+},{}],283:[function(require,module,exports){
+'use strict';
+
+const getDiscriminatorByValue = require('../../queryhelpers').getDiscriminatorByValue;
+
+/*!
+ * Find the correct constructor, taking into account discriminators
+ */
+
+module.exports = function getConstructor(Constructor, value) {
+  const discriminatorKey = Constructor.schema.options.discriminatorKey;
+  if (value != null &&
+      Constructor.discriminators &&
+      value[discriminatorKey] != null) {
+    if (Constructor.discriminators[value[discriminatorKey]]) {
+      Constructor = Constructor.discriminators[value[discriminatorKey]];
+    } else {
+      const constructorByValue = getDiscriminatorByValue(Constructor, value[discriminatorKey]);
+      if (constructorByValue) {
+        Constructor = constructorByValue;
+      }
+    }
+  }
+
+  return Constructor;
+};
+},{"../../queryhelpers":315}],284:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75792,6 +76345,9 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   const skipDocArrays = options.skipDocArrays;
 
   let deleted = 0;
+  if (!doc) {
+    return deleted;
+  }
   for (const modifiedPath of Object.keys(doc.$__.activePaths.states.modify)) {
     if (skipDocArrays) {
       const schemaType = doc.schema.path(modifiedPath);
@@ -75799,7 +76355,7 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
         continue;
       }
     }
-    if (modifiedPath.indexOf(path + '.') === 0) {
+    if (modifiedPath.startsWith(path + '.')) {
       delete doc.$__.activePaths.states.modify[modifiedPath];
       ++deleted;
     }
@@ -75807,9 +76363,10 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   return deleted;
 };
 
-},{}],284:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 'use strict';
 
+const documentSchemaSymbol = require('../../helpers/symbols').documentSchemaSymbol;
 const get = require('../../helpers/get');
 const getSymbol = require('../../helpers/symbols').getSymbol;
 const utils = require('../../utils');
@@ -75881,6 +76438,13 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
             value: prototype.schema
           });
 
+          Object.defineProperty(nested, documentSchemaSymbol, {
+            enumerable: false,
+            configurable: true,
+            writable: false,
+            value: prototype.schema
+          });
+
           Object.defineProperty(nested, 'toObject', {
             enumerable: false,
             configurable: true,
@@ -75908,6 +76472,21 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
             configurable: true,
             writable: false,
             value: true
+          });
+
+          const _isEmptyOptions = Object.freeze({
+            minimize: true,
+            virtuals: false,
+            getters: false,
+            transform: false
+          });
+          Object.defineProperty(nested, '$isEmpty', {
+            enumerable: false,
+            configurable: true,
+            writable: false,
+            value: function() {
+              return Object.keys(this.get(path, null, _isEmptyOptions) || {}).length === 0;
+            }
           });
 
           compile(subprops, nested, path, options);
@@ -75950,13 +76529,13 @@ function getOwnPropertyDescriptors(object) {
       delete result[key];
       return;
     }
-    result[key].enumerable = ['isNew', '$__', 'errors', '_doc'].indexOf(key) === -1;
+    result[key].enumerable = ['isNew', '$__', 'errors', '_doc', '$locals'].indexOf(key) === -1;
   });
 
   return result;
 }
 
-},{"../../document":259,"../../helpers/get":286,"../../helpers/symbols":297,"../../utils":337}],285:[function(require,module,exports){
+},{"../../document":258,"../../helpers/get":287,"../../helpers/symbols":300,"../../utils":349}],286:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -75977,7 +76556,11 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
     const subpath = parts.slice(0, i + 1).join('.');
     schema = doc.schema.path(subpath);
     if (schema == null) {
+      type = 'adhocOrUndefined';
       continue;
+    }
+    if (schema.instance === 'Mixed') {
+      return typeOnly ? 'real' : schema;
     }
     type = doc.schema.pathType(subpath);
     if ((schema.$isSingleNested || schema.$isMongooseDocumentArrayElement) &&
@@ -75989,11 +76572,7 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
         continue;
       }
       const rest = parts.slice(i + 1).join('.');
-      schema = discriminators[discriminatorKey].path(rest);
-      if (schema != null) {
-        type = discriminators[discriminatorKey].pathType(rest);
-        break;
-      }
+      return getEmbeddedDiscriminatorPath(doc.get(subpath), rest, options);
     }
   }
 
@@ -76001,7 +76580,7 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
   return typeOnly ? type : schema;
 };
 
-},{"../get":286}],286:[function(require,module,exports){
+},{"../get":287}],287:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76041,7 +76620,7 @@ function getProperty(obj, prop) {
   }
   return obj[prop];
 }
-},{}],287:[function(require,module,exports){
+},{}],288:[function(require,module,exports){
 (function (process){
 /*!
  * Centralize this so we can more easily work around issues with people
@@ -76057,7 +76636,7 @@ module.exports = function immediate(cb) {
 };
 
 }).call(this,require('_process'))
-},{"_process":352}],288:[function(require,module,exports){
+},{"_process":367}],289:[function(require,module,exports){
 'use strict';
 
 const symbols = require('../../schema/symbols');
@@ -76074,6 +76653,7 @@ module.exports = applyHooks;
  */
 
 applyHooks.middlewareFunctions = [
+  'deleteOne',
   'save',
   'validate',
   'remove',
@@ -76100,12 +76680,22 @@ function applyHooks(model, schema, options) {
   const objToDecorate = options.decorateDoc ? model : model.prototype;
 
   model.$appliedHooks = true;
-  for (let i = 0; i < schema.childSchemas.length; ++i) {
-    const childModel = schema.childSchemas[i].model;
+  for (const key of Object.keys(schema.paths)) {
+    const type = schema.paths[key];
+    let childModel = null;
+    if (type.$isSingleNested) {
+      childModel = type.caster;
+    } else if (type.$isMongooseDocumentArray) {
+      childModel = type.Constructor;
+    } else {
+      continue;
+    }
+
     if (childModel.$appliedHooks) {
       continue;
     }
-    applyHooks(childModel, schema.childSchemas[i].schema, options);
+
+    applyHooks(childModel, type.schema, options);
     if (childModel.discriminators != null) {
       const keys = Object.keys(childModel.discriminators);
       for (let j = 0; j < keys.length; ++j) {
@@ -76121,7 +76711,7 @@ function applyHooks(model, schema, options) {
 
   const middleware = schema.s.hooks.
     filter(hook => {
-      if (hook.name === 'updateOne') {
+      if (hook.name === 'updateOne' || hook.name === 'deleteOne') {
         return !!hook['document'];
       }
       if (hook.name === 'remove') {
@@ -76142,10 +76732,14 @@ function applyHooks(model, schema, options) {
 
   objToDecorate.$__save = middleware.
     createWrapper('save', objToDecorate.$__save, null, kareemOptions);
+
+  objToDecorate.$__originalValidate = objToDecorate.$__originalValidate || objToDecorate.$__validate;
   objToDecorate.$__validate = middleware.
-    createWrapper('validate', objToDecorate.$__validate, null, kareemOptions);
+    createWrapper('validate', objToDecorate.$__originalValidate, null, kareemOptions);
   objToDecorate.$__remove = middleware.
     createWrapper('remove', objToDecorate.$__remove, null, kareemOptions);
+  objToDecorate.$__deleteOne = middleware.
+    createWrapper('deleteOne', objToDecorate.$__deleteOne, null, kareemOptions);
   objToDecorate.$__init = middleware.
     createWrapperSync('init', objToDecorate.$__init, null, kareemOptions);
 
@@ -76181,7 +76775,7 @@ function applyHooks(model, schema, options) {
   }
 }
 
-},{"../../schema/symbols":325,"../../utils":337}],289:[function(require,module,exports){
+},{"../../schema/symbols":336,"../../utils":349}],290:[function(require,module,exports){
 'use strict';
 
 const defineKey = require('../document/compile').defineKey;
@@ -76222,15 +76816,23 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
 
   const key = model.schema.options.discriminatorKey;
 
-  const baseSchemaAddition = {};
-  baseSchemaAddition[key] = {
-    default: void 0,
-    select: true,
-    $skipDiscriminatorCheck: true
-  };
-  baseSchemaAddition[key][model.schema.options.typeKey] = String;
-  model.schema.add(baseSchemaAddition);
-  defineKey(key, null, model.prototype, null, [key], model.schema.options);
+  const existingPath = model.schema.path(key);
+  if (existingPath != null) {
+    if (!utils.hasUserDefinedProperty(existingPath.options, 'select')) {
+      existingPath.options.select = true;
+    }
+    existingPath.options.$skipDiscriminatorCheck = true;
+  } else {
+    const baseSchemaAddition = {};
+    baseSchemaAddition[key] = {
+      default: void 0,
+      select: true,
+      $skipDiscriminatorCheck: true
+    };
+    baseSchemaAddition[key][model.schema.options.typeKey] = String;
+    model.schema.add(baseSchemaAddition);
+    defineKey(key, null, model.prototype, null, [key], model.schema.options);
+  }
 
   if (schema.path(key) && schema.path(key).options.$skipDiscriminatorCheck !== true) {
     throw new Error('Discriminator "' + name +
@@ -76244,7 +76846,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
 
   function merge(schema, baseSchema) {
     // Retain original schema before merging base schema
-    schema._originalSchema = schema.clone();
+    schema._baseSchema = baseSchema;
     if (baseSchema.paths._id &&
         baseSchema.paths._id.options &&
         !baseSchema.paths._id.options.auto) {
@@ -76266,7 +76868,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     }
 
     utils.merge(schema, baseSchema, {
-      omit: { discriminators: true, $parentSchema: true },
+      omit: { discriminators: true },
       omitNested: conflictingPaths.reduce((cur, path) => {
         cur['tree.' + path] = true;
         return cur;
@@ -76277,6 +76879,11 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     for (let i = 0; i < conflictingPaths.length; ++i) {
       delete schema.paths[conflictingPaths[i]];
     }
+
+    // Rebuild schema models because schemas may have been merged re: #7884
+    schema.childSchemas.forEach(obj => {
+      obj.model.prototype.$__setSchema(obj.schema);
+    });
 
     const obj = {};
     obj[key] = {
@@ -76290,7 +76897,9 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
       },
       $skipDiscriminatorCheck: true
     };
-    obj[key][schema.options.typeKey] = String;
+    obj[key][schema.options.typeKey] = existingPath ?
+      existingPath.instance :
+      String;
     schema.add(obj);
     schema.discriminatorMapping = {key: key, value: value, isRoot: false};
 
@@ -76355,7 +76964,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
   return schema;
 };
 
-},{"../../utils":337,"../document/compile":284,"../get":286}],290:[function(require,module,exports){
+},{"../../utils":349,"../document/compile":285,"../get":287}],291:[function(require,module,exports){
 'use strict';
 
 const MongooseError = require('../../error/mongooseError');
@@ -76375,7 +76984,7 @@ function validateRef(ref, path) {
   throw new MongooseError('Invalid ref at path "' + path + '". Got ' +
     util.inspect(ref, { depth: 0 }));
 }
-},{"../../error/mongooseError":272,"util":366}],291:[function(require,module,exports){
+},{"../../error/mongooseError":271,"util":381}],292:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76395,7 +77004,7 @@ module.exports = function isDefiningProjection(val) {
   return true;
 };
 
-},{}],292:[function(require,module,exports){
+},{}],293:[function(require,module,exports){
 'use strict';
 
 const isDefiningProjection = require('./isDefiningProjection');
@@ -76425,7 +77034,7 @@ module.exports = function isExclusive(projection) {
   return exclude;
 };
 
-},{"./isDefiningProjection":291}],293:[function(require,module,exports){
+},{"./isDefiningProjection":292}],294:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76443,6 +77052,7 @@ applyQueryMiddleware.middlewareFunctions = [
   'countDocuments',
   'deleteMany',
   'deleteOne',
+  'distinct',
   'estimatedDocumentCount',
   'find',
   'findOne',
@@ -76454,7 +77064,8 @@ applyQueryMiddleware.middlewareFunctions = [
   'replaceOne',
   'update',
   'updateMany',
-  'updateOne'
+  'updateOne',
+  'validate'
 ];
 
 /*!
@@ -76472,10 +77083,13 @@ function applyQueryMiddleware(Query, model) {
   };
 
   const middleware = model.hooks.filter(hook => {
-    if (hook.name === 'updateOne') {
+    if (hook.name === 'updateOne' || hook.name === 'deleteOne') {
       return hook.query == null || !!hook.query;
     }
     if (hook.name === 'remove') {
+      return !!hook.query;
+    }
+    if (hook.name === 'validate') {
       return !!hook.query;
     }
     return true;
@@ -76484,16 +77098,36 @@ function applyQueryMiddleware(Query, model) {
   // `update()` thunk has a different name because `_update` was already taken
   Query.prototype._execUpdate = middleware.createWrapper('update',
     Query.prototype._execUpdate, null, kareemOptions);
+  // `distinct()` thunk has a different name because `_distinct` was already taken
+  Query.prototype.__distinct = middleware.createWrapper('distinct',
+    Query.prototype.__distinct, null, kareemOptions);
+
+  // `validate()` doesn't have a thunk because it doesn't execute a query.
+  Query.prototype.validate = middleware.createWrapper('validate',
+    Query.prototype.validate, null, kareemOptions);
 
   applyQueryMiddleware.middlewareFunctions.
-    filter(v => v !== 'update').
+    filter(v => v !== 'update' && v !== 'distinct' && v !== 'validate').
     forEach(fn => {
       Query.prototype[`_${fn}`] = middleware.createWrapper(fn,
         Query.prototype[`_${fn}`], null, kareemOptions);
     });
 }
 
-},{}],294:[function(require,module,exports){
+},{}],295:[function(require,module,exports){
+'use strict';
+
+/**
+ * For consistency's sake, we replace positional operator `$` and array filters
+ * `$[]` and `$[foo]` with `0` when looking up schema paths.
+ */
+
+module.exports = function cleanPositionalOperators(path) {
+  return path.
+    replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
+    replace(/\.(\[[^\]]*\])?\$$/g, '.0');
+};
+},{}],296:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -76509,7 +77143,7 @@ module.exports = function getIndexes(schema) {
   const schemaStack = new WeakMap();
   const indexTypes = schema.constructor.indexTypes;
 
-  const collectIndexes = function(schema, prefix) {
+  const collectIndexes = function(schema, prefix, baseSchema) {
     // Ignore infinitely nested schemas, if we've already seen this schema
     // along this path there must be a cycle
     if (schemaStack.has(schema)) {
@@ -76524,6 +77158,11 @@ module.exports = function getIndexes(schema) {
     for (let i = 0; i < length; ++i) {
       const key = keys[i];
       const path = schema.paths[key];
+      if (baseSchema != null && baseSchema.paths[key]) {
+        // If looking at an embedded discriminator schema, don't look at paths
+        // that the
+        continue;
+      }
 
       if (path.$isMongooseDocumentArray || path.$isSingleNested) {
         if (get(path, 'options.excludeIndexes') !== true &&
@@ -76535,8 +77174,8 @@ module.exports = function getIndexes(schema) {
           const discriminators = path.schema.discriminators;
           const discriminatorKeys = Object.keys(discriminators);
           for (const discriminatorKey of discriminatorKeys) {
-            collectIndexes(discriminators[discriminatorKey]._originalSchema,
-              prefix + key + '.');
+            collectIndexes(discriminators[discriminatorKey],
+              prefix + key + '.', path.schema);
           }
         }
 
@@ -76619,7 +77258,7 @@ module.exports = function getIndexes(schema) {
   }
 };
 
-},{"../../utils":337,"../get":286}],295:[function(require,module,exports){
+},{"../../utils":349,"../get":287}],297:[function(require,module,exports){
 'use strict';
 
 module.exports = handleTimestampOption;
@@ -76644,11 +77283,11 @@ function handleTimestampOption(arg, prop) {
   }
   return arg[prop];
 }
-},{}],296:[function(require,module,exports){
+},{}],298:[function(require,module,exports){
 'use strict';
 
 module.exports = function merge(s1, s2) {
-  s1.add(s2.obj);
+  s1.add(s2.obj || {});
 
   s1.callQueue = s1.callQueue.concat(s2.callQueue);
   s1.method(s2.methods);
@@ -76659,26 +77298,76 @@ module.exports = function merge(s1, s2) {
   }
 
   for (const virtual in s2.virtuals) {
-    s1.virtual[virtual] = s2.virtual[virtual].clone();
+    s1.virtuals[virtual] = s2.virtuals[virtual].clone();
   }
 
   s1.s.hooks.merge(s2.s.hooks, false);
 };
-},{}],297:[function(require,module,exports){
+
+},{}],299:[function(require,module,exports){
 'use strict';
 
-exports.validatorErrorSymbol = Symbol.for('mongoose:validatorError');
+const StrictModeError = require('../../error/strict');
 
-exports.documentArrayParent = Symbol.for('mongoose:documentArrayParent');
+/*!
+ * ignore
+ */
 
-exports.modelSymbol = Symbol.for('mongoose#Model');
+module.exports = function(schematype) {
+  if (schematype.$immutable) {
+    schematype.$immutableSetter = createImmutableSetter(schematype.path,
+      schematype.options.immutable);
+    schematype.set(schematype.$immutableSetter);
+  } else if (schematype.$immutableSetter) {
+    schematype.setters = schematype.setters.
+      filter(fn => fn !== schematype.$immutableSetter);
+    delete schematype.$immutableSetter;
+  }
+};
 
-exports.getSymbol = Symbol.for('mongoose#Document#get');
+function createImmutableSetter(path, immutable) {
+  return function immutableSetter(v) {
+    if (this == null || this.$__ == null) {
+      return v;
+    }
+    if (this.isNew) {
+      return v;
+    }
 
-exports.objectIdSymbol = Symbol.for('mongoose#ObjectId');
-},{}],298:[function(require,module,exports){
+    const _immutable = typeof immutable === 'function' ?
+      immutable.call(this, this) :
+      immutable;
+    if (!_immutable) {
+      return v;
+    }
+    if (this.$__.strictMode === 'throw' && v !== this[path]) {
+      throw new StrictModeError(path, 'Path `' + path + '` is immutable ' +
+        'and strict mode is set to throw.', true);
+    }
+
+    return this[path];
+  };
+}
+
+},{"../../error/strict":277}],300:[function(require,module,exports){
 'use strict';
 
+exports.arrayAtomicsSymbol = Symbol('mongoose#Array#_atomics');
+exports.arrayParentSymbol = Symbol('mongoose#Array#_parent');
+exports.arrayPathSymbol = Symbol('mongoose#Array#_path');
+exports.arraySchemaSymbol = Symbol('mongoose#Array#_schema');
+exports.documentArrayParent = Symbol('mongoose:documentArrayParent');
+exports.documentSchemaSymbol = Symbol('mongoose#Document#schema');
+exports.getSymbol = Symbol('mongoose#Document#get');
+exports.modelSymbol = Symbol('mongoose#Model');
+exports.objectIdSymbol = Symbol('mongoose#ObjectId');
+exports.populateModelSymbol = Symbol('mongoose.PopulateOptions#Model');
+exports.schemaTypeSymbol = Symbol('mongoose#schemaType');
+exports.validatorErrorSymbol = Symbol('mongoose:validatorError');
+},{}],301:[function(require,module,exports){
+'use strict';
+
+const cleanPositionalOperators = require('../schema/cleanPositionalOperators');
 const handleTimestampOption = require('../schema/handleTimestampOption');
 
 module.exports = applyTimestampsToChildren;
@@ -76699,7 +77388,7 @@ function applyTimestampsToChildren(now, update, schema) {
   let timestamps;
   let path;
 
-  const hasDollarKey = keys.length && keys[0].charAt(0) === '$';
+  const hasDollarKey = keys.length && keys[0].startsWith('$');
 
   if (hasDollarKey) {
     if (update.$push) {
@@ -76736,53 +77425,61 @@ function applyTimestampsToChildren(now, update, schema) {
       const keys = Object.keys(update.$set);
       for (key of keys) {
         // Replace positional operator `$` and array filters `$[]` and `$[.*]`
-        const keyToSearch = key.
-          replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
-          replace(/\.(\[[^\]]*\])?\$$/, '.0');
+        const keyToSearch = cleanPositionalOperators(key);
         path = schema.path(keyToSearch);
         if (!path) {
           continue;
         }
+
+        let parentSchemaType = null;
+        const pieces = keyToSearch.split('.');
+        for (let i = pieces.length - 1; i > 0; --i) {
+          const s = schema.path(pieces.slice(0, i).join('.'));
+          if (s != null &&
+              (s.$isMongooseDocumentArray || s.$isSingleNested)) {
+            parentSchemaType = s;
+            break;
+          }
+        }
+
         if (Array.isArray(update.$set[key]) && path.$isMongooseDocumentArray) {
           applyTimestampsToDocumentArray(update.$set[key], path, now);
         } else if (update.$set[key] && path.$isSingleNested) {
           applyTimestampsToSingleNested(update.$set[key], path, now);
-        } else if (path.$parentSchema !== schema && path.$parentSchema != null) {
-          const parentPath = path.$parentSchema.$schemaType;
-
-          if (parentPath == null) {
-            continue;
-          }
-
-          timestamps = parentPath.schema.options.timestamps;
+        } else if (parentSchemaType != null) {
+          timestamps = parentSchemaType.schema.options.timestamps;
           createdAt = handleTimestampOption(timestamps, 'createdAt');
           updatedAt = handleTimestampOption(timestamps, 'updatedAt');
 
-          if (updatedAt == null) {
+          if (!timestamps || updatedAt == null) {
             continue;
           }
 
-          if (parentPath.$isSingleNested) {
+          if (parentSchemaType.$isSingleNested) {
             // Single nested is easy
-            update.$set[parentPath.path + '.' + updatedAt] = now;
+            update.$set[parentSchemaType.path + '.' + updatedAt] = now;
             continue;
           }
 
-          let childPath = key.substr(parentPath.path.length + 1);
+          let childPath = key.substr(parentSchemaType.path.length + 1);
+
+          if (/^\d+$/.test(childPath)) {
+            update.$set[parentSchemaType.path + '.' + childPath][updatedAt] = now;
+            continue;
+          }
+
           const firstDot = childPath.indexOf('.');
+          childPath = firstDot !== -1 ? childPath.substr(0, firstDot) : childPath;
 
-          // Shouldn't happen, but if it does ignore this path
-          if (firstDot === -1) {
-            continue;
-          }
-
-          childPath = childPath.substr(0, firstDot);
-
-          update.$set[parentPath.path + '.' + childPath + '.' + updatedAt] = now;
-        } else if (path.schema != null && path.schema != schema) {
+          update.$set[parentSchemaType.path + '.' + childPath + '.' + updatedAt] = now;
+        } else if (path.schema != null && path.schema != schema && update.$set[key]) {
           timestamps = path.schema.options.timestamps;
           createdAt = handleTimestampOption(timestamps, 'createdAt');
           updatedAt = handleTimestampOption(timestamps, 'updatedAt');
+
+          if (!timestamps) {
+            continue;
+          }
 
           if (updatedAt != null) {
             update.$set[key][updatedAt] = now;
@@ -76797,9 +77494,7 @@ function applyTimestampsToChildren(now, update, schema) {
     const keys = Object.keys(update).filter(key => !key.startsWith('$'));
     for (key of keys) {
       // Replace positional operator `$` and array filters `$[]` and `$[.*]`
-      const keyToSearch = key.
-        replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
-        replace(/\.(\[[^\]]*\])?\$$/, '.0');
+      const keyToSearch = cleanPositionalOperators(key);
       path = schema.path(keyToSearch);
       if (!path) {
         continue;
@@ -76850,7 +77545,7 @@ function applyTimestampsToSingleNested(subdoc, schematype, now) {
     subdoc[createdAt] = now;
   }
 }
-},{"../schema/handleTimestampOption":295}],299:[function(require,module,exports){
+},{"../schema/cleanPositionalOperators":295,"../schema/handleTimestampOption":297}],302:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76876,29 +77571,35 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
     return currentUpdate;
   }
 
+  const skipCreatedAt = timestamps != null && timestamps.createdAt === false;
+  const skipUpdatedAt = timestamps != null && timestamps.updatedAt === false;
+
   if (overwrite) {
     if (currentUpdate && currentUpdate.$set) {
       currentUpdate = currentUpdate.$set;
       updates.$set = {};
       _updates = updates.$set;
     }
-    if (updatedAt && !currentUpdate[updatedAt]) {
+    if (!skipUpdatedAt && updatedAt && !currentUpdate[updatedAt]) {
       _updates[updatedAt] = now;
     }
-    if (createdAt && !currentUpdate[createdAt]) {
+    if (!skipCreatedAt && createdAt && !currentUpdate[createdAt]) {
       _updates[createdAt] = now;
     }
     return updates;
   }
-  updates.$set = updates.$set || {};
   currentUpdate = currentUpdate || {};
 
-  if (updatedAt &&
+  updates.$set = updates.$set || {};
+  if (!skipUpdatedAt && updatedAt &&
       (!currentUpdate.$currentDate || !currentUpdate.$currentDate[updatedAt])) {
     updates.$set[updatedAt] = now;
+    if (updates.hasOwnProperty(updatedAt)) {
+      delete updates[updatedAt];
+    }
   }
 
-  if (createdAt) {
+  if (!skipCreatedAt && createdAt) {
     if (currentUpdate[createdAt]) {
       delete currentUpdate[createdAt];
     }
@@ -76917,7 +77618,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
   return updates;
 }
 
-},{"../get":286}],300:[function(require,module,exports){
+},{"../get":287}],303:[function(require,module,exports){
 /*!
  * Dependencies
  */
@@ -76950,13 +77651,14 @@ function InternalCache() {
   this.pathsToScopes = {};
   this.cachedRequired = {};
   this.session = null;
+  this.$setCalled = new Set();
 
   // embedded docs
   this.ownerDocument = undefined;
   this.fullPath = undefined;
 }
 
-},{"./statemachine":327}],301:[function(require,module,exports){
+},{"./statemachine":338}],304:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76972,7 +77674,568 @@ exports.internalToObjectOptions = {
   flattenDecimals: false
 };
 
-},{}],302:[function(require,module,exports){
+},{}],305:[function(require,module,exports){
+'use strict';
+
+const utils = require('../utils');
+
+class PopulateOptions {
+  constructor(obj) {
+    this._docs = {};
+
+    if (obj == null) {
+      return;
+    }
+    obj = utils.clone(obj);
+    Object.assign(this, obj);
+    if (typeof obj.subPopulate === 'object') {
+      this.populate = obj.subPopulate;
+    }
+  }
+}
+
+/**
+ * The connection used to look up models by name. If not specified, Mongoose
+ * will default to using the connection associated with the model in
+ * `PopulateOptions#model`.
+ *
+ * @memberOf PopulateOptions
+ * @property {Connection} connection
+ * @api public
+ */
+
+module.exports = PopulateOptions;
+},{"../utils":349}],306:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on an Array schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ tags: [String] });
+ *     schema.path('tags').options; // SchemaArrayOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaArrayOptions
+ */
+
+class SchemaArrayOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If this is an array of strings, an array of allowed values for this path.
+ * Throws an error if this array isn't an array of strings.
+ *
+ * @api public
+ * @property enum
+ * @memberOf SchemaArrayOptions
+ * @type Array
+ * @instance
+ */
+
+Object.defineProperty(SchemaArrayOptions.prototype, 'enum', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaArrayOptions;
+},{"./SchemaTypeOptions":312}],307:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Buffer schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ bitmap: Buffer });
+ *     schema.path('bitmap').options; // SchemaBufferOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaBufferOptions
+ */
+
+class SchemaBufferOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * Set the default subtype for this buffer.
+ *
+ * @api public
+ * @property subtype
+ * @memberOf SchemaBufferOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaBufferOptions.prototype, 'subtype', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaBufferOptions;
+},{"./SchemaTypeOptions":312}],308:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Date schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ startedAt: Date });
+ *     schema.path('startedAt').options; // SchemaDateOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaDateOptions
+ */
+
+class SchemaDateOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is after the
+ * given `min`.
+ *
+ * @api public
+ * @property min
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'min', opts);
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is before the
+ * given `max`.
+ *
+ * @api public
+ * @property max
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'max', opts);
+
+/**
+ * If set, Mongoose creates a TTL index on this path.
+ *
+ * @api public
+ * @property expires
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'expires', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaDateOptions;
+},{"./SchemaTypeOptions":312}],309:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Number schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ count: Number });
+ *     schema.path('count').options; // SchemaNumberOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaNumberOptions
+ */
+
+class SchemaNumberOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is at least the
+ * given `min`.
+ *
+ * @api public
+ * @property min
+ * @memberOf SchemaNumberOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaNumberOptions.prototype, 'min', opts);
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is less than the
+ * given `max`.
+ *
+ * @api public
+ * @property max
+ * @memberOf SchemaNumberOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaNumberOptions.prototype, 'max', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaNumberOptions;
+},{"./SchemaTypeOptions":312}],310:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on an ObjectId schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ testId: mongoose.ObjectId });
+ *     schema.path('testId').options; // SchemaObjectIdOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaObjectIdOptions
+ */
+
+class SchemaObjectIdOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If truthy, uses Mongoose's default built-in ObjectId path.
+ *
+ * @api public
+ * @property auto
+ * @memberOf SchemaObjectIdOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaObjectIdOptions.prototype, 'auto', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaObjectIdOptions;
+},{"./SchemaTypeOptions":312}],311:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a string schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ name: String });
+ *     schema.path('name').options; // SchemaStringOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaStringOptions
+ */
+
+class SchemaStringOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * Array of allowed values for this path
+ *
+ * @api public
+ * @property enum
+ * @memberOf SchemaStringOptions
+ * @type Array
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'enum', opts);
+
+/**
+ * Attach a validator that succeeds if the data string matches the given regular
+ * expression, and fails otherwise.
+ *
+ * @api public
+ * @property match
+ * @memberOf SchemaStringOptions
+ * @type RegExp
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'match', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that lowercases this string
+ * using JavaScript's built-in `String#toLowerCase()`.
+ *
+ * @api public
+ * @property lowercase
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'lowercase', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that removes leading and trailing
+ * whitespace using JavaScript's built-in `String#trim()`.
+ *
+ * @api public
+ * @property trim
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'trim', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that uppercases this string
+ * using JavaScript's built-in `String#toUpperCase()`.
+ *
+ * @api public
+ * @property uppercase
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'uppercase', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaStringOptions;
+},{"./SchemaTypeOptions":312}],312:[function(require,module,exports){
+'use strict';
+
+const utils = require('../utils');
+
+/**
+ * The options defined on a schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ name: String });
+ *     schema.path('name').options instanceof mongoose.SchemaTypeOptions; // true
+ *
+ * @api public
+ * @constructor SchemaTypeOptions
+ */
+
+class SchemaTypeOptions {
+  constructor(obj) {
+    if (obj == null) {
+      return this;
+    }
+    Object.assign(this, utils.clone(obj));
+  }
+}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * The type to cast this path to.
+ *
+ * @api public
+ * @property type
+ * @memberOf SchemaTypeOptions
+ * @type Function|String|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'type', opts);
+
+/**
+ * Function or object describing how to validate this schematype.
+ *
+ * @api public
+ * @property validate
+ * @memberOf SchemaTypeOptions
+ * @type Function|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'validate', opts);
+
+/**
+ * If true, attach a required validator to this path, which ensures this path
+ * path cannot be set to a nullish value. If a function, Mongoose calls the
+ * function and only checks for nullish values if the function returns a truthy value.
+ *
+ * @api public
+ * @property required
+ * @memberOf SchemaTypeOptions
+ * @type Function|Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'required', opts);
+
+/**
+ * The default value for this path. If a function, Mongoose executes the function
+ * and uses the return value as the default.
+ *
+ * @api public
+ * @property default
+ * @memberOf SchemaTypeOptions
+ * @type Function|Any
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'default', opts);
+
+/**
+ * The model that `populate()` should use if populating this path.
+ *
+ * @api public
+ * @property ref
+ * @memberOf SchemaTypeOptions
+ * @type Function|String
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'ref', opts);
+
+/**
+ * Whether to include or exclude this path by default when loading documents
+ * using `find()`, `findOne()`, etc.
+ *
+ * @api public
+ * @property select
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'select', opts);
+
+/**
+ * If truthy, Mongoose will build an index on this path when the model is
+ * compiled.
+ *
+ * @api public
+ * @property index
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'index', opts);
+
+/**
+ * If truthy, Mongoose will build a unique index on this path when the
+ * model is compiled. [The `unique` option is **not** a validator](/docs/validation.html#the-unique-option-is-not-a-validator).
+ *
+ * @api public
+ * @property unique
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'unique', opts);
+
+/**
+ * If truthy, Mongoose will disallow changes to this path once the document
+ * is saved to the database for the first time. Read more about [immutability in Mongoose here](http://thecodebarbarian.com/whats-new-in-mongoose-5-6-immutable-properties.html).
+ *
+ * @api public
+ * @property immutable
+ * @memberOf SchemaTypeOptions
+ * @type Function|Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'immutable', opts);
+
+/**
+ * If truthy, Mongoose will build a sparse index on this path.
+ *
+ * @api public
+ * @property sparse
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'sparse', opts);
+
+/**
+ * If truthy, Mongoose will build a text index on this path.
+ *
+ * @api public
+ * @property text
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'text', opts);
+
+module.exports = SchemaTypeOptions;
+},{"../utils":349}],313:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77002,7 +78265,7 @@ function idGetter() {
   return null;
 }
 
-},{}],303:[function(require,module,exports){
+},{}],314:[function(require,module,exports){
 (function (global){
 /*!
  * ignore
@@ -77055,13 +78318,15 @@ store.set(global.Promise);
 module.exports = store;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"assert":81,"mquery":346}],304:[function(require,module,exports){
+},{"assert":81,"mquery":359}],315:[function(require,module,exports){
 'use strict';
 
 /*!
  * Module dependencies
  */
 
+const checkEmbeddedDiscriminatorKeyProjection =
+  require('./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection');
 const get = require('./helpers/get');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
 const utils = require('./utils');
@@ -77253,9 +78518,12 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
     // check for parent exclusions
     const pieces = path.split('.');
-    const root = pieces[0];
-    if (~excluded.indexOf(root)) {
-      return;
+    let cur = '';
+    for (let i = 0; i < pieces.length; ++i) {
+      cur += cur.length ? '.' + pieces[i] : pieces[i];
+      if (excluded.indexOf(cur) !== -1) {
+        return;
+      }
     }
 
     // Special case: if user has included a parent path of a discriminator key,
@@ -77273,6 +78541,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
     }
 
     (type.selected ? selected : excluded).push(path);
+    return path;
   };
 
   analyzeSchema(schema);
@@ -77300,7 +78569,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
       }
       // Any leftover plus paths must in the schema, so delete them (gh-7017)
       for (const key of Object.keys(fields || {})) {
-        if (key.charAt(0) === '+') {
+        if (key.startsWith('+')) {
           delete fields[key];
         }
       }
@@ -77318,22 +78587,34 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
     // avoid recursion
     if (stack.indexOf(schema) !== -1) {
-      return;
+      return [];
     }
     stack.push(schema);
 
+    const addedPaths = [];
     schema.eachPath(function(path, type) {
       if (prefix) path = prefix + '.' + path;
 
-      analyzePath(path, type);
+      const addedPath = analyzePath(path, type);
+      if (addedPath != null) {
+        addedPaths.push(addedPath);
+      }
 
-      // array of subdocs?
+      // nested schemas
       if (type.schema) {
-        analyzeSchema(type.schema, path);
+        const _addedPaths = analyzeSchema(type.schema, path);
+
+        // Special case: if discriminator key is the only field that would
+        // be projected in, remove it.
+        if (exclude === false) {
+          checkEmbeddedDiscriminatorKeyProjection(fields, path, type.schema,
+            selected, _addedPaths);
+        }
       }
     });
 
     stack.pop();
+    return addedPaths;
   }
 };
 
@@ -77359,12 +78640,18 @@ exports.handleDeleteWriteOpResult = function handleDeleteWriteOpResult(callback)
     if (error) {
       return callback(error);
     }
-    return callback(null,
-      Object.assign({}, res.result, {deletedCount: res.deletedCount }));
+    const mongooseResult = Object.assign({}, res.result);
+    if (get(res, 'result.n', null) != null) {
+      mongooseResult.deletedCount = res.result.n;
+    }
+    if (res.deletedCount != null) {
+      mongooseResult.deletedCount = res.deletedCount;
+    }
+    return callback(null, mongooseResult);
   };
 };
 
-},{"./helpers/get":286,"./helpers/projection/isDefiningProjection":291,"./utils":337}],305:[function(require,module,exports){
+},{"./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection":282,"./helpers/get":287,"./helpers/projection/isDefiningProjection":292,"./utils":349}],316:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -77378,6 +78665,7 @@ const SchemaType = require('./schematype');
 const VirtualType = require('./virtualtype');
 const applyTimestampsToChildren = require('./helpers/update/applyTimestampsToChildren');
 const applyTimestampsToUpdate = require('./helpers/update/applyTimestampsToUpdate');
+const arrayParentSymbol = require('./helpers/symbols').arrayParentSymbol;
 const get = require('./helpers/get');
 const getIndexes = require('./helpers/schema/getIndexes');
 const handleTimestampOption = require('./helpers/schema/handleTimestampOption');
@@ -77420,11 +78708,12 @@ let id = 0;
  * - [collection](/docs/guide.html#collection): string - no default
  * - [id](/docs/guide.html#id): bool - defaults to true
  * - [_id](/docs/guide.html#_id): bool - defaults to true
- * - `minimize`: bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true
+ * - [minimize](/docs/guide.html#minimize): bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true
  * - [read](/docs/guide.html#read): string
  * - [writeConcern](/docs/guide.html#writeConcern): object - defaults to null, use to override [the MongoDB server's default write concern settings](https://docs.mongodb.com/manual/reference/write-concern/)
- * - [shardKey](/docs/guide.html#shardKey): bool - defaults to `null`
+ * - [shardKey](/docs/guide.html#shardKey): object - defaults to `null`
  * - [strict](/docs/guide.html#strict): bool - defaults to true
+ * - [strictQuery](/docs/guide.html#strictQuery): bool - defaults to false
  * - [toJSON](/docs/guide.html#toJSON) - object - no default
  * - [toObject](/docs/guide.html#toObject) - object - no default
  * - [typeKey](/docs/guide.html#typeKey) - string - defaults to 'type'
@@ -77433,6 +78722,9 @@ let id = 0;
  * - [versionKey](/docs/guide.html#versionKey): string - defaults to "__v"
  * - [collation](/docs/guide.html#collation): object - defaults to null (which means use no collation)
  * - [selectPopulatedPaths](/docs/guide.html#selectPopulatedPaths): boolean - defaults to `true`
+ * - [skipVersioning](/docs/guide.html#skipVersioning): object - paths to exclude from versioning
+ * - [timestamps](/docs/guide.html#timestamps): object or boolean - defaults to `false`. If true, Mongoose adds `createdAt` and `updatedAt` properties to your schema and manages those properties for you.
+ * - [storeSubdocValidationError](/docs/guide.html#storeSubdocValidationError): boolean - Defaults to true. If false, Mongoose will wrap validation errors in single nested document subpaths into a single validation error on the single nested subdoc's path.
  *
  * ####Note:
  *
@@ -77661,25 +78953,23 @@ Schema.prototype.clone = function() {
   s.plugins = Array.prototype.slice.call(this.plugins);
   s._indexes = utils.clone(this._indexes);
   s.s.hooks = this.s.hooks.clone();
-  s._originalSchema = this._originalSchema == null ?
-    this._originalSchema :
-    this._originalSchema.clone();
 
   s.tree = utils.clone(this.tree);
   s.paths = utils.clone(this.paths);
   s.nested = utils.clone(this.nested);
   s.subpaths = utils.clone(this.subpaths);
-  s.childSchemas = this.childSchemas.slice();
   s.singleNestedPaths = utils.clone(this.singleNestedPaths);
+  s.childSchemas = gatherChildSchemas(s);
 
   s.virtuals = utils.clone(this.virtuals);
   s.$globalPluginsApplied = this.$globalPluginsApplied;
   s.$isRootDiscriminator = this.$isRootDiscriminator;
+  s.$implicitlyCreated = this.$implicitlyCreated;
 
   if (this.discriminatorMapping != null) {
     s.discriminatorMapping = Object.assign({}, this.discriminatorMapping);
   }
-  if (s.discriminators != null) {
+  if (this.discriminators != null) {
     s.discriminators = Object.assign({}, this.discriminators);
   }
 
@@ -77760,10 +79050,13 @@ Schema.prototype.defaultOptions = function(options) {
 Schema.prototype.add = function add(obj, prefix) {
   if (obj instanceof Schema) {
     merge(this, obj);
-    return;
+    return this;
   }
 
-  if (obj._id === false) {
+  // Special case: setting top-level `_id` to false should convert to disabling
+  // the `_id` option. This behavior never worked before 5.4.11 but numerous
+  // codebases use it (see gh-7516, gh-7512).
+  if (obj._id === false && prefix == null) {
     delete obj._id;
     this.options._id = false;
   }
@@ -77773,26 +79066,29 @@ Schema.prototype.add = function add(obj, prefix) {
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i];
+    const fullPath = prefix + key;
 
     if (obj[key] == null) {
-      throw new TypeError('Invalid value for schema path `' + prefix + key + '`');
+      throw new TypeError('Invalid value for schema path `' + fullPath +
+        '`, got value "' + obj[key] + '"');
     }
 
     if (Array.isArray(obj[key]) && obj[key].length === 1 && obj[key][0] == null) {
-      throw new TypeError('Invalid value for schema Array path `' + prefix + key + '`');
+      throw new TypeError('Invalid value for schema Array path `' + fullPath +
+        '`, got value "' + obj[key][0] + '"');
     }
 
     if (utils.isPOJO(obj[key]) &&
         (!obj[key][this.options.typeKey] || (this.options.typeKey === 'type' && obj[key].type.type))) {
       if (Object.keys(obj[key]).length) {
         // nested object { last: { name: String }}
-        this.nested[prefix + key] = true;
-        this.add(obj[key], prefix + key + '.');
+        this.nested[fullPath] = true;
+        this.add(obj[key], fullPath + '.');
       } else {
         if (prefix) {
           this.nested[prefix.substr(0, prefix.length - 1)] = true;
         }
-        this.path(prefix + key, obj[key]); // mixed type
+        this.path(fullPath, obj[key]); // mixed type
       }
     } else {
       if (prefix) {
@@ -77811,9 +79107,33 @@ Schema.prototype.add = function add(obj, prefix) {
 /**
  * Reserved document keys.
  *
- * Keys in this object are names that are rejected in schema declarations b/c they conflict with mongoose functionality. Using these key name will throw an error.
+ * Keys in this object are names that are rejected in schema declarations
+ * because they conflict with Mongoose functionality. If you create a schema
+ * using `new Schema()` with one of these property names, Mongoose will throw
+ * an error.
  *
- *      on, emit, _events, db, get, set, init, isNew, errors, schema, options, modelName, collection, _pres, _posts, toObject
+ * - prototype
+ * - emit
+ * - on
+ * - once
+ * - listeners
+ * - removeListener
+ * - collection
+ * - db
+ * - errors
+ * - init
+ * - isModified
+ * - isNew
+ * - get
+ * - modelName
+ * - save
+ * - schema
+ * - toObject
+ * - validate
+ * - remove
+ * - populated
+ * - _pres
+ * - _posts
  *
  * _NOTE:_ Use of these terms as method names is permitted, but play at your own risk, as they may be existing mongoose document methods you are stomping on.
  *
@@ -77846,9 +79166,7 @@ reserved.schema =
 reserved.toObject =
 reserved.validate =
 reserved.remove =
-reserved.populated =
-// hooks.js
-reserved._pres = reserved._posts = 1;
+reserved.populated = 1;
 
 /*!
  * Document keys to print warnings for
@@ -77875,26 +79193,24 @@ warnings.increment = '`increment` should not be used as a schema path name ' +
  */
 
 Schema.prototype.path = function(path, obj) {
+  // Convert to '.$' to check subpaths re: gh-6405
+  const cleanPath = _pathToPositionalSyntax(path);
   if (obj === undefined) {
-    if (this.paths.hasOwnProperty(path)) {
-      return this.paths[path];
-    }
-    if (this.subpaths.hasOwnProperty(path)) {
-      return this.subpaths[path];
-    }
-    if (this.singleNestedPaths.hasOwnProperty(path)) {
-      return this.singleNestedPaths[path];
+    let schematype = _getPath(this, path, cleanPath);
+    if (schematype != null) {
+      return schematype;
     }
 
     // Look for maps
-    for (const _path of Object.keys(this.paths)) {
-      if (!_path.includes('.$*')) {
-        continue;
-      }
-      const re = new RegExp('^' + _path.replace(/\.\$\*/g, '.[^.]+') + '$');
-      if (re.test(path)) {
-        return this.paths[_path];
-      }
+    const mapPath = getMapPath(this, path);
+    if (mapPath != null) {
+      return mapPath;
+    }
+
+    // Look if a parent of this path is mixed
+    schematype = this.hasMixedParent(cleanPath);
+    if (schematype != null) {
+      return schematype;
     }
 
     // subpaths?
@@ -77912,7 +79228,7 @@ Schema.prototype.path = function(path, obj) {
     console.log('WARN: ' + warnings[path]);
   }
 
-  if (typeof obj === 'object' && 'ref' in obj) {
+  if (typeof obj === 'object' && utils.hasUserDefinedProperty(obj, 'ref')) {
     validateRef(obj.ref, path);
   }
 
@@ -77946,9 +79262,16 @@ Schema.prototype.path = function(path, obj) {
     // The '$' is to imply this path should never be stored in MongoDB so we
     // can easily build a regexp out of this path, and '*' to imply "any key."
     const mapPath = path + '.$*';
-    this.paths[path + '.$*'] = this.interpretAsType(mapPath,
-      obj.of || { type: {} }, this.options);
-    schemaType.$__schemaType = this.paths[path + '.$*'];
+    let _mapType = { type: {} };
+    if (utils.hasUserDefinedProperty(obj, 'of')) {
+      const isInlineSchema = utils.isPOJO(obj.of) &&
+        Object.keys(obj.of).length > 0 &&
+        !utils.hasUserDefinedProperty(obj.of, this.options.typeKey);
+      _mapType = isInlineSchema ? new Schema(obj.of) : obj.of;
+    }
+    this.paths[mapPath] = this.interpretAsType(mapPath,
+      _mapType, this.options);
+    schemaType.$__schemaType = this.paths[mapPath];
   }
 
   if (schemaType.$isSingleNested) {
@@ -77958,6 +79281,10 @@ Schema.prototype.path = function(path, obj) {
     for (const key in schemaType.schema.singleNestedPaths) {
       this.singleNestedPaths[path + '.' + key] =
         schemaType.schema.singleNestedPaths[key];
+    }
+    for (const key in schemaType.schema.subpaths) {
+      this.singleNestedPaths[path + '.' + key] =
+        schemaType.schema.subpaths[key];
     }
 
     Object.defineProperty(schemaType.schema, 'base', {
@@ -77987,8 +79314,107 @@ Schema.prototype.path = function(path, obj) {
     });
   }
 
+  if (schemaType.$isMongooseArray && schemaType.caster instanceof SchemaType) {
+    let arrayPath = path;
+    let _schemaType = schemaType;
+
+    let toAdd = [];
+    while (_schemaType.$isMongooseArray) {
+      arrayPath = arrayPath + '.$';
+
+      // Skip arrays of document arrays
+      if (_schemaType.$isMongooseDocumentArray) {
+        toAdd = [];
+        break;
+      }
+      _schemaType = _schemaType.caster.clone();
+      _schemaType.path = arrayPath;
+      toAdd.push(_schemaType);
+    }
+
+    for (const _schemaType of toAdd) {
+      this.subpaths[_schemaType.path] = _schemaType;
+    }
+  }
+
+  if (schemaType.$isMongooseDocumentArray) {
+    for (const key of Object.keys(schemaType.schema.paths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.paths[key];
+      schemaType.schema.paths[key].$isUnderneathDocArray = true;
+    }
+    for (const key of Object.keys(schemaType.schema.subpaths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.subpaths[key];
+      schemaType.schema.subpaths[key].$isUnderneathDocArray = true;
+    }
+    for (const key of Object.keys(schemaType.schema.singleNestedPaths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.singleNestedPaths[key];
+      schemaType.schema.singleNestedPaths[key].$isUnderneathDocArray = true;
+    }
+  }
+
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+function gatherChildSchemas(schema) {
+  const childSchemas = [];
+
+  for (const path of Object.keys(schema.paths)) {
+    const schematype = schema.paths[path];
+    if (schematype.$isMongooseDocumentArray || schematype.$isSingleNested) {
+      childSchemas.push({ schema: schematype.schema, model: schematype.caster });
+    }
+  }
+
+  return childSchemas;
+}
+
+/*!
+ * ignore
+ */
+
+function _getPath(schema, path, cleanPath) {
+  if (schema.paths.hasOwnProperty(path)) {
+    return schema.paths[path];
+  }
+  if (schema.subpaths.hasOwnProperty(cleanPath)) {
+    return schema.subpaths[cleanPath];
+  }
+  if (schema.singleNestedPaths.hasOwnProperty(cleanPath)) {
+    return schema.singleNestedPaths[cleanPath];
+  }
+
+  return null;
+}
+
+/*!
+ * ignore
+ */
+
+function _pathToPositionalSyntax(path) {
+  return path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
+}
+
+/*!
+ * ignore
+ */
+
+function getMapPath(schema, path) {
+  for (const _path of Object.keys(schema.paths)) {
+    if (!_path.includes('.$*')) {
+      continue;
+    }
+    const re = new RegExp('^' + _path.replace(/\.\$\*/g, '\\.[^.]+') + '$');
+    if (re.test(path)) {
+      return schema.paths[_path];
+    }
+  }
+
+  return null;
+}
 
 /**
  * The Mongoose instance this schema is associated with
@@ -78095,7 +79521,7 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
         ? type
         : type.schemaName || utils.getFunctionName(type);
 
-      if (!(name in MongooseTypes)) {
+      if (!MongooseTypes.hasOwnProperty(name)) {
         throw new TypeError('Invalid schema configuration: ' +
           `\`${name}\` is not a valid type within the array \`${path}\`.` +
           'See http://bit.ly/mongoose-schematypes for a list of valid schema types.');
@@ -78235,31 +79661,29 @@ Schema.prototype.indexedPaths = function indexedPaths() {
  */
 
 Schema.prototype.pathType = function(path) {
-  if (path in this.paths) {
+  // Convert to '.$' to check subpaths re: gh-6405
+  const cleanPath = path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
+
+  if (this.paths.hasOwnProperty(path)) {
     return 'real';
   }
-  if (path in this.virtuals) {
+  if (this.virtuals.hasOwnProperty(path)) {
     return 'virtual';
   }
-  if (path in this.nested) {
+  if (this.nested.hasOwnProperty(path)) {
     return 'nested';
   }
-  if (path in this.subpaths) {
+  if (this.subpaths.hasOwnProperty(cleanPath)) {
     return 'real';
   }
-  if (path in this.singleNestedPaths) {
+  if (this.singleNestedPaths.hasOwnProperty(cleanPath)) {
     return 'real';
   }
 
   // Look for maps
-  for (const _path of Object.keys(this.paths)) {
-    if (!_path.includes('.$*')) {
-      continue;
-    }
-    const re = new RegExp('^' + _path.replace(/\.\$\*/g, '.[^.]+') + '$');
-    if (re.test(path)) {
-      return 'real';
-    }
+  const mapPath = getMapPath(this, path);
+  if (mapPath != null) {
+    return 'real';
   }
 
   if (/\.\d+\.|\.\d+$/.test(path)) {
@@ -78283,11 +79707,11 @@ Schema.prototype.hasMixedParent = function(path) {
     path = i > 0 ? path + '.' + subpaths[i] : subpaths[i];
     if (path in this.paths &&
         this.paths[path] instanceof MongooseTypes.Mixed) {
-      return true;
+      return this.paths[path];
     }
   }
 
-  return false;
+  return null;
 };
 
 /**
@@ -78325,23 +79749,27 @@ Schema.prototype.setupTimestamp = function(timestamps) {
   this.add(schemaAdditions);
 
   this.pre('save', function(next) {
-    if (get(this, '$__.saveOptions.timestamps') === false) {
+    const timestampOption = get(this, '$__.saveOptions.timestamps');
+    if (timestampOption === false) {
       return next();
     }
+
+    const skipUpdatedAt = timestampOption != null && timestampOption.updatedAt === false;
+    const skipCreatedAt = timestampOption != null && timestampOption.createdAt === false;
 
     const defaultTimestamp = (this.ownerDocument ? this.ownerDocument() : this).
       constructor.base.now();
     const auto_id = this._id && this._id.auto;
 
-    if (createdAt && !this.get(createdAt) && this.isSelected(createdAt)) {
+    if (!skipCreatedAt && createdAt && !this.get(createdAt) && this.isSelected(createdAt)) {
       this.set(createdAt, auto_id ? this._id.getTimestamp() : defaultTimestamp);
     }
 
-    if (updatedAt && (this.isNew || this.isModified())) {
+    if (!skipUpdatedAt && updatedAt && (this.isNew || this.isModified())) {
       let ts = defaultTimestamp;
       if (this.isNew) {
         if (createdAt != null) {
-          ts = this.getValue(createdAt);
+          ts = this.$__getValue(createdAt);
         } else if (auto_id) {
           ts = this._id.getTimestamp();
         }
@@ -78364,11 +79792,12 @@ Schema.prototype.setupTimestamp = function(timestamps) {
 
   _setTimestampsOnUpdate[symbols.builtInMiddleware] = true;
 
-  this.pre('findOneAndUpdate', _setTimestampsOnUpdate);
-  this.pre('replaceOne', _setTimestampsOnUpdate);
-  this.pre('update', _setTimestampsOnUpdate);
-  this.pre('updateOne', _setTimestampsOnUpdate);
-  this.pre('updateMany', _setTimestampsOnUpdate);
+  const opts = { query: true, model: false };
+  this.pre('findOneAndUpdate', opts, _setTimestampsOnUpdate);
+  this.pre('replaceOne', opts, _setTimestampsOnUpdate);
+  this.pre('update', opts, _setTimestampsOnUpdate);
+  this.pre('updateOne', opts, _setTimestampsOnUpdate);
+  this.pre('updateMany', opts, _setTimestampsOnUpdate);
 
   function _setTimestampsOnUpdate(next) {
     const now = this.model.base.now();
@@ -78380,19 +79809,21 @@ Schema.prototype.setupTimestamp = function(timestamps) {
 };
 
 /*!
- * ignore
+ * ignore. Deprecated re: #6405
  */
 
 function getPositionalPathType(self, path) {
   const subpaths = path.split(/\.(\d+)\.|\.(\d+)$/).filter(Boolean);
   if (subpaths.length < 2) {
-    return self.paths.hasOwnProperty(subpaths[0]) ? self.paths[subpaths[0]] : null;
+    return self.paths.hasOwnProperty(subpaths[0]) ?
+      self.paths[subpaths[0]] :
+      'adhocOrUndefined';
   }
 
   let val = self.path(subpaths[0]);
   let isNested = false;
   if (!val) {
-    return val;
+    return 'adhocOrUndefined';
   }
 
   const last = subpaths.length - 1;
@@ -78424,6 +79855,10 @@ function getPositionalPathType(self, path) {
 
     // ignore if its just a position segment: path.0.subpath
     if (!/\D/.test(subpath)) {
+      // Nested array
+      if (val instanceof MongooseTypes.Array && i !== last) {
+        val = val.caster;
+      }
       continue;
     }
 
@@ -78497,15 +79932,19 @@ Schema.prototype.queue = function(name, args) {
  *
  *     // Equivalent to calling `pre()` on `find`, `findOne`, `findOneAndUpdate`.
  *     toySchema.pre(/^find/, function(next) {
- *       console.log(this.getQuery());
+ *       console.log(this.getFilter());
  *     });
  *
- * @param {String|RegExp} method or regular expression to match method name
+ *     // Equivalent to calling `pre()` on `updateOne`, `findOneAndUpdate`.
+ *     toySchema.pre(['updateOne', 'findOneAndUpdate'], function(next) {
+ *       console.log(this.getFilter());
+ *     });
+ *
+ * @param {String|RegExp} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
  * @param {Function} callback
- * @see hooks.js https://github.com/bnoguchi/hooks-js/tree/31ec571cef0332e21121ee7157e0cf9728572cc3
  * @api public
  */
 
@@ -78516,6 +79955,13 @@ Schema.prototype.pre = function(name) {
       if (name.test(fn)) {
         this.pre.apply(this, [fn].concat(remainingArgs));
       }
+    }
+    return this;
+  }
+  if (Array.isArray(name)) {
+    const remainingArgs = Array.prototype.slice.call(arguments, 1);
+    for (const el of name) {
+      this.pre.apply(this, [el].concat(remainingArgs));
     }
     return this;
   }
@@ -78550,7 +79996,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp} method or regular expression to match method name
+ * @param {String|RegExp} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -78570,6 +80016,13 @@ Schema.prototype.post = function(name) {
     }
     return this;
   }
+  if (Array.isArray(name)) {
+    const remainingArgs = Array.prototype.slice.call(arguments, 1);
+    for (const el of name) {
+      this.post.apply(this, [el].concat(remainingArgs));
+    }
+    return this;
+  }
   this.s.hooks.post.apply(this.s.hooks, arguments);
   return this;
 };
@@ -78581,7 +80034,7 @@ Schema.prototype.post = function(name) {
  *
  *     const s = new Schema({ name: String });
  *     s.plugin(schema => console.log(schema.path('name').path));
- *     mongoose.model('Test', schema); // Prints 'name'
+ *     mongoose.model('Test', s); // Prints 'name'
  *
  * @param {Function} plugin callback
  * @param {Object} [opts]
@@ -78661,21 +80114,21 @@ Schema.prototype.method = function(name, fn, options) {
  *
  * ####Example
  *
- *     var schema = new Schema(..);
- *     schema.static('findByName', function (name, callback) {
- *       return this.find({ name: name }, callback);
+ *     const schema = new Schema(..);
+ *     // Equivalent to `schema.statics.findByName = function(name) {}`;
+ *     schema.static('findByName', function(name) {
+ *       return this.find({ name: name });
  *     });
  *
- *     var Drink = mongoose.model('Drink', schema);
- *     Drink.findByName('sanpellegrino', function (err, drinks) {
- *       //
- *     });
+ *     const Drink = mongoose.model('Drink', schema);
+ *     await Drink.findByName('LaCroix');
  *
  * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as statics.
  *
  * @param {String|Object} name
  * @param {Function} [fn]
  * @api public
+ * @see Statics /docs/guide.html#statics
  */
 
 Schema.prototype.static = function(name, fn) {
@@ -78845,7 +80298,7 @@ Schema.prototype.indexes = function() {
  */
 
 Schema.prototype.virtual = function(name, options) {
-  if (options && options.ref) {
+  if (utils.hasUserDefinedProperty(options, ['ref', 'refPath'])) {
     if (!options.localField) {
       throw new Error('Reference virtuals require `localField` option');
     }
@@ -78882,10 +80335,10 @@ Schema.prototype.virtual = function(name, options) {
         if (!this.$$populatedVirtuals) {
           this.$$populatedVirtuals = {};
         }
-        if (name in this.$$populatedVirtuals) {
+        if (this.$$populatedVirtuals.hasOwnProperty(name)) {
           return this.$$populatedVirtuals[name];
         }
-        return null;
+        return void 0;
       }).
       set(function(_v) {
         if (!this.$$populatedVirtuals) {
@@ -78927,6 +80380,24 @@ Schema.prototype.virtual = function(name, options) {
     return mem[part];
   }, this.tree);
 
+  // Workaround for gh-8198: if virtual is under document array, make a fake
+  // virtual. See gh-8210
+  let cur = parts[0];
+  for (let i = 0; i < parts.length - 1; ++i) {
+    if (this.paths[cur] != null && this.paths[cur].$isMongooseDocumentArray) {
+      const remnant = parts.slice(i + 1).join('.');
+      const v = this.paths[cur].schema.virtual(remnant);
+      v.get((v, virtual, doc) => {
+        const parent = doc.__parentArray[arrayParentSymbol];
+        const path = cur + '.' + doc.__index + '.' + remnant;
+        return parent.get(path);
+      });
+      break;
+    }
+
+    cur += '.' + parts[i + 1];
+  }
+
   return virtuals[name];
 };
 
@@ -78961,21 +80432,45 @@ Schema.prototype.remove = function(path) {
   }
   if (Array.isArray(path)) {
     path.forEach(function(name) {
-      if (this.path(name)) {
-        delete this.paths[name];
-
-        const pieces = name.split('.');
-        const last = pieces.pop();
-        let branch = this.tree;
-        for (let i = 0; i < pieces.length; ++i) {
-          branch = branch[pieces[i]];
-        }
-        delete branch[last];
+      if (this.path(name) == null && !this.nested[name]) {
+        return;
       }
+      if (this.nested[name]) {
+        const allKeys = Object.keys(this.paths).
+          concat(Object.keys(this.nested));
+        for (const path of allKeys) {
+          if (path.startsWith(name + '.')) {
+            delete this.paths[path];
+            delete this.nested[path];
+            _deletePath(this, path);
+          }
+        }
+
+        delete this.nested[name];
+        _deletePath(this, name);
+        return;
+      }
+
+      delete this.paths[name];
+      _deletePath(this, name);
     }, this);
   }
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+function _deletePath(schema, name) {
+  const pieces = name.split('.');
+  const last = pieces.pop();
+  let branch = schema.tree;
+  for (let i = 0; i < pieces.length; ++i) {
+    branch = branch[pieces[i]];
+  }
+  delete branch[last];
+}
 
 /**
  * Loads an ES6 class into a schema. Maps [setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) + [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get), [static methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static),
@@ -79206,8 +80701,7 @@ Schema.prototype._getPathType = function(path) {
  */
 
 function isArrayFilter(piece) {
-  return piece.indexOf('$[') === 0 &&
-    piece.lastIndexOf(']') === piece.length - 1;
+  return piece.startsWith('$[') && piece.endsWith(']');
 }
 
 /*!
@@ -79254,7 +80748,313 @@ Schema.Types = MongooseTypes = require('./schema/index');
 exports.ObjectId = MongooseTypes.ObjectId;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":246,"./driver":261,"./helpers/get":286,"./helpers/model/applyHooks":288,"./helpers/populate/validateRef":290,"./helpers/query/applyQueryMiddleware":293,"./helpers/schema/getIndexes":294,"./helpers/schema/handleTimestampOption":295,"./helpers/schema/merge":296,"./helpers/update/applyTimestampsToChildren":298,"./helpers/update/applyTimestampsToUpdate":299,"./schema/index":313,"./schema/symbols":325,"./schematype":326,"./utils":337,"./virtualtype":338,"events":243,"kareem":247,"mpath":340,"util":366}],306:[function(require,module,exports){
+},{"../../is-buffer/index.js":245,"./driver":260,"./helpers/get":287,"./helpers/model/applyHooks":289,"./helpers/populate/validateRef":291,"./helpers/query/applyQueryMiddleware":294,"./helpers/schema/getIndexes":296,"./helpers/schema/handleTimestampOption":297,"./helpers/schema/merge":298,"./helpers/symbols":300,"./helpers/update/applyTimestampsToChildren":301,"./helpers/update/applyTimestampsToUpdate":302,"./schema/index":324,"./schema/symbols":336,"./schematype":337,"./utils":349,"./virtualtype":350,"events":243,"kareem":246,"mpath":353,"util":381}],317:[function(require,module,exports){
+'use strict';
+
+/*!
+ * Module dependencies.
+ */
+
+const CastError = require('../error/cast');
+const EventEmitter = require('events').EventEmitter;
+const ObjectExpectedError = require('../error/objectExpected');
+const SchemaType = require('../schematype');
+const $exists = require('./operators/exists');
+const castToNumber = require('./operators/helpers').castToNumber;
+const discriminator = require('../helpers/model/discriminator');
+const geospatial = require('./operators/geospatial');
+const get = require('../helpers/get');
+const getConstructor = require('../helpers/discriminator/getConstructor');
+const internalToObjectOptions = require('../options').internalToObjectOptions;
+
+let Subdocument;
+
+module.exports = SingleNestedPath;
+
+/**
+ * Single nested subdocument SchemaType constructor.
+ *
+ * @param {Schema} schema
+ * @param {String} key
+ * @param {Object} options
+ * @inherits SchemaType
+ * @api public
+ */
+
+function SingleNestedPath(schema, path, options) {
+  this.caster = _createConstructor(schema);
+  this.caster.path = path;
+  this.caster.prototype.$basePath = path;
+  this.schema = schema;
+  this.$isSingleNested = true;
+  SchemaType.call(this, path, options, 'Embedded');
+}
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype = Object.create(SchemaType.prototype);
+SingleNestedPath.prototype.constructor = SingleNestedPath;
+
+/*!
+ * ignore
+ */
+
+function _createConstructor(schema, baseClass) {
+  // lazy load
+  Subdocument || (Subdocument = require('../types/subdocument'));
+
+  const _embedded = function SingleNested(value, path, parent) {
+    const _this = this;
+
+    this.$parent = parent;
+    Subdocument.apply(this, arguments);
+
+    this.$session(this.ownerDocument().$session());
+
+    if (parent) {
+      parent.on('save', function() {
+        _this.emit('save', _this);
+        _this.constructor.emit('save', _this);
+      });
+
+      parent.on('isNew', function(val) {
+        _this.isNew = val;
+        _this.emit('isNew', val);
+        _this.constructor.emit('isNew', val);
+      });
+    }
+  };
+
+  const proto = baseClass != null ? baseClass.prototype : Subdocument.prototype;
+  _embedded.prototype = Object.create(proto);
+  _embedded.prototype.$__setSchema(schema);
+  _embedded.prototype.constructor = _embedded;
+  _embedded.schema = schema;
+  _embedded.$isSingleNested = true;
+  _embedded.events = new EventEmitter();
+  _embedded.prototype.toBSON = function() {
+    return this.toObject(internalToObjectOptions);
+  };
+
+  // apply methods
+  for (const i in schema.methods) {
+    _embedded.prototype[i] = schema.methods[i];
+  }
+
+  // apply statics
+  for (const i in schema.statics) {
+    _embedded[i] = schema.statics[i];
+  }
+
+  for (const i in EventEmitter.prototype) {
+    _embedded[i] = EventEmitter.prototype[i];
+  }
+
+  return _embedded;
+}
+
+/*!
+ * Special case for when users use a common location schema to represent
+ * locations for use with $geoWithin.
+ * https://docs.mongodb.org/manual/reference/operator/query/geoWithin/
+ *
+ * @param {Object} val
+ * @api private
+ */
+
+SingleNestedPath.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val) {
+  return { $geometry: this.castForQuery(val.$geometry) };
+};
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype.$conditionalHandlers.$near =
+SingleNestedPath.prototype.$conditionalHandlers.$nearSphere = geospatial.cast$near;
+
+SingleNestedPath.prototype.$conditionalHandlers.$within =
+SingleNestedPath.prototype.$conditionalHandlers.$geoWithin = geospatial.cast$within;
+
+SingleNestedPath.prototype.$conditionalHandlers.$geoIntersects =
+  geospatial.cast$geoIntersects;
+
+SingleNestedPath.prototype.$conditionalHandlers.$minDistance = castToNumber;
+SingleNestedPath.prototype.$conditionalHandlers.$maxDistance = castToNumber;
+
+SingleNestedPath.prototype.$conditionalHandlers.$exists = $exists;
+
+/**
+ * Casts contents
+ *
+ * @param {Object} value
+ * @api private
+ */
+
+SingleNestedPath.prototype.cast = function(val, doc, init, priorVal) {
+  if (val && val.$isSingleNested) {
+    return val;
+  }
+
+  if (val != null && (typeof val !== 'object' || Array.isArray(val))) {
+    throw new ObjectExpectedError(this.path, val);
+  }
+
+  const Constructor = getConstructor(this.caster, val);
+
+  let subdoc;
+
+  // Only pull relevant selected paths and pull out the base path
+  const parentSelected = get(doc, '$__.selected', {});
+  const path = this.path;
+  const selected = Object.keys(parentSelected).reduce((obj, key) => {
+    if (key.startsWith(path + '.')) {
+      obj[key.substr(path.length + 1)] = parentSelected[key];
+    }
+    return obj;
+  }, {});
+
+  if (init) {
+    subdoc = new Constructor(void 0, selected, doc);
+    subdoc.init(val);
+  } else {
+    if (Object.keys(val).length === 0) {
+      return new Constructor({}, selected, doc);
+    }
+
+    return new Constructor(val, selected, doc, undefined, { priorDoc: priorVal });
+  }
+
+  return subdoc;
+};
+
+/**
+ * Casts contents for query
+ *
+ * @param {string} [$conditional] optional query operator (like `$eq` or `$in`)
+ * @param {any} value
+ * @api private
+ */
+
+SingleNestedPath.prototype.castForQuery = function($conditional, val) {
+  let handler;
+  if (arguments.length === 2) {
+    handler = this.$conditionalHandlers[$conditional];
+    if (!handler) {
+      throw new Error('Can\'t use ' + $conditional);
+    }
+    return handler.call(this, val);
+  }
+  val = $conditional;
+  if (val == null) {
+    return val;
+  }
+
+  if (this.options.runSetters) {
+    val = this._applySetters(val);
+  }
+
+  const Constructor = getConstructor(this.caster, val);
+
+  try {
+    val = new Constructor(val);
+  } catch (error) {
+    // Make sure we always wrap in a CastError (gh-6803)
+    if (!(error instanceof CastError)) {
+      throw new CastError('Embedded', val, this.path, error);
+    }
+    throw error;
+  }
+  return val;
+};
+
+/**
+ * Async validation on this single nested doc.
+ *
+ * @api private
+ */
+
+SingleNestedPath.prototype.doValidate = function(value, fn, scope, options) {
+  const Constructor = getConstructor(this.caster, value);
+
+  if (options && options.skipSchemaValidators) {
+    if (!(value instanceof Constructor)) {
+      value = new Constructor(value, null, scope);
+    }
+
+    return value.validate(fn);
+  }
+
+  SchemaType.prototype.doValidate.call(this, value, function(error) {
+    if (error) {
+      return fn(error);
+    }
+    if (!value) {
+      return fn(null);
+    }
+
+    value.validate(fn);
+  }, scope);
+};
+
+/**
+ * Synchronously validate this single nested doc
+ *
+ * @api private
+ */
+
+SingleNestedPath.prototype.doValidateSync = function(value, scope, options) {
+  if (!options || !options.skipSchemaValidators) {
+    const schemaTypeError = SchemaType.prototype.doValidateSync.call(this, value, scope);
+    if (schemaTypeError) {
+      return schemaTypeError;
+    }
+  }
+  if (!value) {
+    return;
+  }
+  return value.validateSync();
+};
+
+/**
+ * Adds a discriminator to this single nested subdocument.
+ *
+ * ####Example:
+ *     const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
+ *     const schema = Schema({ shape: shapeSchema });
+ *
+ *     const singleNestedPath = parentSchema.path('child');
+ *     singleNestedPath.discriminator('Circle', Schema({ radius: Number }));
+ *
+ * @param {String} name
+ * @param {Schema} schema fields to add to the schema for instances of this sub-class
+ * @see discriminators /docs/discriminators.html
+ * @api public
+ */
+
+SingleNestedPath.prototype.discriminator = function(name, schema, tiedValue) {
+  discriminator(this.caster, name, schema, tiedValue);
+
+  this.caster.discriminators[name] = _createConstructor(schema, this.caster);
+
+  return this.caster.discriminators[name];
+};
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.schema, this.path, options);
+  schematype.validators = this.validators.slice();
+  schematype.caster.discriminators = Object.assign({}, this.caster.discriminators);
+  return schematype;
+};
+
+},{"../error/cast":266,"../error/objectExpected":273,"../helpers/discriminator/getConstructor":283,"../helpers/get":287,"../helpers/model/discriminator":290,"../options":304,"../schematype":337,"../types/subdocument":348,"./operators/exists":330,"./operators/geospatial":331,"./operators/helpers":332,"events":243}],318:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79264,18 +81064,9 @@ exports.ObjectId = MongooseTypes.ObjectId;
 const $exists = require('./operators/exists');
 const $type = require('./operators/type');
 const MongooseError = require('../error/mongooseError');
+const SchemaArrayOptions = require('../options/SchemaArrayOptions');
 const SchemaType = require('../schematype');
 const CastError = SchemaType.CastError;
-const Types = {
-  Array: SchemaArray,
-  Boolean: require('./boolean'),
-  Date: require('./date'),
-  Number: require('./number'),
-  String: require('./string'),
-  ObjectId: require('./objectid'),
-  Buffer: require('./buffer'),
-  Map: require('./map')
-};
 const Mixed = require('./mixed');
 const cast = require('../cast');
 const get = require('../helpers/get');
@@ -79306,6 +81097,7 @@ function SchemaArray(key, cast, options, schemaOptions) {
   if (schemaOptions && schemaOptions.typeKey) {
     typeKey = schemaOptions.typeKey;
   }
+  this.schemaOptions = schemaOptions;
 
   if (cast) {
     let castOptions = {};
@@ -79330,9 +81122,8 @@ function SchemaArray(key, cast, options, schemaOptions) {
       ? cast
       : utils.getFunctionName(cast);
 
-    const caster = name in Types
-      ? Types[name]
-      : cast;
+    const Types = require('./index.js');
+    const caster = Types.hasOwnProperty(name) ? Types[name] : cast;
 
     this.casterConstructor = caster;
 
@@ -79401,6 +81192,57 @@ SchemaArray.options = { castNonArrays: true };
  */
 SchemaArray.prototype = Object.create(SchemaType.prototype);
 SchemaArray.prototype.constructor = SchemaArray;
+SchemaArray.prototype.OptionsConstructor = SchemaArrayOptions;
+
+/*!
+ * ignore
+ */
+
+SchemaArray._checkRequired = SchemaType.prototype.checkRequired;
+
+/**
+ * Override the function the required validator uses to check whether an array
+ * passes the `required` check.
+ *
+ * ####Example:
+ *
+ *     // Require non-empty array to pass `required` check
+ *     mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
+ *
+ *     const M = mongoose.model({ arr: { type: Array, required: true } });
+ *     new M({ arr: [] }).validateSync(); // `null`, validation fails!
+ *
+ * @param {Function} fn
+ * @return {Function}
+ * @function checkRequired
+ * @static
+ * @api public
+ */
+
+SchemaArray.checkRequired = SchemaType.checkRequired;
+
+/**
+ * Check if the given value satisfies the `required` validator.
+ *
+ * @param {Any} value
+ * @param {Document} doc
+ * @return {Boolean}
+ * @api public
+ */
+
+SchemaArray.prototype.checkRequired = function checkRequired(value, doc) {
+  if (SchemaType._isRef(this, value, doc, true)) {
+    return !!value;
+  }
+
+  // `require('util').inherits()` does **not** copy static properties, and
+  // plugins like mongoose-float use `inherits()` for pre-ES6.
+  const _checkRequired = typeof this.constructor.checkRequired == 'function' ?
+    this.constructor.checkRequired() :
+    SchemaArray.checkRequired();
+
+  return _checkRequired(value);
+};
 
 /**
  * Adds an enum validator if this is an array of strings. Equivalent to
@@ -79411,11 +81253,19 @@ SchemaArray.prototype.constructor = SchemaArray;
  */
 
 SchemaArray.prototype.enum = function() {
-  const instance = get(this, 'caster.instance');
-  if (instance !== 'String') {
-    throw new Error('`enum` can only be set on an array of strings, not ' + instance);
+  let arr = this; /* eslint consistent-this: 0 */
+  while (true) { /* eslint no-constant-condition: 0 */
+    const instance = get(arr, 'caster.instance');
+    if (instance === 'Array') {
+      arr = arr.caster;
+      continue;
+    }
+    if (instance !== 'String') {
+      throw new Error('`enum` can only be set on an array of strings, not ' + instance);
+    }
+    break;
   }
-  this.caster.enum.apply(this.caster, arguments);
+  arr.caster.enum.apply(arr.caster, arguments);
   return this;
 };
 
@@ -79456,10 +81306,24 @@ SchemaArray.prototype.cast = function(value, doc, init) {
     if (!value.length && doc) {
       const indexes = doc.schema.indexedPaths();
 
+      const arrayPath = this.path;
       for (i = 0, l = indexes.length; i < l; ++i) {
-        const pathIndex = indexes[i][0][this.path];
+        const pathIndex = indexes[i][0][arrayPath];
         if (pathIndex === '2dsphere' || pathIndex === '2d') {
           return;
+        }
+      }
+
+      // Special case: if this index is on the parent of what looks like
+      // GeoJSON, skip setting the default to empty array re: #1668, #3233
+      const arrayGeojsonPath = this.path.endsWith('.coordinates') ?
+        this.path.substr(0, this.path.lastIndexOf('.')) : null;
+      if (arrayGeojsonPath != null) {
+        for (i = 0, l = indexes.length; i < l; ++i) {
+          const pathIndex = indexes[i][0][arrayGeojsonPath];
+          if (pathIndex === '2dsphere') {
+            return;
+          }
         }
       }
     }
@@ -79470,6 +81334,11 @@ SchemaArray.prototype.cast = function(value, doc, init) {
       // We need to create a new array, otherwise change tracking will
       // update the old doc (gh-4449)
       value = new MongooseArray(value, this.path, doc);
+    }
+
+    const isPopulated = doc != null && doc.$__ != null && doc.populated(this.path);
+    if (isPopulated) {
+      return value;
     }
 
     if (this.caster && this.casterConstructor !== Mixed) {
@@ -79512,6 +81381,17 @@ SchemaArray.prototype.discriminator = function(name, schema) {
     }
   }
   return arr.discriminator(name, schema);
+};
+
+/*!
+ * ignore
+ */
+
+SchemaArray.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, this.caster, options, this.schemaOptions);
+  schematype.validators = this.validators.slice();
+  return schematype;
 };
 
 /**
@@ -79612,7 +81492,7 @@ function cast$elemMatch(val) {
   for (let i = 0; i < numKeys; ++i) {
     const key = keys[i];
     const value = val[key];
-    if (key.indexOf('$') === 0 && value) {
+    if (key.startsWith('$') && value) {
       val[key] = this.castForQuery(key, value);
     }
   }
@@ -79669,11 +81549,11 @@ handle.$gte =
 handle.$lt =
 handle.$lte =
 handle.$ne =
-handle.$nin =
 handle.$regex = SchemaArray.prototype.castForQuery;
 
 // `$in` is special because you can also include an empty array in the query
 // like `$in: [1, []]`, see gh-5913
+handle.$nin = SchemaType.prototype.$conditionalHandlers.$nin;
 handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
 
 /*!
@@ -79682,7 +81562,7 @@ handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
 
 module.exports = SchemaArray;
 
-},{"../cast":252,"../error/mongooseError":272,"../helpers/get":286,"../queryhelpers":304,"../schematype":326,"../types":333,"../utils":337,"./boolean":307,"./buffer":308,"./date":309,"./map":314,"./mixed":315,"./number":316,"./objectid":317,"./operators/exists":319,"./operators/geospatial":320,"./operators/helpers":321,"./operators/type":323,"./string":324,"util":366}],307:[function(require,module,exports){
+},{"../cast":251,"../error/mongooseError":271,"../helpers/get":287,"../options/SchemaArrayOptions":306,"../queryhelpers":315,"../schematype":337,"../types":345,"../utils":349,"./index.js":324,"./mixed":326,"./operators/exists":330,"./operators/geospatial":331,"./operators/helpers":332,"./operators/type":334,"util":381}],319:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79892,7 +81772,7 @@ SchemaBoolean.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaBoolean;
 
-},{"../cast/boolean":253,"../error/cast":267,"../schematype":326,"../utils":337}],308:[function(require,module,exports){
+},{"../cast/boolean":252,"../error/cast":266,"../schematype":337,"../utils":349}],320:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -79900,11 +81780,13 @@ module.exports = SchemaBoolean;
 
 'use strict';
 
+const MongooseBuffer = require('../types/buffer');
+const SchemaBufferOptions = require('../options/SchemaBufferOptions');
+const SchemaType = require('../schematype');
 const handleBitwiseOperator = require('./operators/bitwise');
 const utils = require('../utils');
 
-const MongooseBuffer = require('../types/buffer');
-const SchemaType = require('../schematype');
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const Binary = MongooseBuffer.Binary;
 const CastError = SchemaType.CastError;
@@ -79936,6 +81818,7 @@ SchemaBuffer.schemaName = 'Buffer';
  */
 SchemaBuffer.prototype = Object.create(SchemaType.prototype);
 SchemaBuffer.prototype.constructor = SchemaBuffer;
+SchemaBuffer.prototype.OptionsConstructor = SchemaBufferOptions;
 
 /*!
  * ignore
@@ -80021,7 +81904,7 @@ SchemaBuffer.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    ret = new pop.options.model(value);
+    ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -80146,18 +82029,18 @@ SchemaBuffer.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaBuffer;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../schematype":326,"../types/buffer":329,"../utils":337,"./../document":259,"./operators/bitwise":318}],309:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../helpers/symbols":300,"../options/SchemaBufferOptions":307,"../schematype":337,"../types/buffer":340,"../utils":349,"./../document":258,"./operators/bitwise":329}],321:[function(require,module,exports){
 /*!
  * Module requirements.
  */
 
 'use strict';
 
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaDateOptions = require('../options/SchemaDateOptions');
+const SchemaType = require('../schematype');
 const castDate = require('../cast/date');
 const utils = require('../utils');
-
-const SchemaType = require('../schematype');
 
 const CastError = SchemaType.CastError;
 
@@ -80187,6 +82070,7 @@ SchemaDate.schemaName = 'Date';
  */
 SchemaDate.prototype = Object.create(SchemaType.prototype);
 SchemaDate.prototype.constructor = SchemaDate;
+SchemaDate.prototype.OptionsConstructor = SchemaDateOptions;
 
 /*!
  * ignore
@@ -80365,11 +82249,15 @@ SchemaDate.prototype.min = function(value, message) {
 
   if (value) {
     let msg = message || MongooseError.messages.Date.min;
-    msg = msg.replace(/{MIN}/, (value === Date.now ? 'Date.now()' : this.cast(value).toString()));
+    msg = msg.replace(/{MIN}/, (value === Date.now ? 'Date.now()' : value.toString()));
     const _this = this;
     this.validators.push({
       validator: this.minValidator = function(val) {
-        const min = (value === Date.now ? value() : _this.cast(value));
+        let _value = value;
+        if (typeof value === 'function' && value !== Date.now) {
+          _value = _value.call(this);
+        }
+        const min = (_value === Date.now ? _value() : _this.cast(_value));
         return val === null || val.valueOf() >= min.valueOf();
       },
       message: msg,
@@ -80421,11 +82309,15 @@ SchemaDate.prototype.max = function(value, message) {
 
   if (value) {
     let msg = message || MongooseError.messages.Date.max;
-    msg = msg.replace(/{MAX}/, (value === Date.now ? 'Date.now()' : this.cast(value).toString()));
+    msg = msg.replace(/{MAX}/, (value === Date.now ? 'Date.now()' : value.toString()));
     const _this = this;
     this.validators.push({
       validator: this.maxValidator = function(val) {
-        const max = (value === Date.now ? value() : _this.cast(value));
+        let _value = value;
+        if (typeof _value === 'function' && _value !== Date.now) {
+          _value = _value.call(this);
+        }
+        const max = (_value === Date.now ? _value() : _this.cast(_value));
         return val === null || val.valueOf() <= max.valueOf();
       },
       message: msg,
@@ -80502,7 +82394,7 @@ SchemaDate.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaDate;
 
-},{"../cast/date":254,"../error":269,"../schematype":326,"../utils":337}],310:[function(require,module,exports){
+},{"../cast/date":253,"../error/index":268,"../options/SchemaDateOptions":308,"../schematype":337,"../utils":349}],322:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -80515,6 +82407,8 @@ const CastError = SchemaType.CastError;
 const Decimal128Type = require('../types/decimal128');
 const castDecimal128 = require('../cast/decimal128');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 let Document;
 
@@ -80676,7 +82570,7 @@ Decimal128.prototype.cast = function(value, doc, init) {
         !doc.$__.populated[path].options ||
         !doc.$__.populated[path].options.options ||
         !doc.$__.populated[path].options.options.lean) {
-      ret = new pop.options.model(value);
+      ret = new pop.options[populateModelSymbol](value);
       ret.$__.wasPopulated = true;
     }
 
@@ -80716,7 +82610,7 @@ Decimal128.prototype.$conditionalHandlers =
 module.exports = Decimal128;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../cast/decimal128":255,"../schematype":326,"../types/decimal128":330,"../utils":337,"./../document":259}],311:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../cast/decimal128":254,"../helpers/symbols":300,"../schematype":337,"../types/decimal128":342,"../utils":349,"./../document":258}],323:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -80730,7 +82624,10 @@ const SchemaType = require('../schematype');
 const discriminator = require('../helpers/model/discriminator');
 const util = require('util');
 const utils = require('../utils');
-const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
+const getConstructor = require('../helpers/discriminator/getConstructor');
+
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
 
 let MongooseDocumentArray;
 let Subdocument;
@@ -80801,7 +82698,7 @@ DocumentArray.prototype.constructor = DocumentArray;
  * Ignore
  */
 
-function _createConstructor(schema, options) {
+function _createConstructor(schema, options, baseClass) {
   Subdocument || (Subdocument = require('../types/embedded'));
 
   // compile an embedded document for this schema
@@ -80811,7 +82708,8 @@ function _createConstructor(schema, options) {
     this.$session(this.ownerDocument().$session());
   }
 
-  EmbeddedDocument.prototype = Object.create(Subdocument.prototype);
+  const proto = baseClass != null ? baseClass.prototype : Subdocument.prototype;
+  EmbeddedDocument.prototype = Object.create(proto);
   EmbeddedDocument.prototype.$__setSchema(schema);
   EmbeddedDocument.schema = schema;
   EmbeddedDocument.prototype.constructor = EmbeddedDocument;
@@ -80841,14 +82739,14 @@ function _createConstructor(schema, options) {
  * Ignore
  */
 
-DocumentArray.prototype.discriminator = function(name, schema) {
+DocumentArray.prototype.discriminator = function(name, schema, tiedValue) {
   if (typeof name === 'function') {
     name = utils.getFunctionName(name);
   }
 
-  schema = discriminator(this.casterConstructor, name, schema);
+  schema = discriminator(this.casterConstructor, name, schema, tiedValue);
 
-  const EmbeddedDocument = _createConstructor(schema);
+  const EmbeddedDocument = _createConstructor(schema, null, this.casterConstructor);
   EmbeddedDocument.baseCasterConstructor = this.casterConstructor;
 
   try {
@@ -80926,8 +82824,8 @@ DocumentArray.prototype.doValidate = function(array, fn, scope, options) {
       // If you set the array index directly, the doc might not yet be
       // a full fledged mongoose subdoc, so make it into one.
       if (!(doc instanceof Subdocument)) {
-        doc = array[i] = new _this.casterConstructor(doc, array, undefined,
-          undefined, i);
+        const Constructor = getConstructor(_this.casterConstructor, array[i]);
+        doc = array[i] = new Constructor(doc, array, undefined, undefined, i);
       }
 
       doc.$__validate(callback);
@@ -80974,8 +82872,8 @@ DocumentArray.prototype.doValidateSync = function(array, scope) {
     // If you set the array index directly, the doc might not yet be
     // a full fledged mongoose subdoc, so make it into one.
     if (!(doc instanceof Subdocument)) {
-      doc = array[i] = new this.casterConstructor(doc, array, undefined,
-        undefined, i);
+      const Constructor = getConstructor(this.casterConstructor, array[i]);
+      doc = array[i] = new Constructor(doc, array, undefined, undefined, i);
     }
 
     const subdocValidateError = doc.validateSync();
@@ -81009,15 +82907,16 @@ DocumentArray.prototype.getDefault = function(scope) {
   }
 
   ret = new MongooseDocumentArray(ret, this.path, scope);
-  const _parent = ret._parent;
-  ret._parent = null;
+  const _parent = ret[arrayParentSymbol];
+  ret[arrayParentSymbol] = null;
 
   for (let i = 0; i < ret.length; ++i) {
-    ret[i] = new this.Constructor(ret[i], ret, undefined,
+    const Constructor = getConstructor(this.casterConstructor, ret[i]);
+    ret[i] = new Constructor(ret[i], ret, undefined,
       undefined, i);
   }
 
-  ret._parent = _parent;
+  ret[arrayParentSymbol] = _parent;
 
   return ret;
 };
@@ -81054,7 +82953,6 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
   if (!(value && value.isMongooseDocumentArray) &&
       (!options || !options.skipDocumentArrayCast)) {
     value = new MongooseDocumentArray(value, this.path, doc);
-    _clearListeners(prev);
   } else if (value && value.isMongooseDocumentArray) {
     // We need to create a new array, otherwise change tracking will
     // update the old doc (gh-4449)
@@ -81068,30 +82966,24 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
       continue;
     }
 
-    let Constructor = this.casterConstructor;
-    if (Constructor.discriminators &&
-        Constructor.schema &&
-        Constructor.schema.options &&
-        typeof value[i][Constructor.schema.options.discriminatorKey] === 'string') {
-      if (Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]]) {
-        Constructor = Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]];
-      } else {
-        const constructorByValue = getDiscriminatorByValue(Constructor, value[i][Constructor.schema.options.discriminatorKey]);
-        if (constructorByValue) {
-          Constructor = constructorByValue;
-        }
-      }
-    }
+    const Constructor = getConstructor(this.casterConstructor, value[i]);
 
     // Check if the document has a different schema (re gh-3701)
     if ((value[i].$__) &&
-        value[i].schema !== Constructor.schema) {
-      value[i] = value[i].toObject({ transform: false, virtuals: false });
+        !(value[i] instanceof Constructor)) {
+      value[i] = value[i].toObject({
+        transform: false,
+        // Special case: if different model, but same schema, apply virtuals
+        // re: gh-7898
+        virtuals: value[i].schema === Constructor.schema
+      });
     }
 
     if (value[i] instanceof Subdocument) {
       // Might not have the correct index yet, so ensure it does.
-      value[i].$setIndex(i);
+      if (value[i].__index == null) {
+        value[i].$setIndex(i);
+      }
     } else if (value[i] != null) {
       if (init) {
         if (doc) {
@@ -81103,7 +82995,7 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
         subdoc = new Constructor(null, value, true, selected, i);
         value[i] = subdoc.init(value[i]);
       } else {
-        if (prev && (subdoc = prev.id(value[i]._id))) {
+        if (prev && typeof prev.id === 'function') {
           subdoc = prev.id(value[i]._id);
         }
 
@@ -81121,12 +83013,9 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
             // see gh-746
             value[i] = subdoc;
           } catch (error) {
-            // Make sure we don't leave listeners dangling because `value`
-            // won't get back up to the schema type. See gh-6723
-            _clearListeners(value);
             const valueInErrorMessage = util.inspect(value[i]);
             throw new CastError('embedded', valueInErrorMessage,
-              value._path, error);
+              value[arrayPathSymbol], error);
           }
         }
       }
@@ -81137,18 +83026,17 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
 };
 
 /*!
- * Removes listeners from parent
+ * ignore
  */
 
-function _clearListeners(arr) {
-  if (arr == null || arr._parent == null) {
-    return;
-  }
-
-  for (const key in arr._handlers) {
-    arr._parent.removeListener(key, arr._handlers[key]);
-  }
-}
+DocumentArray.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, this.schema, options, this.schemaOptions);
+  schematype.validators = this.validators.slice();
+  schematype.Constructor.discriminators = Object.assign({},
+    this.Constructor.discriminators);
+  return schematype;
+};
 
 /*!
  * Scopes paths selected in a query to this array.
@@ -81174,12 +83062,12 @@ function scopePaths(array, fields, init) {
 
   while (i--) {
     key = keys[i];
-    if (key.indexOf(path) === 0) {
+    if (key.startsWith(path)) {
       sub = key.substring(path.length);
       if (sub === '$') {
         continue;
       }
-      if (sub.indexOf('$.') === 0) {
+      if (sub.startsWith('$.')) {
         sub = sub.substr(2);
       }
       hasKeys || (hasKeys = true);
@@ -81196,329 +83084,7 @@ function scopePaths(array, fields, init) {
 
 module.exports = DocumentArray;
 
-},{"../error/cast":267,"../helpers/model/discriminator":289,"../queryhelpers":304,"../schematype":326,"../types/documentarray":331,"../types/embedded":332,"../utils":337,"./array":306,"events":243,"util":366}],312:[function(require,module,exports){
-'use strict';
-
-/*!
- * Module dependencies.
- */
-
-const CastError = require('../error/cast');
-const EventEmitter = require('events').EventEmitter;
-const ObjectExpectedError = require('../error/objectExpected');
-const SchemaType = require('../schematype');
-const $exists = require('./operators/exists');
-const castToNumber = require('./operators/helpers').castToNumber;
-const discriminator = require('../helpers/model/discriminator');
-const geospatial = require('./operators/geospatial');
-const get = require('../helpers/get');
-const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
-const internalToObjectOptions = require('../options').internalToObjectOptions;
-
-let Subdocument;
-
-module.exports = Embedded;
-
-/**
- * Sub-schema schematype constructor
- *
- * @param {Schema} schema
- * @param {String} key
- * @param {Object} options
- * @inherits SchemaType
- * @api public
- */
-
-function Embedded(schema, path, options) {
-  this.caster = _createConstructor(schema);
-  this.caster.path = path;
-  this.caster.prototype.$basePath = path;
-  this.schema = schema;
-  this.$isSingleNested = true;
-  SchemaType.call(this, path, options, 'Embedded');
-}
-
-/*!
- * ignore
- */
-
-Embedded.prototype = Object.create(SchemaType.prototype);
-
-/*!
- * ignore
- */
-
-function _createConstructor(schema) {
-  // lazy load
-  Subdocument || (Subdocument = require('../types/subdocument'));
-
-  const _embedded = function SingleNested(value, path, parent) {
-    const _this = this;
-
-    this.$parent = parent;
-    Subdocument.apply(this, arguments);
-
-    this.$session(this.ownerDocument().$session());
-
-    if (parent) {
-      parent.on('save', function() {
-        _this.emit('save', _this);
-        _this.constructor.emit('save', _this);
-      });
-
-      parent.on('isNew', function(val) {
-        _this.isNew = val;
-        _this.emit('isNew', val);
-        _this.constructor.emit('isNew', val);
-      });
-    }
-  };
-  _embedded.prototype = Object.create(Subdocument.prototype);
-  _embedded.prototype.$__setSchema(schema);
-  _embedded.prototype.constructor = _embedded;
-  _embedded.schema = schema;
-  _embedded.$isSingleNested = true;
-  _embedded.events = new EventEmitter();
-  _embedded.prototype.toBSON = function() {
-    return this.toObject(internalToObjectOptions);
-  };
-
-  // apply methods
-  for (const i in schema.methods) {
-    _embedded.prototype[i] = schema.methods[i];
-  }
-
-  // apply statics
-  for (const i in schema.statics) {
-    _embedded[i] = schema.statics[i];
-  }
-
-  for (const i in EventEmitter.prototype) {
-    _embedded[i] = EventEmitter.prototype[i];
-  }
-
-  return _embedded;
-}
-
-/*!
- * Special case for when users use a common location schema to represent
- * locations for use with $geoWithin.
- * https://docs.mongodb.org/manual/reference/operator/query/geoWithin/
- *
- * @param {Object} val
- * @api private
- */
-
-Embedded.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val) {
-  return { $geometry: this.castForQuery(val.$geometry) };
-};
-
-/*!
- * ignore
- */
-
-Embedded.prototype.$conditionalHandlers.$near =
-Embedded.prototype.$conditionalHandlers.$nearSphere = geospatial.cast$near;
-
-Embedded.prototype.$conditionalHandlers.$within =
-Embedded.prototype.$conditionalHandlers.$geoWithin = geospatial.cast$within;
-
-Embedded.prototype.$conditionalHandlers.$geoIntersects =
-  geospatial.cast$geoIntersects;
-
-Embedded.prototype.$conditionalHandlers.$minDistance = castToNumber;
-Embedded.prototype.$conditionalHandlers.$maxDistance = castToNumber;
-
-Embedded.prototype.$conditionalHandlers.$exists = $exists;
-
-/**
- * Casts contents
- *
- * @param {Object} value
- * @api private
- */
-
-Embedded.prototype.cast = function(val, doc, init, priorVal) {
-  if (val && val.$isSingleNested) {
-    return val;
-  }
-
-  if (val != null && (typeof val !== 'object' || Array.isArray(val))) {
-    throw new ObjectExpectedError(this.path, val);
-  }
-
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (val != null &&
-      Constructor.discriminators &&
-      typeof val[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[val[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[val[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, val[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  let subdoc;
-
-  // Only pull relevant selected paths and pull out the base path
-  const parentSelected = get(doc, '$__.selected', {});
-  const path = this.path;
-  const selected = Object.keys(parentSelected).reduce((obj, key) => {
-    if (key.startsWith(path + '.')) {
-      obj[key.substr(path.length + 1)] = parentSelected[key];
-    }
-    return obj;
-  }, {});
-
-  if (init) {
-    subdoc = new Constructor(void 0, selected, doc);
-    subdoc.init(val);
-  } else {
-    if (Object.keys(val).length === 0) {
-      return new Constructor({}, selected, doc);
-    }
-
-    return new Constructor(val, selected, doc, undefined, { priorDoc: priorVal });
-  }
-
-  return subdoc;
-};
-
-/**
- * Casts contents for query
- *
- * @param {string} [$conditional] optional query operator (like `$eq` or `$in`)
- * @param {any} value
- * @api private
- */
-
-Embedded.prototype.castForQuery = function($conditional, val) {
-  let handler;
-  if (arguments.length === 2) {
-    handler = this.$conditionalHandlers[$conditional];
-    if (!handler) {
-      throw new Error('Can\'t use ' + $conditional);
-    }
-    return handler.call(this, val);
-  }
-  val = $conditional;
-  if (val == null) {
-    return val;
-  }
-
-  if (this.options.runSetters) {
-    val = this._applySetters(val);
-  }
-
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (val != null &&
-      Constructor.discriminators &&
-      typeof val[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[val[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[val[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, val[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  try {
-    val = new Constructor(val);
-  } catch (error) {
-    // Make sure we always wrap in a CastError (gh-6803)
-    if (!(error instanceof CastError)) {
-      throw new CastError('Embedded', val, this.path, error);
-    }
-    throw error;
-  }
-  return val;
-};
-
-/**
- * Async validation on this single nested doc.
- *
- * @api private
- */
-
-Embedded.prototype.doValidate = function(value, fn, scope, options) {
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (value != null &&
-      Constructor.discriminators &&
-      typeof value[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[value[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[value[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, value[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  if (options && options.skipSchemaValidators) {
-    if (!(value instanceof Constructor)) {
-      value = new Constructor(value, null, scope);
-    }
-
-    return value.validate(fn);
-  }
-
-  SchemaType.prototype.doValidate.call(this, value, function(error) {
-    if (error) {
-      return fn(error);
-    }
-    if (!value) {
-      return fn(null);
-    }
-
-    value.validate(fn);
-  }, scope);
-};
-
-/**
- * Synchronously validate this single nested doc
- *
- * @api private
- */
-
-Embedded.prototype.doValidateSync = function(value, scope, options) {
-  if (!options || !options.skipSchemaValidators) {
-    const schemaTypeError = SchemaType.prototype.doValidateSync.call(this, value, scope);
-    if (schemaTypeError) {
-      return schemaTypeError;
-    }
-  }
-  if (!value) {
-    return;
-  }
-  return value.validateSync();
-};
-
-/**
- * Adds a discriminator to this property
- *
- * @param {String} name
- * @param {Schema} schema fields to add to the schema for instances of this sub-class
- * @api public
- */
-
-Embedded.prototype.discriminator = function(name, schema) {
-  discriminator(this.caster, name, schema);
-
-  this.caster.discriminators[name] = _createConstructor(schema);
-
-  return this.caster.discriminators[name];
-};
-
-},{"../error/cast":267,"../error/objectExpected":274,"../helpers/get":286,"../helpers/model/discriminator":289,"../options":301,"../queryhelpers":304,"../schematype":326,"../types/subdocument":336,"./operators/exists":319,"./operators/geospatial":320,"./operators/helpers":321,"events":243}],313:[function(require,module,exports){
+},{"../error/cast":266,"../helpers/discriminator/getConstructor":283,"../helpers/model/discriminator":290,"../helpers/symbols":300,"../schematype":337,"../types/documentarray":343,"../types/embedded":344,"../utils":349,"./array":318,"events":243,"util":381}],324:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -81534,7 +83100,7 @@ exports.Boolean = require('./boolean');
 
 exports.DocumentArray = require('./documentarray');
 
-exports.Embedded = require('./embedded');
+exports.Embedded = require('./SingleNestedPath');
 
 exports.Array = require('./array');
 
@@ -81555,8 +83121,10 @@ exports.Map = require('./map');
 exports.Oid = exports.ObjectId;
 exports.Object = exports.Mixed;
 exports.Bool = exports.Boolean;
+exports.ObjectID = exports.ObjectId;
 
-},{"./array":306,"./boolean":307,"./buffer":308,"./date":309,"./decimal128":310,"./documentarray":311,"./embedded":312,"./map":314,"./mixed":315,"./number":316,"./objectid":317,"./string":324}],314:[function(require,module,exports){
+},{"./SingleNestedPath":317,"./array":318,"./boolean":319,"./buffer":320,"./date":321,"./decimal128":322,"./documentarray":323,"./map":325,"./mixed":326,"./number":327,"./objectid":328,"./string":335}],325:[function(require,module,exports){
+(function (global){
 'use strict';
 
 /*!
@@ -81584,8 +83152,14 @@ class Map extends SchemaType {
     if (init) {
       const map = new MongooseMap({}, this.path, doc, this.$__schemaType);
 
-      for (const key of Object.keys(val)) {
-        map.$init(key, this.$__schemaType.cast(val[key], doc, true));
+      if (val instanceof global.Map) {
+        for (const key of val.keys()) {
+          map.$init(key, map.$__schemaType.cast(val.get(key), doc, true));
+        }
+      } else {
+        for (const key of Object.keys(val)) {
+          map.$init(key, map.$__schemaType.cast(val[key], doc, true));
+        }
       }
 
       return map;
@@ -81597,7 +83171,8 @@ class Map extends SchemaType {
 
 module.exports = Map;
 
-},{"../schematype":326,"../types/map":334}],315:[function(require,module,exports){
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"../schematype":337,"../types/map":346}],326:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -81704,7 +83279,7 @@ Mixed.prototype.castForQuery = function($cond, val) {
 
 module.exports = Mixed;
 
-},{"../schematype":326,"../utils":337,"./symbols":325}],316:[function(require,module,exports){
+},{"../schematype":337,"../utils":349,"./symbols":336}],327:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -81712,11 +83287,14 @@ module.exports = Mixed;
  * Module requirements.
  */
 
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaNumberOptions = require('../options/SchemaNumberOptions');
 const SchemaType = require('../schematype');
 const castNumber = require('../cast/number');
 const handleBitwiseOperator = require('./operators/bitwise');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const CastError = SchemaType.CastError;
 let Document;
@@ -81812,6 +83390,7 @@ SchemaNumber.schemaName = 'Number';
  */
 SchemaNumber.prototype = Object.create(SchemaType.prototype);
 SchemaNumber.prototype.constructor = SchemaNumber;
+SchemaNumber.prototype.OptionsConstructor = SchemaNumberOptions;
 
 /*!
  * ignore
@@ -82001,7 +83580,7 @@ SchemaNumber.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    const ret = new pop.options.model(value);
+    const ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -82079,7 +83658,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaNumber;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../cast/number":256,"../error":269,"../schematype":326,"../utils":337,"./../document":259,"./operators/bitwise":318}],317:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../cast/number":255,"../error/index":268,"../helpers/symbols":300,"../options/SchemaNumberOptions":309,"../schematype":337,"../utils":349,"./../document":258,"./operators/bitwise":329}],328:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -82087,10 +83666,13 @@ module.exports = SchemaNumber;
 
 'use strict';
 
-const castObjectId = require('../cast/objectid');
+const SchemaObjectIdOptions = require('../options/SchemaObjectIdOptions');
 const SchemaType = require('../schematype');
+const castObjectId = require('../cast/objectid');
 const oid = require('../types/objectid');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const CastError = SchemaType.CastError;
 let Document;
@@ -82130,6 +83712,7 @@ ObjectId.schemaName = 'ObjectId';
  */
 ObjectId.prototype = Object.create(SchemaType.prototype);
 ObjectId.prototype.constructor = ObjectId;
+ObjectId.prototype.OptionsConstructor = SchemaObjectIdOptions;
 
 /**
  * Attaches a getter for all ObjectId instances
@@ -82309,7 +83892,7 @@ ObjectId.prototype.cast = function(value, doc, init) {
         !doc.$__.populated[path].options ||
         !doc.$__.populated[path].options.options ||
         !doc.$__.populated[path].options.options.lean) {
-      ret = new pop.options.model(value);
+      ret = new pop.options[populateModelSymbol](value);
       ret.$__.wasPopulated = true;
     }
 
@@ -82375,7 +83958,7 @@ function resetId(v) {
 module.exports = ObjectId;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../cast/objectid":257,"../schematype":326,"../types/objectid":335,"../utils":337,"./../document":259}],318:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../cast/objectid":256,"../helpers/symbols":300,"../options/SchemaObjectIdOptions":310,"../schematype":337,"../types/objectid":347,"../utils":349,"./../document":258}],329:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module requirements.
@@ -82417,7 +84000,7 @@ function _castNumber(path, num) {
 module.exports = handleBitwiseOperator;
 
 }).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":246,"../../error/cast":267}],319:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":245,"../../error/cast":266}],330:[function(require,module,exports){
 'use strict';
 
 const castBoolean = require('../../cast/boolean');
@@ -82431,7 +84014,7 @@ module.exports = function(val) {
   return castBoolean(val, path);
 };
 
-},{"../../cast/boolean":253}],320:[function(require,module,exports){
+},{"../../cast/boolean":252}],331:[function(require,module,exports){
 /*!
  * Module requirements.
  */
@@ -82535,7 +84118,7 @@ function _castMinMaxDistance(self, val) {
   }
 }
 
-},{"../array":306,"./helpers":321}],321:[function(require,module,exports){
+},{"../array":318,"./helpers":332}],332:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -82569,7 +84152,7 @@ function castArraysOfNumbers(arr, self) {
   });
 }
 
-},{"../number":316}],322:[function(require,module,exports){
+},{"../number":327}],333:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../../error/cast');
@@ -82610,7 +84193,7 @@ module.exports = function(val, path) {
   return val;
 };
 
-},{"../../cast/boolean":253,"../../cast/string":258,"../../error/cast":267}],323:[function(require,module,exports){
+},{"../../cast/boolean":252,"../../cast/string":257,"../../error/cast":266}],334:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -82625,7 +84208,7 @@ module.exports = function(val) {
   return val;
 };
 
-},{}],324:[function(require,module,exports){
+},{}],335:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -82634,11 +84217,14 @@ module.exports = function(val) {
  */
 
 const SchemaType = require('../schematype');
-const CastError = SchemaType.CastError;
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaStringOptions = require('../options/SchemaStringOptions');
 const castString = require('../cast/string');
 const utils = require('../utils');
 
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
+
+const CastError = SchemaType.CastError;
 let Document;
 
 /**
@@ -82669,6 +84255,7 @@ SchemaString.schemaName = 'String';
  */
 SchemaString.prototype = Object.create(SchemaType.prototype);
 SchemaString.prototype.constructor = SchemaString;
+SchemaString.prototype.OptionsConstructor = SchemaStringOptions;
 
 /*!
  * ignore
@@ -83166,7 +84753,7 @@ SchemaString.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    const ret = new pop.options.model(value);
+    const ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -83206,7 +84793,7 @@ SchemaString.prototype.$conditionalHandlers =
       $gte: handleSingle,
       $lt: handleSingle,
       $lte: handleSingle,
-      $options: handleSingle,
+      $options: String,
       $regex: handleSingle,
       $not: handleSingle
     });
@@ -83243,13 +84830,13 @@ SchemaString.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaString;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../cast/string":258,"../error":269,"../schematype":326,"../utils":337,"./../document":259}],325:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../cast/string":257,"../error/index":268,"../helpers/symbols":300,"../options/SchemaStringOptions":311,"../schematype":337,"../utils":349,"./../document":258}],336:[function(require,module,exports){
 'use strict';
 
 exports.schemaMixedSymbol = Symbol.for('mongoose:schema_mixed');
 
 exports.builtInMiddleware = Symbol.for('mongoose:built-in-middleware');
-},{}],326:[function(require,module,exports){
+},{}],337:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -83257,11 +84844,15 @@ exports.builtInMiddleware = Symbol.for('mongoose:built-in-middleware');
  * Module dependencies.
  */
 
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
+const SchemaTypeOptions = require('./options/SchemaTypeOptions');
 const $exists = require('./schema/operators/exists');
 const $type = require('./schema/operators/type');
 const get = require('./helpers/get');
+const handleImmutable = require('./helpers/schematype/handleImmutable');
 const immediate = require('./helpers/immediate');
+const schemaTypeSymbol = require('./helpers/symbols').schemaTypeSymbol;
+const util = require('util');
 const utils = require('./utils');
 const validatorErrorSymbol = require('./helpers/symbols').validatorErrorSymbol;
 
@@ -83278,12 +84869,13 @@ const ValidatorError = MongooseError.ValidatorError;
  *     schema.path('name') instanceof SchemaType; // true
  *
  * @param {String} path
- * @param {Object} [options]
+ * @param {SchemaTypeOptions} [options] See [SchemaTypeOptions docs](/docs/api/schematypeoptions.html)
  * @param {String} [instance]
  * @api public
  */
 
 function SchemaType(path, options, instance) {
+  this[schemaTypeSymbol] = true;
   this.path = path;
   this.instance = instance;
   this.validators = [];
@@ -83291,14 +84883,37 @@ function SchemaType(path, options, instance) {
     this.constructor.getters.slice() :
     [];
   this.setters = [];
-  this.options = options;
+
+  const Options = this.OptionsConstructor || SchemaTypeOptions;
+  this.options = new Options(options);
   this._index = null;
   this.selected;
+  if (utils.hasUserDefinedProperty(this.options, 'immutable')) {
+    this.$immutable = this.options.immutable;
 
-  for (const prop in options) {
-    if (this[prop] && typeof this[prop] === 'function') {
+    handleImmutable(this);
+  }
+
+  const keys = Object.keys(this.options);
+  for (const prop of keys) {
+    if (utils.hasUserDefinedProperty(this.options, prop) && typeof this[prop] === 'function') {
       // { unique: true, index: true }
       if (prop === 'index' && this._index) {
+        if (options.index === false) {
+          const index = this._index;
+          if (typeof index === 'object' && index != null) {
+            if (index.unique) {
+              throw new Error('Path "' + this.path + '" may not have `index` ' +
+                'set to false and `unique` set to true');
+            }
+            if (index.sparse) {
+              throw new Error('Path "' + this.path + '" may not have `index` ' +
+                'set to false and `sparse` set to true');
+            }
+          }
+
+          this._index = false;
+        }
         continue;
       }
 
@@ -83322,6 +84937,12 @@ function SchemaType(path, options, instance) {
     value: null
   });
 }
+
+/*!
+ * ignore
+ */
+
+SchemaType.prototype.OptionsConstructor = SchemaTypeOptions;
 
 /**
  * Get/set the function used to cast arbitrary values to this type.
@@ -83443,9 +85064,9 @@ SchemaType.prototype.default = function(val) {
  *     var s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
  *     var s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
  *     var s = new Schema({ date: { type: Date, index: { unique: true, expires: '1d' }})
- *     Schema.path('my.path').index(true);
- *     Schema.path('my.date').index({ expires: 60 });
- *     Schema.path('my.path').index({ unique: true, sparse: true });
+ *     s.path('my.path').index(true);
+ *     s.path('my.date').index({ expires: 60 });
+ *     s.path('my.path').index({ unique: true, sparse: true });
  *
  * ####NOTE:
  *
@@ -83471,7 +85092,7 @@ SchemaType.prototype.index = function(options) {
  * ####Example:
  *
  *     var s = new Schema({ name: { type: String, unique: true }});
- *     Schema.path('name').index({ unique: true });
+ *     s.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._
  *
@@ -83504,13 +85125,21 @@ SchemaType.prototype.unique = function(bool) {
  * ###Example:
  *
  *      var s = new Schema({name : {type: String, text : true })
- *      Schema.path('name').index({text : true});
+ *      s.path('name').index({text : true});
  * @param {Boolean} bool
  * @return {SchemaType} this
  * @api public
  */
 
 SchemaType.prototype.text = function(bool) {
+  if (this._index === false) {
+    if (!bool) {
+      return;
+    }
+    throw new Error('Path "' + this.path + '" may not have `index` set to ' +
+      'false and `text` set to true');
+  }
+
   if (this._index === null || this._index === undefined ||
     typeof this._index === 'boolean') {
     this._index = {};
@@ -83527,8 +85156,8 @@ SchemaType.prototype.text = function(bool) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, sparse: true })
- *     Schema.path('name').index({ sparse: true });
+ *     var s = new Schema({ name: { type: String, sparse: true } });
+ *     s.path('name').index({ sparse: true });
  *
  * @param {Boolean} bool
  * @return {SchemaType} this
@@ -83536,14 +85165,71 @@ SchemaType.prototype.text = function(bool) {
  */
 
 SchemaType.prototype.sparse = function(bool) {
-  if (this._index === null || this._index === undefined ||
-    typeof this._index === 'boolean') {
+  if (this._index === false) {
+    if (!bool) {
+      return;
+    }
+    throw new Error('Path "' + this.path + '" may not have `index` set to ' +
+      'false and `sparse` set to true');
+  }
+
+  if (this._index == null || typeof this._index === 'boolean') {
     this._index = {};
   } else if (typeof this._index === 'string') {
     this._index = {type: this._index};
   }
 
   this._index.sparse = bool;
+  return this;
+};
+
+/**
+ * Defines this path as immutable. Mongoose prevents you from changing
+ * immutable paths unless the parent document has [`isNew: true`](/docs/api.html#document_Document-isNew).
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({
+ *       name: { type: String, immutable: true },
+ *       age: Number
+ *     });
+ *     const Model = mongoose.model('Test', schema);
+ *
+ *     await Model.create({ name: 'test' });
+ *     const doc = await Model.findOne();
+ *
+ *     doc.isNew; // false
+ *     doc.name = 'new name';
+ *     doc.name; // 'test', because `name` is immutable
+ *
+ * Mongoose also prevents changing immutable properties using `updateOne()`
+ * and `updateMany()` based on [strict mode](/docs/guide.html#strict).
+ *
+ * ####Example:
+ *
+ *     // Mongoose will strip out the `name` update, because `name` is immutable
+ *     Model.updateOne({}, { $set: { name: 'test2' }, $inc: { age: 1 } });
+ *
+ *     // If `strict` is set to 'throw', Mongoose will throw an error if you
+ *     // update `name`
+ *     const err = await Model.updateOne({}, { name: 'test2' }, { strict: 'throw' }).
+ *       then(() => null, err => err);
+ *     err.name; // StrictModeError
+ *
+ *     // If `strict` is `false`, Mongoose allows updating `name` even though
+ *     // the property is immutable.
+ *     Model.updateOne({}, { name: 'test2' }, { strict: false });
+ *
+ * @param {Boolean} bool
+ * @return {SchemaType} this
+ * @see isNew /docs/api.html#document_Document-isNew
+ * @api public
+ */
+
+SchemaType.prototype.immutable = function(bool) {
+  this.$immutable = bool;
+  handleImmutable(this);
+
   return this;
 };
 
@@ -83846,6 +85532,11 @@ SchemaType.prototype.validate = function(obj, message, type) {
       }
       properties = {message: message, type: type, validator: obj};
     }
+
+    if (properties.isAsync) {
+      handleIsAsync();
+    }
+
     this.validators.push(properties);
     return this;
   }
@@ -83868,6 +85559,15 @@ SchemaType.prototype.validate = function(obj, message, type) {
 
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+const handleIsAsync = util.deprecate(function handleIsAsync() {},
+  'Mongoose: the `isAsync` option for custom validators is deprecated. Make ' +
+  'your async validators return a promise instead: ' +
+  'https://mongoosejs.com/docs/validation.html#async-custom-validators');
 
 /**
  * Adds a required validator to this SchemaType. The validator gets added
@@ -83905,15 +85605,15 @@ SchemaType.prototype.validate = function(obj, message, type) {
  *
  *     // or through the path API
  *
- *     Schema.path('name').required(true);
+ *     s.path('name').required(true);
  *
  *     // with custom error messaging
  *
- *     Schema.path('name').required(true, 'grrr :( ');
+ *     s.path('name').required(true, 'grrr :( ');
  *
  *     // or make a path conditionally required based on a function
  *     var isOver18 = function() { return this.age >= 18; };
- *     Schema.path('voterRegistrationId').required(isOver18);
+ *     s.path('voterRegistrationId').required(isOver18);
  *
  * The required validator uses the SchemaType's `checkRequired` function to
  * determine whether a given value satisfies the required validator. By default,
@@ -83938,6 +85638,17 @@ SchemaType.prototype.validate = function(obj, message, type) {
 
 SchemaType.prototype.required = function(required, message) {
   let customOptions = {};
+
+  if (arguments.length > 0 && required == null) {
+    this.validators = this.validators.filter(function(v) {
+      return v.validator !== this.requiredValidator;
+    }, this);
+
+    this.isRequired = false;
+    delete this.originalRequiredValue;
+    return this;
+  }
+
   if (typeof required === 'object') {
     customOptions = required;
     message = customOptions.message || message;
@@ -84042,7 +85753,7 @@ SchemaType.prototype.getDefault = function(scope, init) {
       ret = utils.clone(ret);
     }
 
-    const casted = this.cast(ret, scope, init);
+    const casted = this.applySetters(ret, scope, init);
     if (casted && casted.$isSingleNested) {
       casted.$parent = scope;
     }
@@ -84155,10 +85866,15 @@ SchemaType.prototype.select = function select(val) {
  * @api private
  */
 
-SchemaType.prototype.doValidate = function(value, fn, scope) {
+SchemaType.prototype.doValidate = function(value, fn, scope, options) {
   let err = false;
   const path = this.path;
-  let count = this.validators.length;
+
+  // Avoid non-object `validators`
+  const validators = this.validators.
+    filter(v => v != null && typeof v === 'object');
+
+  let count = validators.length;
 
   if (!count) {
     return fn(null);
@@ -84185,7 +85901,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
   };
 
   const _this = this;
-  this.validators.forEach(function(v) {
+  validators.forEach(function(v) {
     if (err) {
       return;
     }
@@ -84194,7 +85910,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
     let ok;
 
     const validatorProperties = utils.clone(v);
-    validatorProperties.path = path;
+    validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.value = value;
 
     if (validator instanceof RegExp) {
@@ -84225,6 +85941,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
             function(ok) { validate(ok, validatorProperties); },
             function(error) {
               validatorProperties.reason = error;
+              validatorProperties.message = error.message;
               ok = false;
               validate(ok, validatorProperties);
             });
@@ -84272,6 +85989,7 @@ function asyncValidate(validator, scope, value, props, cb) {
         called = true;
 
         props.reason = error;
+        props.message = error.message;
         cb(false, props);
       });
   }
@@ -84290,7 +86008,7 @@ function asyncValidate(validator, scope, value, props, cb) {
  * @api private
  */
 
-SchemaType.prototype.doValidateSync = function(value, scope) {
+SchemaType.prototype.doValidateSync = function(value, scope, options) {
   let err = null;
   const path = this.path;
   const count = this.validators.length;
@@ -84324,9 +86042,13 @@ SchemaType.prototype.doValidateSync = function(value, scope) {
       return;
     }
 
+    if (v == null || typeof v !== 'object') {
+      return;
+    }
+
     const validator = v.validator;
     const validatorProperties = utils.clone(v);
-    validatorProperties.path = path;
+    validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.value = value;
     let ok;
 
@@ -84450,7 +86172,7 @@ SchemaType.prototype.$conditionalHandlers = {
   $eq: handleSingle,
   $in: handle$in,
   $ne: handleSingle,
-  $nin: handleArray,
+  $nin: handle$in,
   $exists: $exists,
   $type: $type
 };
@@ -84538,6 +86260,20 @@ SchemaType.prototype.checkRequired = function(val) {
 };
 
 /*!
+ * ignore
+ */
+
+SchemaType.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, options, this.instance);
+  schematype.validators = this.validators.slice();
+  schematype.requiredValidator = this.requiredValidator;
+  schematype.getters = this.getters.slice();
+  schematype.setters = this.setters.slice();
+  return schematype;
+};
+
+/*!
  * Module exports.
  */
 
@@ -84548,7 +86284,7 @@ exports.CastError = CastError;
 exports.ValidatorError = ValidatorError;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":246,"./error":269,"./helpers/get":286,"./helpers/immediate":287,"./helpers/symbols":297,"./schema/operators/exists":319,"./schema/operators/type":323,"./utils":337}],327:[function(require,module,exports){
+},{"../../is-buffer/index.js":245,"./error/index":268,"./helpers/get":287,"./helpers/immediate":288,"./helpers/schematype/handleImmutable":299,"./helpers/symbols":300,"./options/SchemaTypeOptions":312,"./schema/operators/exists":330,"./schema/operators/type":334,"./utils":349,"util":381}],338:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -84730,24 +86466,22 @@ StateMachine.prototype.map = function map() {
   return this.map.apply(this, arguments);
 };
 
-},{"./utils":337}],328:[function(require,module,exports){
-(function (Buffer){
+},{"./utils":349}],339:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
 
 'use strict';
 
-const EmbeddedDocument = require('./embedded');
+const CoreMongooseArray = require('./core_array');
 const Document = require('../document');
-const ObjectId = require('./objectid');
-const cleanModifiedSubpaths = require('../helpers/document/cleanModifiedSubpaths');
-const get = require('../helpers/get');
-const internalToObjectOptions = require('../options').internalToObjectOptions;
-const utils = require('../utils');
-const util = require('util');
 
-const isMongooseObject = utils.isMongooseObject;
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
+
+const _basePush = Array.prototype.push;
 
 /**
  * Mongoose Array constructor.
@@ -84765,814 +86499,33 @@ const isMongooseObject = utils.isMongooseObject;
  */
 
 function MongooseArray(values, path, doc) {
-  const arr = [].concat(values);
+  // TODO: replace this with `new CoreMongooseArray().concat()` when we remove
+  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
+  const arr = new CoreMongooseArray();
+  arr[arrayAtomicsSymbol] = {};
 
-  const keysMA = Object.keys(MongooseArray.mixin);
-  const numKeys = keysMA.length;
-  for (let i = 0; i < numKeys; ++i) {
-    arr[keysMA[i]] = MongooseArray.mixin[keysMA[i]];
+  if (Array.isArray(values)) {
+    const len = values.length;
+    for (let i = 0; i < len; ++i) {
+      _basePush.call(arr, values[i]);
+    }
+
+    arr[arrayAtomicsSymbol] = values[arrayAtomicsSymbol] || {};
   }
 
-  arr._path = path;
-  arr.isMongooseArray = true;
-  arr.validators = [];
-  arr._atomics = {};
-  arr._schema = void 0;
-  if (util.inspect.custom) {
-    arr[util.inspect.custom] = arr.inspect;
-  }
+  arr[arrayPathSymbol] = path;
+  arr[arraySchemaSymbol] = void 0;
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020)
   // RB Jun 17, 2015 updated to check for presence of expected paths instead
   // to make more proof against unusual node environments
   if (doc && doc instanceof Document) {
-    arr._parent = doc;
-    arr._schema = doc.schema.path(path);
+    arr[arrayParentSymbol] = doc;
+    arr[arraySchemaSymbol] = doc.schema.path(path);
   }
 
   return arr;
-}
-
-MongooseArray.mixin = {
-  /*!
-   * ignore
-   */
-  toBSON: function() {
-    return this.toObject(internalToObjectOptions);
-  },
-
-  /**
-   * Stores a queue of atomic operations to perform
-   *
-   * @property _atomics
-   * @api private
-   */
-
-  _atomics: undefined,
-
-  /**
-   * Parent owner document
-   *
-   * @property _parent
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _parent: undefined,
-
-  /**
-   * Casts a member based on this arrays schema.
-   *
-   * @param {any} value
-   * @return value the casted value
-   * @method _cast
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _cast: function(value) {
-    let populated = false;
-    let Model;
-
-    if (this._parent) {
-      populated = this._parent.populated(this._path, true);
-    }
-
-    if (populated && value !== null && value !== undefined) {
-      // cast to the populated Models schema
-      Model = populated.options.model || populated.options.Model;
-
-      // only objects are permitted so we can safely assume that
-      // non-objects are to be interpreted as _id
-      if (Buffer.isBuffer(value) ||
-          value instanceof ObjectId || !utils.isObject(value)) {
-        value = {_id: value};
-      }
-
-      // gh-2399
-      // we should cast model only when it's not a discriminator
-      const isDisc = value.schema && value.schema.discriminatorMapping &&
-          value.schema.discriminatorMapping.key !== undefined;
-      if (!isDisc) {
-        value = new Model(value);
-      }
-      return this._schema.caster.applySetters(value, this._parent, true);
-    }
-
-    return this._schema.caster.applySetters(value, this._parent, false);
-  },
-
-  /**
-   * Marks this array as modified.
-   *
-   * If it bubbles up from an embedded document change, then it takes the following arguments (otherwise, takes 0 arguments)
-   *
-   * @param {EmbeddedDocument} embeddedDoc the embedded doc that invoked this method on the Array
-   * @param {String} embeddedPath the path which changed in the embeddedDoc
-   * @method _markModified
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _markModified: function(elem, embeddedPath) {
-    const parent = this._parent;
-    let dirtyPath;
-
-    if (parent) {
-      dirtyPath = this._path;
-
-      if (arguments.length) {
-        if (embeddedPath != null) {
-          // an embedded doc bubbled up the change
-          dirtyPath = dirtyPath + '.' + this.indexOf(elem) + '.' + embeddedPath;
-        } else {
-          // directly set an index
-          dirtyPath = dirtyPath + '.' + elem;
-        }
-      }
-
-      parent.markModified(dirtyPath, arguments.length > 0 ? elem : parent);
-    }
-
-    return this;
-  },
-
-  /**
-   * Register an atomic operation with the parent.
-   *
-   * @param {Array} op operation
-   * @param {any} val
-   * @method _registerAtomic
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _registerAtomic: function(op, val) {
-    if (op === '$set') {
-      // $set takes precedence over all other ops.
-      // mark entire array modified.
-      this._atomics = {$set: val};
-      return this;
-    }
-
-    const atomics = this._atomics;
-
-    // reset pop/shift after save
-    if (op === '$pop' && !('$pop' in atomics)) {
-      const _this = this;
-      this._parent.once('save', function() {
-        _this._popped = _this._shifted = null;
-      });
-    }
-
-    // check for impossible $atomic combos (Mongo denies more than one
-    // $atomic op on a single path
-    if (this._atomics.$set ||
-        Object.keys(atomics).length && !(op in atomics)) {
-      // a different op was previously registered.
-      // save the entire thing.
-      this._atomics = {$set: this};
-      return this;
-    }
-
-    let selector;
-
-    if (op === '$pullAll' || op === '$addToSet') {
-      atomics[op] || (atomics[op] = []);
-      atomics[op] = atomics[op].concat(val);
-    } else if (op === '$pullDocs') {
-      const pullOp = atomics['$pull'] || (atomics['$pull'] = {});
-      if (val[0] instanceof EmbeddedDocument) {
-        selector = pullOp['$or'] || (pullOp['$or'] = []);
-        Array.prototype.push.apply(selector, val.map(function(v) {
-          return v.toObject({transform: false, virtuals: false});
-        }));
-      } else {
-        selector = pullOp['_id'] || (pullOp['_id'] = {$in: []});
-        selector['$in'] = selector['$in'].concat(val);
-      }
-    } else if (op === '$push') {
-      atomics.$push = atomics.$push || { $each: [] };
-      atomics.$push.$each = atomics.$push.$each.concat(val);
-    } else {
-      atomics[op] = val;
-    }
-
-    return this;
-  },
-
-  /**
-   * Depopulates stored atomic operation values as necessary for direct insertion to MongoDB.
-   *
-   * If no atomics exist, we return all array values after conversion.
-   *
-   * @return {Array}
-   * @method $__getAtomics
-   * @memberOf MongooseArray
-   * @instance
-   * @api private
-   */
-
-  $__getAtomics: function() {
-    const ret = [];
-    const keys = Object.keys(this._atomics);
-    let i = keys.length;
-
-    const opts = Object.assign({}, internalToObjectOptions, { _isNested: true });
-
-    if (i === 0) {
-      ret[0] = ['$set', this.toObject(opts)];
-      return ret;
-    }
-
-    while (i--) {
-      const op = keys[i];
-      let val = this._atomics[op];
-
-      // the atomic values which are arrays are not MongooseArrays. we
-      // need to convert their elements as if they were MongooseArrays
-      // to handle populated arrays versus DocumentArrays properly.
-      if (isMongooseObject(val)) {
-        val = val.toObject(opts);
-      } else if (Array.isArray(val)) {
-        val = this.toObject.call(val, opts);
-      } else if (val != null && Array.isArray(val.$each)) {
-        val.$each = this.toObject.call(val.$each, opts);
-      } else if (val.valueOf) {
-        val = val.valueOf();
-      }
-
-      if (op === '$addToSet') {
-        val = {$each: val};
-      }
-
-      ret.push([op, val]);
-    }
-
-    return ret;
-  },
-
-  /**
-   * Returns the number of pending atomic operations to send to the db for this array.
-   *
-   * @api private
-   * @return {Number}
-   * @method hasAtomics
-   * @memberOf MongooseArray
-   */
-
-  hasAtomics: function hasAtomics() {
-    if (!(this._atomics && this._atomics.constructor.name === 'Object')) {
-      return 0;
-    }
-
-    return Object.keys(this._atomics).length;
-  },
-
-  /**
-   * Internal helper for .map()
-   *
-   * @api private
-   * @return {Number}
-   * @method _mapCast
-   * @memberOf MongooseArray
-   */
-  _mapCast: function(val, index) {
-    return this._cast(val, this.length + index);
-  },
-
-  /**
-   * Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking.
-   *
-   * @param {Object} [args...]
-   * @api public
-   * @method push
-   * @memberOf MongooseArray
-   */
-
-  push: function() {
-    _checkManualPopulation(this, arguments);
-    let values = [].map.call(arguments, this._mapCast, this);
-    values = this._schema.applySetters(values, this._parent, undefined,
-      undefined, { skipDocumentArrayCast: true });
-    const ret = [].push.apply(this, values);
-
-    this._registerAtomic('$push', values);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pushes items to the array non-atomically.
-   *
-   * ####NOTE:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @param {any} [args...]
-   * @api public
-   * @method nonAtomicPush
-   * @memberOf MongooseArray
-   */
-
-  nonAtomicPush: function() {
-    const values = [].map.call(arguments, this._mapCast, this);
-    const ret = [].push.apply(this, values);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pops the array atomically at most one time per document `save()`.
-   *
-   * #### NOTE:
-   *
-   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
-   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
-   *
-   *      doc.array = [1,2,3];
-   *
-   *      var popped = doc.array.$pop();
-   *      console.log(popped); // 3
-   *      console.log(doc.array); // [1,2]
-   *
-   *      // no affect
-   *      popped = doc.array.$pop();
-   *      console.log(doc.array); // [1,2]
-   *
-   *      doc.save(function (err) {
-   *        if (err) return handleError(err);
-   *
-   *        // we saved, now $pop works again
-   *        popped = doc.array.$pop();
-   *        console.log(popped); // 2
-   *        console.log(doc.array); // [1]
-   *      })
-   *
-   * @api public
-   * @method $pop
-   * @memberOf MongooseArray
-   * @instance
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
-   * @method $pop
-   * @memberOf MongooseArray
-   */
-
-  $pop: function() {
-    this._registerAtomic('$pop', 1);
-    this._markModified();
-
-    // only allow popping once
-    if (this._popped) {
-      return;
-    }
-    this._popped = true;
-
-    return [].pop.call(this);
-  },
-
-  /**
-   * Wraps [`Array#pop`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/pop) with proper change tracking.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified which will pass the entire thing to $set potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @see MongooseArray#$pop #types_array_MongooseArray-%24pop
-   * @api public
-   * @method pop
-   * @memberOf MongooseArray
-   */
-
-  pop: function() {
-    const ret = [].pop.call(this);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Atomically shifts the array at most one time per document `save()`.
-   *
-   * ####NOTE:
-   *
-   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
-   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
-   *
-   *      doc.array = [1,2,3];
-   *
-   *      var shifted = doc.array.$shift();
-   *      console.log(shifted); // 1
-   *      console.log(doc.array); // [2,3]
-   *
-   *      // no affect
-   *      shifted = doc.array.$shift();
-   *      console.log(doc.array); // [2,3]
-   *
-   *      doc.save(function (err) {
-   *        if (err) return handleError(err);
-   *
-   *        // we saved, now $shift works again
-   *        shifted = doc.array.$shift();
-   *        console.log(shifted ); // 2
-   *        console.log(doc.array); // [3]
-   *      })
-   *
-   * @api public
-   * @memberOf MongooseArray
-   * @instance
-   * @method $shift
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
-   */
-
-  $shift: function $shift() {
-    this._registerAtomic('$pop', -1);
-    this._markModified();
-
-    // only allow shifting once
-    if (this._shifted) {
-      return;
-    }
-    this._shifted = true;
-
-    return [].shift.call(this);
-  },
-
-  /**
-   * Wraps [`Array#shift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
-   *
-   * ####Example:
-   *
-   *     doc.array = [2,3];
-   *     var res = doc.array.shift();
-   *     console.log(res) // 2
-   *     console.log(doc.array) // [3]
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method shift
-   * @memberOf MongooseArray
-   */
-
-  shift: function() {
-    const ret = [].shift.call(this);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pulls items from the array atomically. Equality is determined by casting
-   * the provided value to an embedded document and comparing using
-   * [the `Document.equals()` function.](./api.html#document_Document-equals)
-   *
-   * ####Examples:
-   *
-   *     doc.array.pull(ObjectId)
-   *     doc.array.pull({ _id: 'someId' })
-   *     doc.array.pull(36)
-   *     doc.array.pull('tag 1', 'tag 2')
-   *
-   * To remove a document from a subdocument array we may pass an object with a matching `_id`.
-   *
-   *     doc.subdocs.push({ _id: 4815162342 })
-   *     doc.subdocs.pull({ _id: 4815162342 }) // removed
-   *
-   * Or we may passing the _id directly and let mongoose take care of it.
-   *
-   *     doc.subdocs.push({ _id: 4815162342 })
-   *     doc.subdocs.pull(4815162342); // works
-   *
-   * The first pull call will result in a atomic operation on the database, if pull is called repeatedly without saving the document, a $set operation is used on the complete array instead, overwriting possible changes that happened on the database in the meantime.
-   *
-   * @param {any} [args...]
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
-   * @api public
-   * @method pull
-   * @memberOf MongooseArray
-   */
-
-  pull: function() {
-    const values = [].map.call(arguments, this._cast, this);
-    const cur = this._parent.get(this._path);
-    let i = cur.length;
-    let mem;
-
-    while (i--) {
-      mem = cur[i];
-      if (mem instanceof Document) {
-        const some = values.some(function(v) {
-          return mem.equals(v);
-        });
-        if (some) {
-          [].splice.call(cur, i, 1);
-        }
-      } else if (~cur.indexOf.call(values, mem)) {
-        [].splice.call(cur, i, 1);
-      }
-    }
-
-    if (values[0] instanceof EmbeddedDocument) {
-      this._registerAtomic('$pullDocs', values.map(function(v) {
-        return v._id || v;
-      }));
-    } else {
-      this._registerAtomic('$pullAll', values);
-    }
-
-    this._markModified();
-
-    // Might have modified child paths and then pulled, like
-    // `doc.children[1].name = 'test';` followed by
-    // `doc.children.remove(doc.children[0]);`. In this case we fall back
-    // to a `$set` on the whole array. See #3511
-    if (cleanModifiedSubpaths(this._parent, this._path) > 0) {
-      this._registerAtomic('$set', this);
-    }
-
-    return this;
-  },
-
-  /**
-   * Wraps [`Array#splice`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/splice) with proper change tracking and casting.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method splice
-   * @memberOf MongooseArray
-   */
-
-  splice: function splice() {
-    let ret;
-
-    _checkManualPopulation(this, Array.prototype.slice.call(arguments, 2));
-
-    if (arguments.length) {
-      const vals = [];
-      for (let i = 0; i < arguments.length; ++i) {
-        vals[i] = i < 2 ?
-          arguments[i] :
-          this._cast(arguments[i], arguments[0] + (i - 2));
-      }
-      ret = [].splice.apply(this, vals);
-      this._registerAtomic('$set', this);
-      this._markModified();
-      cleanModifiedSubpaths(this._parent, this._path);
-    }
-
-    return ret;
-  },
-
-  /**
-   * Wraps [`Array#unshift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method unshift
-   * @memberOf MongooseArray
-   */
-
-  unshift: function() {
-    _checkManualPopulation(this, arguments);
-
-    let values = [].map.call(arguments, this._cast, this);
-    values = this._schema.applySetters(values, this._parent);
-    [].unshift.apply(this, values);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return this.length;
-  },
-
-  /**
-   * Wraps [`Array#sort`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort) with proper change tracking.
-   *
-   * ####NOTE:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method sort
-   * @memberOf MongooseArray
-   */
-
-  sort: function() {
-    const ret = [].sort.apply(this, arguments);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Adds values to the array if not already present.
-   *
-   * ####Example:
-   *
-   *     console.log(doc.array) // [2,3,4]
-   *     var added = doc.array.addToSet(4,5);
-   *     console.log(doc.array) // [2,3,4,5]
-   *     console.log(added)     // [5]
-   *
-   * @param {any} [args...]
-   * @return {Array} the values that were added
-   * @memberOf MongooseArray
-   * @api public
-   * @method addToSet
-   */
-
-  addToSet: function addToSet() {
-    _checkManualPopulation(this, arguments);
-
-    let values = [].map.call(arguments, this._mapCast, this);
-    values = this._schema.applySetters(values, this._parent);
-    const added = [];
-    let type = '';
-    if (values[0] instanceof EmbeddedDocument) {
-      type = 'doc';
-    } else if (values[0] instanceof Date) {
-      type = 'date';
-    }
-
-    values.forEach(function(v) {
-      let found;
-      const val = +v;
-      switch (type) {
-        case 'doc':
-          found = this.some(function(doc) {
-            return doc.equals(v);
-          });
-          break;
-        case 'date':
-          found = this.some(function(d) {
-            return +d === val;
-          });
-          break;
-        default:
-          found = ~this.indexOf(v);
-      }
-
-      if (!found) {
-        [].push.call(this, v);
-        this._registerAtomic('$addToSet', v);
-        this._markModified();
-        [].push.call(added, v);
-      }
-    }, this);
-
-    return added;
-  },
-
-  /**
-   * Sets the casted `val` at index `i` and marks the array modified.
-   *
-   * ####Example:
-   *
-   *     // given documents based on the following
-   *     var Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
-   *
-   *     var doc = new Doc({ array: [2,3,4] })
-   *
-   *     console.log(doc.array) // [2,3,4]
-   *
-   *     doc.array.set(1,"5");
-   *     console.log(doc.array); // [2,5,4] // properly cast to number
-   *     doc.save() // the change is saved
-   *
-   *     // VS not using array#set
-   *     doc.array[1] = "5";
-   *     console.log(doc.array); // [2,"5",4] // no casting
-   *     doc.save() // change is not saved
-   *
-   * @return {Array} this
-   * @api public
-   * @method set
-   * @memberOf MongooseArray
-   */
-
-  set: function set(i, val) {
-    const value = this._cast(val, i);
-    this[i] = value;
-    this._markModified(i);
-    return this;
-  },
-
-  /**
-   * Returns a native js Array.
-   *
-   * @param {Object} options
-   * @return {Array}
-   * @api public
-   * @method toObject
-   * @memberOf MongooseArray
-   */
-
-  toObject: function(options) {
-    if (options && options.depopulate) {
-      options = utils.clone(options);
-      options._isNested = true;
-      return this.map(function(doc) {
-        return doc instanceof Document
-          ? doc.toObject(options)
-          : doc;
-      });
-    }
-
-    return this.slice();
-  },
-
-  /**
-   * Helper for console.log
-   *
-   * @api public
-   * @method inspect
-   * @memberOf MongooseArray
-   */
-
-  inspect: function() {
-    return JSON.stringify(this);
-  },
-
-  /**
-   * Return the index of `obj` or `-1` if not found.
-   *
-   * @param {Object} obj the item to look for
-   * @return {Number}
-   * @api public
-   * @method indexOf
-   * @memberOf MongooseArray
-   */
-
-  indexOf: function indexOf(obj) {
-    if (obj instanceof ObjectId) {
-      obj = obj.toString();
-    }
-    for (let i = 0, len = this.length; i < len; ++i) {
-      if (obj == this[i]) {
-        return i;
-      }
-    }
-    return -1;
-  }
-};
-
-/**
- * Alias of [pull](#types_array_MongooseArray-pull)
- *
- * @see MongooseArray#pull #types_array_MongooseArray-pull
- * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
- * @api public
- * @memberOf MongooseArray
- * @instance
- * @method remove
- */
-
-MongooseArray.mixin.remove = MongooseArray.mixin.pull;
-
-/*!
- * ignore
- */
-
-function _isAllSubdocs(docs, ref) {
-  if (!ref) {
-    return false;
-  }
-  for (let i = 0; i < docs.length; ++i) {
-    const arg = docs[i];
-    if (arg == null) {
-      return false;
-    }
-    const model = arg.constructor;
-    if (!(arg instanceof Document) ||
-      (model.modelName !== ref && model.baseModelName !== ref)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/*!
- * ignore
- */
-
-function _checkManualPopulation(arr, docs) {
-  const ref = get(arr, '_schema.caster.options.ref', null);
-  if (arr.length === 0 &&
-      docs.length > 0) {
-    if (_isAllSubdocs(docs, ref)) {
-      arr._parent.populated(arr._path, [], { model: docs[0].constructor });
-    }
-  }
 }
 
 /*!
@@ -85581,8 +86534,7 @@ function _checkManualPopulation(arr, docs) {
 
 module.exports = exports = MongooseArray;
 
-}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../document":259,"../helpers/document/cleanModifiedSubpaths":283,"../helpers/get":286,"../options":301,"../utils":337,"./embedded":332,"./objectid":335,"util":366}],329:[function(require,module,exports){
+},{"../document":258,"../helpers/symbols":300,"./core_array":341}],340:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -85641,48 +86593,22 @@ function MongooseBuffer(value, encode, offset) {
   buf.isMongooseBuffer = true;
 
   // make sure these internal props don't show up in Object.keys()
-  Object.defineProperties(buf, {
-    validators: {
-      value: [],
-      enumerable: false
-    },
-    _path: {
-      value: path,
-      enumerable: false
-    },
-    _parent: {
-      value: doc,
-      enumerable: false
-    }
-  });
-
-  if (doc && typeof path === 'string') {
-    Object.defineProperty(buf, '_schema', {
-      value: doc.schema.path(path)
-    });
-  }
+  buf[MongooseBuffer.pathSymbol] = path;
+  buf[parentSymbol] = doc;
 
   buf._subtype = 0;
   return buf;
 }
 
+const pathSymbol = Symbol.for('mongoose#Buffer#_path');
+const parentSymbol = Symbol.for('mongoose#Buffer#_parent');
+MongooseBuffer.pathSymbol = pathSymbol;
+
 /*!
  * Inherit from Buffer.
  */
 
-// MongooseBuffer.prototype = Buffer.alloc(0);
-
 MongooseBuffer.mixin = {
-
-  /**
-   * Parent owner document
-   *
-   * @api private
-   * @property _parent
-   * @receiver MongooseBuffer
-   */
-
-  _parent: undefined,
 
   /**
    * Default subtype for the Binary representing this Buffer
@@ -85703,10 +86629,10 @@ MongooseBuffer.mixin = {
    */
 
   _markModified: function() {
-    const parent = this._parent;
+    const parent = this[parentSymbol];
 
     if (parent) {
-      parent.markModified(this._path);
+      parent.markModified(this[MongooseBuffer.pathSymbol]);
     }
     return this;
   },
@@ -85804,7 +86730,7 @@ MongooseBuffer.mixin.toObject = function(options) {
   const subtype = typeof options === 'number'
     ? options
     : (this._subtype || 0);
-  return new Binary(this, subtype);
+  return new Binary(Buffer.from(this), subtype);
 };
 
 /**
@@ -85889,7 +86815,877 @@ MongooseBuffer.Binary = Binary;
 
 module.exports = MongooseBuffer;
 
-},{"../driver":261,"../utils":337,"safe-buffer":354}],330:[function(require,module,exports){
+},{"../driver":260,"../utils":349,"safe-buffer":352}],341:[function(require,module,exports){
+(function (Buffer){
+'use strict';
+
+const Document = require('../document');
+const EmbeddedDocument = require('./embedded');
+const ObjectId = require('./objectid');
+const cleanModifiedSubpaths = require('../helpers/document/cleanModifiedSubpaths');
+const get = require('../helpers/get');
+const internalToObjectOptions = require('../options').internalToObjectOptions;
+const utils = require('../utils');
+const util = require('util');
+
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
+
+const _basePush = Array.prototype.push;
+
+const validatorsSymbol = Symbol('mongoose#MongooseCoreArray#validators');
+
+/*!
+ * ignore
+ */
+
+class CoreMongooseArray extends Array {
+  get isMongooseArray() {
+    return true;
+  }
+
+  get validators() {
+    return this[validatorsSymbol];
+  }
+
+  set validators(v) {
+    this[validatorsSymbol] = v;
+  }
+
+  /**
+   * Depopulates stored atomic operation values as necessary for direct insertion to MongoDB.
+   *
+   * If no atomics exist, we return all array values after conversion.
+   *
+   * @return {Array}
+   * @method $__getAtomics
+   * @memberOf MongooseArray
+   * @instance
+   * @api private
+   */
+
+  $__getAtomics() {
+    const ret = [];
+    const keys = Object.keys(this[arrayAtomicsSymbol]);
+    let i = keys.length;
+
+    const opts = Object.assign({}, internalToObjectOptions, { _isNested: true });
+
+    if (i === 0) {
+      ret[0] = ['$set', this.toObject(opts)];
+      return ret;
+    }
+
+    while (i--) {
+      const op = keys[i];
+      let val = this[arrayAtomicsSymbol][op];
+
+      // the atomic values which are arrays are not MongooseArrays. we
+      // need to convert their elements as if they were MongooseArrays
+      // to handle populated arrays versus DocumentArrays properly.
+      if (utils.isMongooseObject(val)) {
+        val = val.toObject(opts);
+      } else if (Array.isArray(val)) {
+        val = this.toObject.call(val, opts);
+      } else if (val != null && Array.isArray(val.$each)) {
+        val.$each = this.toObject.call(val.$each, opts);
+      } else if (val != null && typeof val.valueOf === 'function') {
+        val = val.valueOf();
+      }
+
+      if (op === '$addToSet') {
+        val = {$each: val};
+      }
+
+      ret.push([op, val]);
+    }
+
+    return ret;
+  }
+
+  /*!
+   * ignore
+   */
+
+  $atomics() {
+    return this[arrayAtomicsSymbol];
+  }
+
+  /*!
+   * ignore
+   */
+
+  $parent() {
+    return this[arrayParentSymbol];
+  }
+
+  /*!
+   * ignore
+   */
+
+  $path() {
+    return this[arrayPathSymbol];
+  }
+
+  /**
+   * Atomically shifts the array at most one time per document `save()`.
+   *
+   * ####NOTE:
+   *
+   * _Calling this multiple times on an array before saving sends the same command as calling it once._
+   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
+   *
+   *      doc.array = [1,2,3];
+   *
+   *      var shifted = doc.array.$shift();
+   *      console.log(shifted); // 1
+   *      console.log(doc.array); // [2,3]
+   *
+   *      // no affect
+   *      shifted = doc.array.$shift();
+   *      console.log(doc.array); // [2,3]
+   *
+   *      doc.save(function (err) {
+   *        if (err) return handleError(err);
+   *
+   *        // we saved, now $shift works again
+   *        shifted = doc.array.$shift();
+   *        console.log(shifted ); // 2
+   *        console.log(doc.array); // [3]
+   *      })
+   *
+   * @api public
+   * @memberOf MongooseArray
+   * @instance
+   * @method $shift
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
+   */
+
+  $shift() {
+    this._registerAtomic('$pop', -1);
+    this._markModified();
+
+    // only allow shifting once
+    if (this._shifted) {
+      return;
+    }
+    this._shifted = true;
+
+    return [].shift.call(this);
+  }
+
+  /**
+   * Pops the array atomically at most one time per document `save()`.
+   *
+   * #### NOTE:
+   *
+   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
+   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
+   *
+   *      doc.array = [1,2,3];
+   *
+   *      var popped = doc.array.$pop();
+   *      console.log(popped); // 3
+   *      console.log(doc.array); // [1,2]
+   *
+   *      // no affect
+   *      popped = doc.array.$pop();
+   *      console.log(doc.array); // [1,2]
+   *
+   *      doc.save(function (err) {
+   *        if (err) return handleError(err);
+   *
+   *        // we saved, now $pop works again
+   *        popped = doc.array.$pop();
+   *        console.log(popped); // 2
+   *        console.log(doc.array); // [1]
+   *      })
+   *
+   * @api public
+   * @method $pop
+   * @memberOf MongooseArray
+   * @instance
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
+   * @method $pop
+   * @memberOf MongooseArray
+   */
+
+  $pop() {
+    this._registerAtomic('$pop', 1);
+    this._markModified();
+
+    // only allow popping once
+    if (this._popped) {
+      return;
+    }
+    this._popped = true;
+
+    return [].pop.call(this);
+  }
+
+  /*!
+   * ignore
+   */
+
+  $schema() {
+    return this[arraySchemaSymbol];
+  }
+
+  /**
+   * Casts a member based on this arrays schema.
+   *
+   * @param {any} value
+   * @return value the casted value
+   * @method _cast
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _cast(value) {
+    let populated = false;
+    let Model;
+
+    if (this[arrayParentSymbol]) {
+      populated = this[arrayParentSymbol].populated(this[arrayPathSymbol], true);
+    }
+
+    if (populated && value !== null && value !== undefined) {
+      // cast to the populated Models schema
+      Model = populated.options[populateModelSymbol];
+
+      // only objects are permitted so we can safely assume that
+      // non-objects are to be interpreted as _id
+      if (Buffer.isBuffer(value) ||
+          value instanceof ObjectId || !utils.isObject(value)) {
+        value = {_id: value};
+      }
+
+      // gh-2399
+      // we should cast model only when it's not a discriminator
+      const isDisc = value.schema && value.schema.discriminatorMapping &&
+          value.schema.discriminatorMapping.key !== undefined;
+      if (!isDisc) {
+        value = new Model(value);
+      }
+      return this[arraySchemaSymbol].caster.applySetters(value, this[arrayParentSymbol], true);
+    }
+
+    return this[arraySchemaSymbol].caster.applySetters(value, this[arrayParentSymbol], false);
+  }
+
+  /**
+   * Internal helper for .map()
+   *
+   * @api private
+   * @return {Number}
+   * @method _mapCast
+   * @memberOf MongooseArray
+   */
+
+  _mapCast(val, index) {
+    return this._cast(val, this.length + index);
+  }
+
+  /**
+   * Marks this array as modified.
+   *
+   * If it bubbles up from an embedded document change, then it takes the following arguments (otherwise, takes 0 arguments)
+   *
+   * @param {EmbeddedDocument} embeddedDoc the embedded doc that invoked this method on the Array
+   * @param {String} embeddedPath the path which changed in the embeddedDoc
+   * @method _markModified
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _markModified(elem, embeddedPath) {
+    const parent = this[arrayParentSymbol];
+    let dirtyPath;
+
+    if (parent) {
+      dirtyPath = this[arrayPathSymbol];
+
+      if (arguments.length) {
+        if (embeddedPath != null) {
+          // an embedded doc bubbled up the change
+          dirtyPath = dirtyPath + '.' + this.indexOf(elem) + '.' + embeddedPath;
+        } else {
+          // directly set an index
+          dirtyPath = dirtyPath + '.' + elem;
+        }
+      }
+
+      parent.markModified(dirtyPath, arguments.length > 0 ? elem : parent);
+    }
+
+    return this;
+  }
+
+  /**
+   * Register an atomic operation with the parent.
+   *
+   * @param {Array} op operation
+   * @param {any} val
+   * @method _registerAtomic
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _registerAtomic(op, val) {
+    if (op === '$set') {
+      // $set takes precedence over all other ops.
+      // mark entire array modified.
+      this[arrayAtomicsSymbol] = {$set: val};
+      cleanModifiedSubpaths(this[arrayParentSymbol], this[arrayPathSymbol]);
+      this._markModified();
+      return this;
+    }
+
+    const atomics = this[arrayAtomicsSymbol];
+
+    // reset pop/shift after save
+    if (op === '$pop' && !('$pop' in atomics)) {
+      const _this = this;
+      this[arrayParentSymbol].once('save', function() {
+        _this._popped = _this._shifted = null;
+      });
+    }
+
+    // check for impossible $atomic combos (Mongo denies more than one
+    // $atomic op on a single path
+    if (this[arrayAtomicsSymbol].$set ||
+        Object.keys(atomics).length && !(op in atomics)) {
+      // a different op was previously registered.
+      // save the entire thing.
+      this[arrayAtomicsSymbol] = {$set: this};
+      return this;
+    }
+
+    let selector;
+
+    if (op === '$pullAll' || op === '$addToSet') {
+      atomics[op] || (atomics[op] = []);
+      atomics[op] = atomics[op].concat(val);
+    } else if (op === '$pullDocs') {
+      const pullOp = atomics['$pull'] || (atomics['$pull'] = {});
+      if (val[0] instanceof EmbeddedDocument) {
+        selector = pullOp['$or'] || (pullOp['$or'] = []);
+        Array.prototype.push.apply(selector, val.map(function(v) {
+          return v.toObject({transform: false, virtuals: false});
+        }));
+      } else {
+        selector = pullOp['_id'] || (pullOp['_id'] = {$in: []});
+        selector['$in'] = selector['$in'].concat(val);
+      }
+    } else if (op === '$push') {
+      atomics.$push = atomics.$push || { $each: [] };
+      atomics.$push.$each = atomics.$push.$each.concat(val);
+    } else {
+      atomics[op] = val;
+    }
+
+    return this;
+  }
+
+  /**
+   * Adds values to the array if not already present.
+   *
+   * ####Example:
+   *
+   *     console.log(doc.array) // [2,3,4]
+   *     var added = doc.array.addToSet(4,5);
+   *     console.log(doc.array) // [2,3,4,5]
+   *     console.log(added)     // [5]
+   *
+   * @param {any} [args...]
+   * @return {Array} the values that were added
+   * @memberOf MongooseArray
+   * @api public
+   * @method addToSet
+   */
+
+  addToSet() {
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._mapCast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
+    const added = [];
+    let type = '';
+    if (values[0] instanceof EmbeddedDocument) {
+      type = 'doc';
+    } else if (values[0] instanceof Date) {
+      type = 'date';
+    }
+
+    values.forEach(function(v) {
+      let found;
+      const val = +v;
+      switch (type) {
+        case 'doc':
+          found = this.some(function(doc) {
+            return doc.equals(v);
+          });
+          break;
+        case 'date':
+          found = this.some(function(d) {
+            return +d === val;
+          });
+          break;
+        default:
+          found = ~this.indexOf(v);
+      }
+
+      if (!found) {
+        [].push.call(this, v);
+        this._registerAtomic('$addToSet', v);
+        this._markModified();
+        [].push.call(added, v);
+      }
+    }, this);
+
+    return added;
+  }
+
+  /**
+   * Returns the number of pending atomic operations to send to the db for this array.
+   *
+   * @api private
+   * @return {Number}
+   * @method hasAtomics
+   * @memberOf MongooseArray
+   */
+
+  hasAtomics() {
+    if (!utils.isPOJO(this[arrayAtomicsSymbol])) {
+      return 0;
+    }
+
+    return Object.keys(this[arrayAtomicsSymbol]).length;
+  }
+
+  /**
+   * Return whether or not the `obj` is included in the array.
+   *
+   * @param {Object} obj the item to check
+   * @return {Boolean}
+   * @api public
+   * @method includes
+   * @memberOf MongooseArray
+   */
+
+  includes(obj, fromIndex) {
+    const ret = this.indexOf(obj, fromIndex);
+    return ret !== -1;
+  }
+
+  /**
+   * Return the index of `obj` or `-1` if not found.
+   *
+   * @param {Object} obj the item to look for
+   * @return {Number}
+   * @api public
+   * @method indexOf
+   * @memberOf MongooseArray
+   */
+
+  indexOf(obj, fromIndex) {
+    if (obj instanceof ObjectId) {
+      obj = obj.toString();
+    }
+
+    fromIndex = fromIndex == null ? 0 : fromIndex;
+    const len = this.length;
+    for (let i = fromIndex; i < len; ++i) {
+      if (obj == this[i]) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Helper for console.log
+   *
+   * @api public
+   * @method inspect
+   * @memberOf MongooseArray
+   */
+
+  inspect() {
+    return JSON.stringify(this);
+  }
+
+  /**
+   * Pushes items to the array non-atomically.
+   *
+   * ####NOTE:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @param {any} [args...]
+   * @api public
+   * @method nonAtomicPush
+   * @memberOf MongooseArray
+   */
+
+  nonAtomicPush() {
+    const values = [].map.call(arguments, this._mapCast, this);
+    const ret = [].push.apply(this, values);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#pop`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/pop) with proper change tracking.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified which will pass the entire thing to $set potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @see MongooseArray#$pop #types_array_MongooseArray-%24pop
+   * @api public
+   * @method pop
+   * @memberOf MongooseArray
+   */
+
+  pop() {
+    const ret = [].pop.call(this);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Pulls items from the array atomically. Equality is determined by casting
+   * the provided value to an embedded document and comparing using
+   * [the `Document.equals()` function.](./api.html#document_Document-equals)
+   *
+   * ####Examples:
+   *
+   *     doc.array.pull(ObjectId)
+   *     doc.array.pull({ _id: 'someId' })
+   *     doc.array.pull(36)
+   *     doc.array.pull('tag 1', 'tag 2')
+   *
+   * To remove a document from a subdocument array we may pass an object with a matching `_id`.
+   *
+   *     doc.subdocs.push({ _id: 4815162342 })
+   *     doc.subdocs.pull({ _id: 4815162342 }) // removed
+   *
+   * Or we may passing the _id directly and let mongoose take care of it.
+   *
+   *     doc.subdocs.push({ _id: 4815162342 })
+   *     doc.subdocs.pull(4815162342); // works
+   *
+   * The first pull call will result in a atomic operation on the database, if pull is called repeatedly without saving the document, a $set operation is used on the complete array instead, overwriting possible changes that happened on the database in the meantime.
+   *
+   * @param {any} [args...]
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
+   * @api public
+   * @method pull
+   * @memberOf MongooseArray
+   */
+
+  pull() {
+    const values = [].map.call(arguments, this._cast, this);
+    const cur = this[arrayParentSymbol].get(this[arrayPathSymbol]);
+    let i = cur.length;
+    let mem;
+
+    while (i--) {
+      mem = cur[i];
+      if (mem instanceof Document) {
+        const some = values.some(function(v) {
+          return mem.equals(v);
+        });
+        if (some) {
+          [].splice.call(cur, i, 1);
+        }
+      } else if (~cur.indexOf.call(values, mem)) {
+        [].splice.call(cur, i, 1);
+      }
+    }
+
+    if (values[0] instanceof EmbeddedDocument) {
+      this._registerAtomic('$pullDocs', values.map(function(v) {
+        return v._id || v;
+      }));
+    } else {
+      this._registerAtomic('$pullAll', values);
+    }
+
+    this._markModified();
+
+    // Might have modified child paths and then pulled, like
+    // `doc.children[1].name = 'test';` followed by
+    // `doc.children.remove(doc.children[0]);`. In this case we fall back
+    // to a `$set` on the whole array. See #3511
+    if (cleanModifiedSubpaths(this[arrayParentSymbol], this[arrayPathSymbol]) > 0) {
+      this._registerAtomic('$set', this);
+    }
+
+    return this;
+  }
+
+  /**
+   * Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking.
+   *
+   * @param {Object} [args...]
+   * @api public
+   * @method push
+   * @memberOf MongooseArray
+   */
+
+  push() {
+    if (this[arraySchemaSymbol] == null) {
+      return _basePush.apply(this, arguments);
+    }
+
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._mapCast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol], undefined,
+      undefined, { skipDocumentArrayCast: true });
+    const ret = [].push.apply(this, values);
+
+    this._registerAtomic('$push', values);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Alias of [pull](#types_array_MongooseArray-pull)
+   *
+   * @see MongooseArray#pull #types_array_MongooseArray-pull
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
+   * @api public
+   * @memberOf MongooseArray
+   * @instance
+   * @method remove
+   */
+
+  remove() {
+    return this.pull.apply(this, arguments);
+  }
+
+  /**
+   * Sets the casted `val` at index `i` and marks the array modified.
+   *
+   * ####Example:
+   *
+   *     // given documents based on the following
+   *     var Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
+   *
+   *     var doc = new Doc({ array: [2,3,4] })
+   *
+   *     console.log(doc.array) // [2,3,4]
+   *
+   *     doc.array.set(1,"5");
+   *     console.log(doc.array); // [2,5,4] // properly cast to number
+   *     doc.save() // the change is saved
+   *
+   *     // VS not using array#set
+   *     doc.array[1] = "5";
+   *     console.log(doc.array); // [2,"5",4] // no casting
+   *     doc.save() // change is not saved
+   *
+   * @return {Array} this
+   * @api public
+   * @method set
+   * @memberOf MongooseArray
+   */
+
+  set(i, val) {
+    const value = this._cast(val, i);
+    this[i] = value;
+    this._markModified(i);
+    return this;
+  }
+
+  /**
+   * Wraps [`Array#shift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
+   *
+   * ####Example:
+   *
+   *     doc.array = [2,3];
+   *     var res = doc.array.shift();
+   *     console.log(res) // 2
+   *     console.log(doc.array) // [3]
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method shift
+   * @memberOf MongooseArray
+   */
+
+  shift() {
+    const ret = [].shift.call(this);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#sort`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort) with proper change tracking.
+   *
+   * ####NOTE:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method sort
+   * @memberOf MongooseArray
+   */
+
+  sort() {
+    const ret = [].sort.apply(this, arguments);
+    this._registerAtomic('$set', this);
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#splice`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/splice) with proper change tracking and casting.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method splice
+   * @memberOf MongooseArray
+   */
+
+  splice() {
+    let ret;
+
+    _checkManualPopulation(this, Array.prototype.slice.call(arguments, 2));
+
+    if (arguments.length) {
+      const vals = [];
+      for (let i = 0; i < arguments.length; ++i) {
+        vals[i] = i < 2 ?
+          arguments[i] :
+          this._cast(arguments[i], arguments[0] + (i - 2));
+      }
+      ret = [].splice.apply(this, vals);
+      this._registerAtomic('$set', this);
+    }
+
+    return ret;
+  }
+
+  /*!
+   * ignore
+   */
+
+  toBSON() {
+    return this.toObject(internalToObjectOptions);
+  }
+
+  /**
+   * Returns a native js Array.
+   *
+   * @param {Object} options
+   * @return {Array}
+   * @api public
+   * @method toObject
+   * @memberOf MongooseArray
+   */
+
+  toObject(options) {
+    if (options && options.depopulate) {
+      options = utils.clone(options);
+      options._isNested = true;
+      return this.map(function(doc) {
+        return doc instanceof Document
+          ? doc.toObject(options)
+          : doc;
+      });
+    }
+
+    return this.slice();
+  }
+
+  /**
+   * Wraps [`Array#unshift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method unshift
+   * @memberOf MongooseArray
+   */
+
+  unshift() {
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._cast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
+    [].unshift.apply(this, values);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return this.length;
+  }
+}
+
+if (util.inspect.custom) {
+  CoreMongooseArray.prototype[util.inspect.custom] =
+    CoreMongooseArray.prototype.inspect;
+}
+
+/*!
+ * ignore
+ */
+
+function _isAllSubdocs(docs, ref) {
+  if (!ref) {
+    return false;
+  }
+  for (let i = 0; i < docs.length; ++i) {
+    const arg = docs[i];
+    if (arg == null) {
+      return false;
+    }
+    const model = arg.constructor;
+    if (!(arg instanceof Document) ||
+      (model.modelName !== ref && model.baseModelName !== ref)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*!
+ * ignore
+ */
+
+function _checkManualPopulation(arr, docs) {
+  const ref = arr == null ?
+    null :
+    get(arr[arraySchemaSymbol], 'caster.options.ref', null);
+  if (arr.length === 0 &&
+      docs.length > 0) {
+    if (_isAllSubdocs(docs, ref)) {
+      arr[arrayParentSymbol].populated(arr[arrayPathSymbol], [], {
+        [populateModelSymbol]: docs[0].constructor
+      });
+    }
+  }
+}
+
+module.exports = CoreMongooseArray;
+}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
+},{"../../../is-buffer/index.js":245,"../document":258,"../helpers/document/cleanModifiedSubpaths":284,"../helpers/get":287,"../helpers/symbols":300,"../options":304,"../utils":349,"./embedded":344,"./objectid":347,"util":381}],342:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -85904,7 +87700,7 @@ module.exports = MongooseBuffer;
 
 module.exports = require('../driver').get().Decimal128;
 
-},{"../driver":261}],331:[function(require,module,exports){
+},{"../driver":260}],343:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -85912,136 +87708,35 @@ module.exports = require('../driver').get().Decimal128;
  * Module dependencies.
  */
 
+const CoreMongooseArray = require('./core_array');
 const Document = require('../document');
-const MongooseArray = require('./array');
 const ObjectId = require('./objectid');
 const castObjectId = require('../cast/objectid');
-const get = require('../helpers/get');
 const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 const internalToObjectOptions = require('../options').internalToObjectOptions;
 const util = require('util');
 const utils = require('../utils');
 
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
 const documentArrayParent = require('../helpers/symbols').documentArrayParent;
 
-/*!
- * ignore
- */
+const _basePush = Array.prototype.push;
 
-class CoreMongooseArray extends Array {
-  get isMongooseArray() {
+class CoreDocumentArray extends CoreMongooseArray {
+  get isMongooseDocumentArray() {
     return true;
   }
 
-  remove() {}
-}
-
-/**
- * DocumentArray constructor
- *
- * @param {Array} values
- * @param {String} path the path to this array
- * @param {Document} doc parent document
- * @api private
- * @return {MongooseDocumentArray}
- * @inherits MongooseArray
- * @see http://bit.ly/f6CnZU
- */
-
-function MongooseDocumentArray(values, path, doc) {
-  // TODO: replace this with `new CoreMongooseArray().concat()` when we remove
-  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
-  const arr = new CoreMongooseArray();
-
-  const props = {
-    isMongooseDocumentArray: true,
-    validators: [],
-    _atomics: {},
-    _schema: void 0,
-    _handlers: void 0
-  };
-
-  if (Array.isArray(values)) {
-    if (values instanceof CoreMongooseArray &&
-        values._path === path &&
-        values._parent === doc) {
-      props._atomics = Object.assign({}, values._atomics);
-    }
-    values.forEach(v => {
-      arr.push(v);
-    });
-  }
-  arr._path = path;
-
-  // Values always have to be passed to the constructor to initialize, since
-  // otherwise MongooseArray#push will mark the array as modified to the parent.
-  const keysMA = Object.keys(MongooseArray.mixin);
-  let numKeys = keysMA.length;
-  for (let j = 0; j < numKeys; ++j) {
-    arr[keysMA[j]] = MongooseArray.mixin[keysMA[j]];
-  }
-
-  const keysMDA = Object.keys(MongooseDocumentArray.mixin);
-  numKeys = keysMDA.length;
-  for (let i = 0; i < numKeys; ++i) {
-    arr[keysMDA[i]] = MongooseDocumentArray.mixin[keysMDA[i]];
-  }
-  if (util.inspect.custom) {
-    props[util.inspect.custom] = arr.inspect;
-  }
-
-  const keysP = Object.keys(props);
-  numKeys = keysP.length;
-  for (let k = 0; k < numKeys; ++k) {
-    arr[keysP[k]] = props[keysP[k]];
-  }
-
-  // Because doc comes from the context of another function, doc === global
-  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
-  // RB Jun 17, 2015 updated to check for presence of expected paths instead
-  // to make more proof against unusual node environments
-  if (doc && doc instanceof Document) {
-    arr._parent = doc;
-    arr._schema = doc.schema.path(path);
-
-    // `schema.path()` doesn't drill into nested arrays properly yet, see
-    // gh-6398, gh-6602. This is a workaround because nested arrays are
-    // always plain non-document arrays, so once you get to a document array
-    // nesting is done. Matryoshka code.
-    while (get(arr, '_schema.$isMongooseArray') &&
-        !get(arr, '_schema.$isMongooseDocumentArray')) {
-      arr._schema = arr._schema.casterConstructor;
-    }
-
-    // Tricky but this may be a document array embedded in a normal array,
-    // in which case `path` would point to the embedded array. See #6405, #6398
-    if (arr._schema && !arr._schema.$isMongooseDocumentArray) {
-      arr._schema = arr._schema.casterConstructor;
-    }
-
-    arr._handlers = {
-      isNew: arr.notify('isNew'),
-      save: arr.notify('save')
-    };
-
-    doc.on('save', arr._handlers.save);
-    doc.on('isNew', arr._handlers.isNew);
-  }
-
-  return arr;
-}
-
-/*!
- * Inherits from MongooseArray
- */
-
-MongooseDocumentArray.mixin = {
   /*!
    * ignore
    */
-  toBSON: function() {
+
+  toBSON() {
     return this.toObject(internalToObjectOptions);
-  },
+  }
 
   /**
    * Overrides MongooseArray#cast
@@ -86051,8 +87746,8 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  _cast: function(value, index) {
-    let Constructor = this._schema.casterConstructor;
+  _cast(value, index) {
+    let Constructor = this[arraySchemaSymbol].casterConstructor;
     const isInstance = Constructor.$isMongooseDocumentArray ?
       value && value.isMongooseDocumentArray :
       value instanceof Constructor;
@@ -86061,7 +87756,7 @@ MongooseDocumentArray.mixin = {
         (value && value.constructor && value.constructor.baseCasterConstructor === Constructor)) {
       if (!(value[documentArrayParent] && value.__parentArray)) {
         // value may have been created using array.create()
-        value[documentArrayParent] = this._parent;
+        value[documentArrayParent] = this[arrayParentSymbol];
         value.__parentArray = this;
       }
       value.$setIndex(index);
@@ -86100,7 +87795,7 @@ MongooseDocumentArray.mixin = {
       return Constructor.cast(value, this, undefined, undefined, index);
     }
     return new Constructor(value, this, undefined, undefined, index);
-  },
+  }
 
   /**
    * Searches array items for the first document with a matching _id.
@@ -86117,7 +87812,7 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  id: function(id) {
+  id(id) {
     let casted;
     let sid;
     let _id;
@@ -86151,7 +87846,7 @@ MongooseDocumentArray.mixin = {
     }
 
     return null;
-  },
+  }
 
   /**
    * Returns a native js Array of plain js objects
@@ -86167,15 +87862,19 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  toObject: function(options) {
-    return this.map(function(doc) {
-      try {
-        return doc.toObject(options);
-      } catch (e) {
-        return doc || null;
+  toObject(options) {
+    // `[].concat` coerces the return value into a vanilla JS array, rather
+    // than a Mongoose array.
+    return [].concat(this.map(function(doc) {
+      if (doc == null) {
+        return null;
       }
-    });
-  },
+      if (typeof doc.toObject !== 'function') {
+        return doc;
+      }
+      return doc.toObject(options);
+    }));
+  }
 
   /**
    * Helper for console.log
@@ -86185,9 +87884,9 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  inspect: function() {
+  inspect() {
     return this.toObject();
-  },
+  }
 
   /**
    * Creates a subdocument casted to this schema.
@@ -86200,8 +87899,8 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  create: function(obj) {
-    let Constructor = this._schema.casterConstructor;
+  create(obj) {
+    let Constructor = this[arraySchemaSymbol].casterConstructor;
     if (obj &&
         Constructor.discriminators &&
         Constructor.schema &&
@@ -86219,19 +87918,13 @@ MongooseDocumentArray.mixin = {
     }
 
     return new Constructor(obj, this);
-  },
+  }
 
-  /**
-   * Creates a fn that notifies all child docs of `event`.
-   *
-   * @param {String} event
-   * @return {Function}
-   * @method notify
-   * @api private
-   * @receiver MongooseDocumentArray
+  /*!
+   * ignore
    */
 
-  notify: function notify(event) {
+  notify(event) {
     const _this = this;
     return function notify(val, _arr) {
       _arr = _arr || _this;
@@ -86258,8 +87951,72 @@ MongooseDocumentArray.mixin = {
       }
     };
   }
+}
 
-};
+if (util.inspect.custom) {
+  CoreDocumentArray.prototype[util.inspect.custom] =
+    CoreDocumentArray.prototype.inspect;
+}
+
+/**
+ * DocumentArray constructor
+ *
+ * @param {Array} values
+ * @param {String} path the path to this array
+ * @param {Document} doc parent document
+ * @api private
+ * @return {MongooseDocumentArray}
+ * @inherits MongooseArray
+ * @see http://bit.ly/f6CnZU
+ */
+
+function MongooseDocumentArray(values, path, doc) {
+  // TODO: replace this with `new CoreDocumentArray().concat()` when we remove
+  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
+  const arr = new CoreDocumentArray();
+
+  arr[arrayAtomicsSymbol] = {};
+  arr[arraySchemaSymbol] = void 0;
+  if (Array.isArray(values)) {
+    if (values instanceof CoreDocumentArray &&
+        values[arrayPathSymbol] === path &&
+        values[arrayParentSymbol] === doc) {
+      arr[arrayAtomicsSymbol] = Object.assign({}, values[arrayAtomicsSymbol]);
+    }
+    values.forEach(v => {
+      _basePush.call(arr, v);
+    });
+  }
+  arr[arrayPathSymbol] = path;
+
+  // Because doc comes from the context of another function, doc === global
+  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
+  // RB Jun 17, 2015 updated to check for presence of expected paths instead
+  // to make more proof against unusual node environments
+  if (doc && doc instanceof Document) {
+    arr[arrayParentSymbol] = doc;
+    arr[arraySchemaSymbol] = doc.schema.path(path);
+
+    // `schema.path()` doesn't drill into nested arrays properly yet, see
+    // gh-6398, gh-6602. This is a workaround because nested arrays are
+    // always plain non-document arrays, so once you get to a document array
+    // nesting is done. Matryoshka code.
+    while (arr != null &&
+        arr[arraySchemaSymbol] != null &&
+        arr[arraySchemaSymbol].$isMongooseArray &&
+        !arr[arraySchemaSymbol].$isMongooseDocumentArray) {
+      arr[arraySchemaSymbol] = arr[arraySchemaSymbol].casterConstructor;
+    }
+
+    // Tricky but this may be a document array embedded in a normal array,
+    // in which case `path` would point to the embedded array. See #6405, #6398
+    if (arr[arraySchemaSymbol] && !arr[arraySchemaSymbol].$isMongooseDocumentArray) {
+      arr[arraySchemaSymbol] = arr[arraySchemaSymbol].casterConstructor;
+    }
+  }
+
+  return arr;
+}
 
 /*!
  * Module exports.
@@ -86268,7 +88025,7 @@ MongooseDocumentArray.mixin = {
 module.exports = MongooseDocumentArray;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":246,"../cast/objectid":257,"../document":259,"../helpers/get":286,"../helpers/symbols":297,"../options":301,"../queryhelpers":304,"../utils":337,"./array":328,"./objectid":335,"util":366}],332:[function(require,module,exports){
+},{"../../../is-buffer/index.js":245,"../cast/objectid":256,"../document":258,"../helpers/symbols":300,"../options":304,"../queryhelpers":315,"../utils":349,"./core_array":341,"./objectid":347,"util":381}],344:[function(require,module,exports){
 /* eslint no-func-assign: 1 */
 
 /*!
@@ -86301,7 +88058,7 @@ const validatorErrorSymbol = require('../helpers/symbols').validatorErrorSymbol;
 function EmbeddedDocument(obj, parentArr, skipId, fields, index) {
   if (parentArr) {
     this.__parentArray = parentArr;
-    this[documentArrayParent] = parentArr._parent;
+    this[documentArrayParent] = parentArr.$parent();
   } else {
     this.__parentArray = undefined;
     this[documentArrayParent] = undefined;
@@ -86556,7 +88313,7 @@ EmbeddedDocument.prototype.invalidate = function(path, err, val) {
   }
 
   const index = this.__index;
-  const parentPath = this.__parentArray._path;
+  const parentPath = this.__parentArray.$path();
   const fullPath = [parentPath, index, path].join('.');
   this[documentArrayParent].invalidate(fullPath, err, val);
 
@@ -86579,7 +88336,7 @@ EmbeddedDocument.prototype.$markValid = function(path) {
 
   const index = this.__index;
   if (typeof index !== 'undefined') {
-    const parentPath = this.__parentArray._path;
+    const parentPath = this.__parentArray.$path();
     const fullPath = [parentPath, index, path].join('.');
     this[documentArrayParent].$markValid(fullPath);
   }
@@ -86598,7 +88355,7 @@ EmbeddedDocument.prototype.$ignore = function(path) {
 
   const index = this.__index;
   if (typeof index !== 'undefined') {
-    const parentPath = this.__parentArray._path;
+    const parentPath = this.__parentArray.$path();
     const fullPath = [parentPath, index, path].join('.');
     this[documentArrayParent].$ignore(fullPath);
   }
@@ -86668,7 +88425,7 @@ EmbeddedDocument.prototype.$__fullPath = function(path) {
     const paths = [];
     while (parent[documentArrayParent] || parent.$parent) {
       if (parent[documentArrayParent]) {
-        paths.unshift(parent.__parentArray._path);
+        paths.unshift(parent.__parentArray.$path());
       } else {
         paths.unshift(parent.$basePath);
       }
@@ -86714,7 +88471,7 @@ EmbeddedDocument.prototype.parentArray = function() {
 
 module.exports = EmbeddedDocument;
 
-},{"../document_provider":260,"../helpers/get":286,"../helpers/immediate":287,"../helpers/symbols":297,"../options":301,"../utils":337,"events":243,"util":366}],333:[function(require,module,exports){
+},{"../document_provider":259,"../helpers/get":287,"../helpers/immediate":288,"../helpers/symbols":300,"../options":304,"../utils":349,"events":243,"util":381}],345:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -86736,12 +88493,15 @@ exports.Map = require('./map');
 
 exports.Subdocument = require('./subdocument');
 
-},{"./array":328,"./buffer":329,"./decimal128":330,"./documentarray":331,"./embedded":332,"./map":334,"./objectid":335,"./subdocument":336}],334:[function(require,module,exports){
+},{"./array":339,"./buffer":340,"./decimal128":342,"./documentarray":343,"./embedded":344,"./map":346,"./objectid":347,"./subdocument":348}],346:[function(require,module,exports){
 'use strict';
 
 const Mixed = require('../schema/mixed');
 const get = require('../helpers/get');
 const util = require('util');
+const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 /*!
  * ignore
@@ -86795,7 +88555,7 @@ class MongooseMap extends Map {
 
     if (populated != null) {
       if (value.$__ == null) {
-        value = new populated.options.model(value);
+        value = new populated.options[populateModelSymbol](value);
       }
       value.$__.wasPopulated = true;
     } else {
@@ -86820,6 +88580,11 @@ class MongooseMap extends Map {
     if (this.$__parent != null && this.$__parent.$__) {
       this.$__parent.markModified(this.$__path + '.' + key);
     }
+  }
+
+  delete(key) {
+    this.set(key, undefined);
+    super.delete(key);
   }
 
   toBSON() {
@@ -86926,11 +88691,14 @@ function checkValidKey(key) {
   if (key.includes('.')) {
     throw new Error(`Mongoose maps do not support keys that contain ".", got "${key}"`);
   }
+  if (utils.specialProperties.has(key)) {
+    throw new Error(`Mongoose maps do not support reserved key name "${key}"`);
+  }
 }
 
 module.exports = MongooseMap;
 
-},{"../helpers/get":286,"../schema/mixed":315,"util":366}],335:[function(require,module,exports){
+},{"../helpers/get":287,"../helpers/symbols":300,"../schema/mixed":326,"../utils":349,"util":381}],347:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -86962,7 +88730,7 @@ ObjectId.prototype[objectIdSymbol] = true;
 
 module.exports = ObjectId;
 
-},{"../driver":261,"../helpers/symbols":297}],336:[function(require,module,exports){
+},{"../driver":260,"../helpers/symbols":300}],348:[function(require,module,exports){
 'use strict';
 
 const Document = require('../document');
@@ -86983,13 +88751,30 @@ module.exports = Subdocument;
 
 function Subdocument(value, fields, parent, skipId, options) {
   this.$isSingleNested = true;
+
+  const hasPriorDoc = options != null && options.priorDoc;
+  let initedPaths = null;
+  if (hasPriorDoc) {
+    this._doc = Object.assign({}, options.priorDoc._doc);
+    delete this._doc[this.schema.options.discriminatorKey];
+    initedPaths = Object.keys(options.priorDoc._doc || {}).
+      filter(key => key !== this.schema.options.discriminatorKey);
+  }
   if (parent != null) {
     // If setting a nested path, should copy isNew from parent re: gh-7048
     options = Object.assign({}, options, { isNew: parent.isNew });
   }
   Document.call(this, value, fields, skipId, options);
 
-  delete this.$__.$options.priorDoc;
+  if (hasPriorDoc) {
+    for (const key of initedPaths) {
+      if (!this.$__.activePaths.states.modify[key] &&
+          !this.$__.activePaths.states.default[key] &&
+          !this.$__.$setCalled.has(key)) {
+        delete this._doc[key];
+      }
+    }
+  }
 }
 
 Subdocument.prototype = Object.create(Document.prototype);
@@ -87062,6 +88847,25 @@ Subdocument.prototype.markModified = function(path) {
     this.$parent.markModified([this.$basePath, path].join('.'), this);
   }
 };
+
+Subdocument.prototype.isModified = function(paths, modifiedPaths) {
+  if (this.$parent && this.$basePath) {
+    paths = (Array.isArray(paths) ? paths : paths.split(' ')).
+      map(p => [this.$basePath, p].join('.'));
+    return this.$parent.isModified(paths, modifiedPaths);
+  }
+
+  return Document.prototype.isModified(paths, modifiedPaths);
+};
+
+/**
+ * Marks a path as valid, removing existing validation errors.
+ *
+ * @param {String} path the field to mark as valid
+ * @api private
+ * @method $markValid
+ * @receiver Subdocument
+ */
 
 Subdocument.prototype.$markValid = function(path) {
   Document.prototype.$markValid.call(this, path);
@@ -87181,7 +88985,7 @@ Subdocument.prototype.populate = function() {
  * Registers remove event listeners for triggering
  * on subdocuments.
  *
- * @param {EmbeddedDocument} sub
+ * @param {Subdocument} sub
  * @api private
  */
 
@@ -87200,7 +89004,7 @@ function registerRemoveListener(sub) {
   owner.on('remove', emitRemove);
 }
 
-},{"../document":259,"../helpers/immediate":287,"../helpers/symbols":297,"../options":301,"../utils":337}],337:[function(require,module,exports){
+},{"../document":258,"../helpers/immediate":288,"../helpers/symbols":300,"../options":304,"../utils":349}],349:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -87210,12 +89014,14 @@ function registerRemoveListener(sub) {
 
 const Decimal = require('./types/decimal128');
 const ObjectId = require('./types/objectid');
+const PopulateOptions = require('./options/PopulateOptions');
 const PromiseProvider = require('./promise_provider');
 const cloneRegExp = require('regexp-clone');
 const get = require('./helpers/get');
 const sliced = require('sliced');
 const mpath = require('mpath');
 const ms = require('ms');
+const symbols = require('./helpers/symbols');
 const Buffer = require('safe-buffer').Buffer;
 
 const emittedSymbol = Symbol.for('mongoose:emitted');
@@ -87430,7 +89236,11 @@ exports.clone = function clone(obj, options, isArrayChild) {
     return cloneObject(obj, options, isArrayChild);
   }
 
-  if (obj.valueOf) {
+  if (obj[symbols.schemaTypeSymbol]) {
+    return obj.clone();
+  }
+
+  if (obj.valueOf != null) {
     return obj.valueOf();
   }
 
@@ -87480,6 +89290,25 @@ exports.promiseOrCallback = function promiseOrCallback(callback, fn, ee) {
       resolve(res);
     });
   });
+};
+
+/*!
+ * ignore
+ */
+
+exports.omit = function omit(obj, keys) {
+  if (keys == null) {
+    return Object.assign({}, obj);
+  }
+  if (!Array.isArray(keys)) {
+    keys = [keys];
+  }
+
+  const ret = Object.assign({}, obj);
+  for (const key of keys) {
+    delete ret[key];
+  }
+  return ret;
 };
 
 /*!
@@ -87590,7 +89419,11 @@ exports.merge = function merge(to, from, options, path) {
       }
       if (from[key] != null) {
         if (from[key].instanceOfSchema) {
-          to[key] = from[key].clone();
+          if (to[key].instanceOfSchema) {
+            to[key].add(from[key].clone());
+          } else {
+            to[key] = from[key].clone();
+          }
           continue;
         } else if (from[key] instanceof ObjectId) {
           to[key] = new ObjectId(from[key]);
@@ -87677,7 +89510,7 @@ exports.isObject = function(arg) {
  * @return {Boolean}
  */
 
-exports.isPOJO = function(arg) {
+exports.isPOJO = function isPOJO(arg) {
   if (arg == null || typeof arg !== 'object') {
     return false;
   }
@@ -87686,6 +89519,47 @@ exports.isPOJO = function(arg) {
   // Checking `proto`'s constructor is safe because `getPrototypeOf()`
   // explicitly crosses the boundary from object data to object metadata
   return !proto || proto.constructor.name === 'Object';
+};
+
+/*!
+ * Determines if `obj` is a built-in object like an array, date, boolean,
+ * etc.
+ */
+
+exports.isNativeObject = function(arg) {
+  return Array.isArray(arg) ||
+    arg instanceof Date ||
+    arg instanceof Boolean ||
+    arg instanceof Number ||
+    arg instanceof String;
+};
+
+/*!
+ * Determines if `val` is an object that has no own keys
+ */
+
+exports.isEmptyObject = function(val) {
+  return val != null &&
+    typeof val === 'object' &&
+    Object.keys(val).length === 0;
+};
+
+/*!
+ * Search if `obj` or any POJOs nested underneath `obj` has a property named
+ * `key`
+ */
+
+exports.hasKey = function hasKey(obj, key) {
+  const props = Object.keys(obj);
+  for (const prop of props) {
+    if (prop === key) {
+      return true;
+    }
+    if (exports.isPOJO(obj[prop]) && exports.hasKey(obj[prop], key)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /*!
@@ -87721,6 +89595,15 @@ exports.tick = function tick(callback) {
       });
     }
   };
+};
+
+/*!
+ * Returns true if `v` is an object that can be serialized as a primitive in
+ * MongoDB
+ */
+
+exports.isMongooseType = function(v) {
+  return v instanceof ObjectId || v instanceof Decimal || v instanceof Buffer;
 };
 
 /*!
@@ -87775,38 +89658,53 @@ exports.expires = function expires(object) {
 };
 
 /*!
- * Populate options constructor
- */
-
-function PopulateOptions(obj) {
-  this.path = obj.path;
-  this.match = obj.match;
-  this.select = obj.select;
-  this.options = obj.options;
-  this.model = obj.model;
-  if (typeof obj.subPopulate === 'object') {
-    this.populate = obj.subPopulate;
-  }
-  if (obj.justOne != null) {
-    this.justOne = obj.justOne;
-  }
-  if (obj.count != null) {
-    this.count = obj.count;
-  }
-  this._docs = {};
-}
-
-// make it compatible with utils.clone
-PopulateOptions.prototype.constructor = Object;
-
-// expose
-exports.PopulateOptions = PopulateOptions;
-
-/*!
  * populate helper
  */
 
 exports.populate = function populate(path, select, model, match, options, subPopulate, justOne, count) {
+  // might have passed an object specifying all arguments
+  let obj = null;
+  if (arguments.length === 1) {
+    if (path instanceof PopulateOptions) {
+      return [path];
+    }
+
+    if (Array.isArray(path)) {
+      const singles = makeSingles(path);
+      return singles.map(o => exports.populate(o)[0]);
+    }
+
+    if (exports.isObject(path)) {
+      obj = Object.assign({}, path);
+    } else {
+      obj = { path: path };
+    }
+  } else if (typeof model === 'object') {
+    obj = {
+      path: path,
+      select: select,
+      match: model,
+      options: match
+    };
+  } else {
+    obj = {
+      path: path,
+      select: select,
+      model: model,
+      match: match,
+      options: options,
+      populate: subPopulate,
+      justOne: justOne,
+      count: count
+    };
+  }
+
+  if (typeof obj.path !== 'string') {
+    throw new TypeError('utils.populate: invalid path. Expected string. Got typeof `' + typeof path + '`');
+  }
+
+  return _populateObj(obj);
+
   // The order of select/conditions args is opposite Model.find but
   // necessary to keep backward compatibility (select could be
   // an array, string, or object literal).
@@ -87827,47 +89725,12 @@ exports.populate = function populate(path, select, model, match, options, subPop
 
     return ret;
   }
+};
 
-  // might have passed an object specifying all arguments
-  if (arguments.length === 1) {
-    if (path instanceof PopulateOptions) {
-      return [path];
-    }
-
-    if (Array.isArray(path)) {
-      const singles = makeSingles(path);
-      return singles.map(function(o) {
-        if (o.populate && !(o.match || o.options)) {
-          return exports.populate(o)[0];
-        } else {
-          return exports.populate(o)[0];
-        }
-      });
-    }
-
-    if (exports.isObject(path)) {
-      match = path.match;
-      options = path.options;
-      select = path.select;
-      model = path.model;
-      subPopulate = path.populate;
-      justOne = path.justOne;
-      path = path.path;
-      count = path.count;
-    }
-  } else if (typeof model === 'object') {
-    options = match;
-    match = model;
-    model = undefined;
-  }
-
-  if (typeof path !== 'string') {
-    throw new TypeError('utils.populate: invalid path. Expected string. Got typeof `' + typeof path + '`');
-  }
-
-  if (Array.isArray(subPopulate)) {
+function _populateObj(obj) {
+  if (Array.isArray(obj.populate)) {
     const ret = [];
-    subPopulate.forEach(function(obj) {
+    obj.populate.forEach(function(obj) {
       if (/[\s]/.test(obj.path)) {
         const copy = Object.assign({}, obj);
         const paths = copy.path.split(' ');
@@ -87879,29 +89742,23 @@ exports.populate = function populate(path, select, model, match, options, subPop
         ret.push(exports.populate(obj)[0]);
       }
     });
-    subPopulate = exports.populate(ret);
-  } else if (typeof subPopulate === 'object') {
-    subPopulate = exports.populate(subPopulate);
+    obj.populate = exports.populate(ret);
+  } else if (obj.populate != null && typeof obj.populate === 'object') {
+    obj.populate = exports.populate(obj.populate);
   }
 
   const ret = [];
-  const paths = path.split(' ');
-  options = exports.clone(options);
+  const paths = obj.path.split(' ');
+  if (obj.options != null) {
+    obj.options = exports.clone(obj.options);
+  }
+
   for (let i = 0; i < paths.length; ++i) {
-    ret.push(new PopulateOptions({
-      path: paths[i],
-      select: select,
-      match: match,
-      options: options,
-      model: model,
-      subPopulate: subPopulate,
-      justOne: justOne,
-      count: count
-    }));
+    ret.push(new PopulateOptions(Object.assign({}, obj, { path: paths[i] })));
   }
 
   return ret;
-};
+}
 
 /*!
  * Return the value of `obj` at the given `path`.
@@ -87987,7 +89844,7 @@ exports.array = {};
  * [ 1, [ 2, 3, [4] ]] -> [1,2,3,4]
  *
  * @param {Array} arr
- * @param {Function} [filter] If passed, will be invoked with each item in the array. If `filter` returns a falsey value, the item will not be included in the results.
+ * @param {Function} [filter] If passed, will be invoked with each item in the array. If `filter` returns a falsy value, the item will not be included in the results.
  * @return {Array}
  * @private
  */
@@ -88006,6 +89863,58 @@ exports.array.flatten = function flatten(arr, filter, ret) {
   });
 
   return ret;
+};
+
+/*!
+ * ignore
+ */
+
+const _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+exports.hasUserDefinedProperty = function(obj, key) {
+  if (obj == null) {
+    return false;
+  }
+
+  if (Array.isArray(key)) {
+    for (const k of key) {
+      if (exports.hasUserDefinedProperty(obj, k)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (_hasOwnProperty.call(obj, key)) {
+    return true;
+  }
+  if (key in obj) {
+    const v = obj[key];
+    return v !== Object.prototype[key] && v !== Array.prototype[key];
+  }
+
+  return false;
+};
+
+/*!
+ * ignore
+ */
+
+const MAX_ARRAY_INDEX = Math.pow(2, 32) - 1;
+
+exports.isArrayIndex = function(val) {
+  if (typeof val === 'number') {
+    return val >= 0 && val <= MAX_ARRAY_INDEX;
+  }
+  if (typeof val === 'string') {
+    if (!/^\d+$/.test(val)) {
+      return false;
+    }
+    val = +val;
+    return val >= 0 && val <= MAX_ARRAY_INDEX;
+  }
+
+  return false;
 };
 
 /*!
@@ -88175,10 +90084,26 @@ exports.each = function(arr, fn) {
  * ignore
  */
 
+exports.getOption = function(name) {
+  const sources = Array.prototype.slice.call(arguments, 1);
+
+  for (const source of sources) {
+    if (source[name] != null) {
+      return source[name];
+    }
+  }
+
+  return null;
+};
+
+/*!
+ * ignore
+ */
+
 exports.noop = function() {};
 
 }).call(this,require('_process'))
-},{"./document":259,"./helpers/get":286,"./promise_provider":303,"./types":333,"./types/decimal128":330,"./types/objectid":335,"_process":352,"mpath":340,"ms":339,"regexp-clone":353,"safe-buffer":354,"sliced":355}],338:[function(require,module,exports){
+},{"./document":258,"./helpers/get":287,"./helpers/symbols":300,"./options/PopulateOptions":305,"./promise_provider":314,"./types":345,"./types/decimal128":342,"./types/objectid":347,"_process":367,"mpath":353,"ms":351,"regexp-clone":368,"safe-buffer":352,"sliced":369}],350:[function(require,module,exports){
 'use strict';
 
 /**
@@ -88243,16 +90168,22 @@ VirtualType.prototype.clone = function() {
 };
 
 /**
- * Defines a getter.
+ * Adds a custom getter to this virtual.
+ *
+ * Mongoose calls the getter function with 3 parameters:
+ *
+ * - `value`: the value returned by the previous getter. If there is only one getter, `value` will be `undefined`.
+ * - `virtual`: the virtual object you called `.get()` on
+ * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * ####Example:
  *
  *     var virtual = schema.virtual('fullname');
- *     virtual.get(function () {
+ *     virtual.get(function(value, virtual, doc) {
  *       return this.name.first + ' ' + this.name.last;
  *     });
  *
- * @param {Function} fn
+ * @param {Function(Any, VirtualType, Document)} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -88263,18 +90194,31 @@ VirtualType.prototype.get = function(fn) {
 };
 
 /**
- * Defines a setter.
+ * Adds a custom setter to this virtual.
+ *
+ * Mongoose calls the setter function with 3 parameters:
+ *
+ * - `value`: the value being set
+ * - `virtual`: the virtual object you're calling `.set()` on
+ * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * ####Example:
  *
- *     var virtual = schema.virtual('fullname');
- *     virtual.set(function (v) {
- *       var parts = v.split(' ');
+ *     const virtual = schema.virtual('fullname');
+ *     virtual.set(function(value, virtual, doc) {
+ *       var parts = value.split(' ');
  *       this.name.first = parts[0];
  *       this.name.last = parts[1];
  *     });
  *
- * @param {Function} fn
+ *     const Model = mongoose.model('Test', schema);
+ *     const doc = new Model();
+ *     // Calls the setter with `value = 'Jean-Luc Picard'`
+ *     doc.fullname = 'Jean-Luc Picard';
+ *     doc.name.first; // 'Jean-Luc'
+ *     doc.name.last; // 'Picard'
+ *
+ * @param {Function(Any, VirtualType, Document)} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -88285,35 +90229,35 @@ VirtualType.prototype.set = function(fn) {
 };
 
 /**
- * Applies getters to `value` using optional `scope`.
+ * Applies getters to `value`.
  *
  * @param {Object} value
- * @param {Object} scope
+ * @param {Document} doc The document this virtual is attached to
  * @return {any} the value after applying all getters
  * @api public
  */
 
-VirtualType.prototype.applyGetters = function(value, scope) {
+VirtualType.prototype.applyGetters = function(value, doc) {
   let v = value;
   for (let l = this.getters.length - 1; l >= 0; l--) {
-    v = this.getters[l].call(scope, v, this);
+    v = this.getters[l].call(doc, v, this, doc);
   }
   return v;
 };
 
 /**
- * Applies setters to `value` using optional `scope`.
+ * Applies setters to `value`.
  *
  * @param {Object} value
- * @param {Object} scope
+ * @param {Document} doc
  * @return {any} the value after applying all setters
  * @api public
  */
 
-VirtualType.prototype.applySetters = function(value, scope) {
+VirtualType.prototype.applySetters = function(value, doc) {
   let v = value;
   for (let l = this.setters.length - 1; l >= 0; l--) {
-    v = this.setters[l].call(scope, v, this);
+    v = this.setters[l].call(doc, v, this, doc);
   }
   return v;
 };
@@ -88324,7 +90268,7 @@ VirtualType.prototype.applySetters = function(value, scope) {
 
 module.exports = VirtualType;
 
-},{}],339:[function(require,module,exports){
+},{}],351:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -88355,7 +90299,7 @@ module.exports = function(val, options) {
   var type = typeof val;
   if (type === 'string' && val.length > 0) {
     return parse(val);
-  } else if (type === 'number' && isNaN(val) === false) {
+  } else if (type === 'number' && isFinite(val)) {
     return options.long ? fmtLong(val) : fmtShort(val);
   }
   throw new Error(
@@ -88377,7 +90321,7 @@ function parse(str) {
   if (str.length > 100) {
     return;
   }
-  var match = /^((?:\d+)?\-?\d?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+  var match = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
     str
   );
   if (!match) {
@@ -88488,14 +90432,74 @@ function plural(ms, msAbs, n, name) {
   return Math.round(ms / n) + ' ' + name + (isPlural ? 's' : '');
 }
 
-},{}],340:[function(require,module,exports){
+},{}],352:[function(require,module,exports){
+/* eslint-disable node/no-deprecated-api */
+var buffer = require('buffer')
+var Buffer = buffer.Buffer
+
+// alternative to using Object.keys for old browsers
+function copyProps (src, dst) {
+  for (var key in src) {
+    dst[key] = src[key]
+  }
+}
+if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+  module.exports = buffer
+} else {
+  // Copy properties from require('buffer')
+  copyProps(buffer, exports)
+  exports.Buffer = SafeBuffer
+}
+
+function SafeBuffer (arg, encodingOrOffset, length) {
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+// Copy static methods from Buffer
+copyProps(Buffer, SafeBuffer)
+
+SafeBuffer.from = function (arg, encodingOrOffset, length) {
+  if (typeof arg === 'number') {
+    throw new TypeError('Argument must not be a number')
+  }
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+SafeBuffer.alloc = function (size, fill, encoding) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  var buf = Buffer(size)
+  if (fill !== undefined) {
+    if (typeof encoding === 'string') {
+      buf.fill(fill, encoding)
+    } else {
+      buf.fill(fill)
+    }
+  } else {
+    buf.fill(0)
+  }
+  return buf
+}
+
+SafeBuffer.allocUnsafe = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return Buffer(size)
+}
+
+SafeBuffer.allocUnsafeSlow = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return buffer.SlowBuffer(size)
+}
+
+},{"buffer":107}],353:[function(require,module,exports){
 module.exports = exports = require('./lib');
 
-},{"./lib":341}],341:[function(require,module,exports){
-(function (global){
-// Make sure Map exists for old Node.js versions
-var Map = global.Map != null ? global.Map : function() {};
-
+},{"./lib":354}],354:[function(require,module,exports){
 // These properties are special and can open client libraries to security
 // issues
 var ignoreProperties = ['__proto__', 'constructor', 'prototype'];
@@ -88561,7 +90565,9 @@ exports.get = function (path, o, special, map) {
       // reading a property from the array items
       var paths = parts.slice(i);
 
-      return obj.map(function (item) {
+      // Need to `concat()` to avoid `map()` calling a constructor of an array
+      // subclass
+      return [].concat(obj).map(function (item) {
         return item
           ? exports.get(paths, item, special || lookup, map)
           : map(undefined);
@@ -88750,17 +90756,7 @@ exports.set = function (path, val, o, special, map, _copying) {
   // set the value on the last branch
   if (Array.isArray(obj) && !/^\d+$/.test(part)) {
     if (!copy && Array.isArray(val)) {
-      for (var item, j = 0; j < obj.length && j < val.length; ++j) {
-        item = obj[j];
-        if (item) {
-          if (lookup) {
-            lookup(item, part, map(val[j]));
-          } else {
-            if (item[special]) item = item[special];
-            item[part] = map(val[j]);
-          }
-        }
-      }
+      _setArray(obj, val, part, lookup, special, map);
     } else {
       for (var j = 0; j < obj.length; ++j) {
         item = obj[j];
@@ -88786,6 +90782,26 @@ exports.set = function (path, val, o, special, map, _copying) {
 }
 
 /*!
+ * Recursively set nested arrays
+ */
+
+function _setArray(obj, val, part, lookup, special, map) {
+  for (var item, j = 0; j < obj.length && j < val.length; ++j) {
+    item = obj[j];
+    if (Array.isArray(item) && Array.isArray(val[j])) {
+      _setArray(item, val[j], part, lookup, special, map);
+    } else if (item) {
+      if (lookup) {
+        lookup(item, part, map(val[j]));
+      } else {
+        if (item[special]) item = item[special];
+        item[part] = map(val[j]);
+      }
+    }
+  }
+}
+
+/*!
  * Returns the value passed to it.
  */
 
@@ -88793,8 +90809,7 @@ function K (v) {
   return v;
 }
 
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],342:[function(require,module,exports){
+},{}],355:[function(require,module,exports){
 'use strict';
 
 /**
@@ -88842,7 +90857,7 @@ function notImplemented(method) {
   };
 }
 
-},{}],343:[function(require,module,exports){
+},{}],356:[function(require,module,exports){
 'use strict';
 
 var env = require('../env');
@@ -88857,7 +90872,7 @@ module.exports =
       require('./collection');
 
 
-},{"../env":345,"./collection":342,"./node":344}],344:[function(require,module,exports){
+},{"../env":358,"./collection":355,"./node":357}],357:[function(require,module,exports){
 'use strict';
 
 /**
@@ -89010,7 +91025,7 @@ NodeCollection.prototype.findCursor = function(match, findOptions) {
 
 module.exports = exports = NodeCollection;
 
-},{"../utils":348,"./collection":342}],345:[function(require,module,exports){
+},{"../utils":361,"./collection":355}],358:[function(require,module,exports){
 (function (process,global,Buffer){
 'use strict';
 
@@ -89036,7 +91051,7 @@ exports.type = exports.isNode ? 'node'
       : 'unknown';
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"_process":352,"buffer":107}],346:[function(require,module,exports){
+},{"_process":367,"buffer":107}],359:[function(require,module,exports){
 'use strict';
 
 /**
@@ -89073,8 +91088,7 @@ function Query(criteria, options) {
 
   this.op = proto.op || undefined;
 
-  this.options = {};
-  this.setOptions(proto.options);
+  this.options = Object.assign({}, proto.options);
 
   this._conditions = proto._conditions
     ? utils.clone(proto._conditions)
@@ -92291,7 +94305,7 @@ module.exports = exports = Query;
 // TODO
 // test utils
 
-},{"./collection":343,"./collection/collection":342,"./env":345,"./permissions":347,"./utils":348,"assert":81,"bluebird":86,"debug":349,"sliced":355,"util":366}],347:[function(require,module,exports){
+},{"./collection":356,"./collection/collection":355,"./env":358,"./permissions":360,"./utils":361,"assert":81,"bluebird":86,"debug":362,"sliced":369,"util":381}],360:[function(require,module,exports){
 'use strict';
 
 var denied = exports;
@@ -92381,7 +94395,7 @@ denied.count.maxScan =
 denied.count.snapshot =
 denied.count.tailable = true;
 
-},{}],348:[function(require,module,exports){
+},{}],361:[function(require,module,exports){
 (function (process,setImmediate){
 'use strict';
 
@@ -92741,7 +94755,7 @@ exports.isArgumentsObject = function(v) {
 };
 
 }).call(this,require('_process'),require("timers").setImmediate)
-},{"_process":352,"regexp-clone":353,"safe-buffer":354,"timers":356}],349:[function(require,module,exports){
+},{"_process":367,"regexp-clone":368,"safe-buffer":364,"timers":370}],362:[function(require,module,exports){
 (function (process){
 /**
  * This is the web browser implementation of `debug()`.
@@ -92940,7 +94954,7 @@ function localstorage() {
 }
 
 }).call(this,require('_process'))
-},{"./debug":350,"_process":352}],350:[function(require,module,exports){
+},{"./debug":363,"_process":367}],363:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -93167,7 +95181,9 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":351}],351:[function(require,module,exports){
+},{"ms":365}],364:[function(require,module,exports){
+arguments[4][352][0].apply(exports,arguments)
+},{"buffer":107,"dup":352}],365:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -93321,7 +95337,99 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],352:[function(require,module,exports){
+},{}],366:[function(require,module,exports){
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+'use strict';
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+},{}],367:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -93507,9 +95615,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],353:[function(require,module,exports){
+},{}],368:[function(require,module,exports){
 
-var toString = Object.prototype.toString;
+const toString = Object.prototype.toString;
 
 function isRegExp (o) {
   return 'object' == typeof o
@@ -93521,79 +95629,22 @@ module.exports = exports = function (regexp) {
     throw new TypeError('Not a RegExp');
   }
 
-  var flags = [];
+  const flags = [];
   if (regexp.global) flags.push('g');
   if (regexp.multiline) flags.push('m');
   if (regexp.ignoreCase) flags.push('i');
-  return new RegExp(regexp.source, flags.join(''));
-}
-
-
-},{}],354:[function(require,module,exports){
-/* eslint-disable node/no-deprecated-api */
-var buffer = require('buffer')
-var Buffer = buffer.Buffer
-
-// alternative to using Object.keys for old browsers
-function copyProps (src, dst) {
-  for (var key in src) {
-    dst[key] = src[key]
+  if (regexp.dotAll) flags.push('s');
+  if (regexp.unicode) flags.push('u');
+  if (regexp.sticky) flags.push('y');
+  const result = new RegExp(regexp.source, flags.join(''));
+  if (typeof regexp.lastIndex === 'number') {
+    result.lastIndex = regexp.lastIndex;
   }
-}
-if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
-  module.exports = buffer
-} else {
-  // Copy properties from require('buffer')
-  copyProps(buffer, exports)
-  exports.Buffer = SafeBuffer
+  return result;
 }
 
-function SafeBuffer (arg, encodingOrOffset, length) {
-  return Buffer(arg, encodingOrOffset, length)
-}
 
-// Copy static methods from Buffer
-copyProps(Buffer, SafeBuffer)
-
-SafeBuffer.from = function (arg, encodingOrOffset, length) {
-  if (typeof arg === 'number') {
-    throw new TypeError('Argument must not be a number')
-  }
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-SafeBuffer.alloc = function (size, fill, encoding) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  var buf = Buffer(size)
-  if (fill !== undefined) {
-    if (typeof encoding === 'string') {
-      buf.fill(fill, encoding)
-    } else {
-      buf.fill(fill)
-    }
-  } else {
-    buf.fill(0)
-  }
-  return buf
-}
-
-SafeBuffer.allocUnsafe = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return Buffer(size)
-}
-
-SafeBuffer.allocUnsafeSlow = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return buffer.SlowBuffer(size)
-}
-
-},{"buffer":107}],355:[function(require,module,exports){
+},{}],369:[function(require,module,exports){
 
 /**
  * An Array.prototype.slice.call(arguments) alternative
@@ -93628,7 +95679,7 @@ module.exports = function (args, slice, sliceEnd) {
 }
 
 
-},{}],356:[function(require,module,exports){
+},{}],370:[function(require,module,exports){
 (function (setImmediate,clearImmediate){
 var nextTick = require('process/browser.js').nextTick;
 var apply = Function.prototype.apply;
@@ -93707,7 +95758,7 @@ exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate :
   delete immediateIds[id];
 };
 }).call(this,require("timers").setImmediate,require("timers").clearImmediate)
-},{"process/browser.js":352,"timers":356}],357:[function(require,module,exports){
+},{"process/browser.js":367,"timers":370}],371:[function(require,module,exports){
 module.exports={
   "10*": {
     "value": 10,
@@ -94911,10 +96962,10 @@ module.exports={
   }
 }
 
-},{}],358:[function(require,module,exports){
+},{}],372:[function(require,module,exports){
 module.exports={"mol":true,"sr":true,"Hz":true,"N":true,"Pa":true,"J":true,"W":true,"A":true,"V":true,"F":true,"Ohm":true,"S":true,"Wb":true,"Cel":true,"T":true,"H":true,"lm":true,"lx":true,"Bq":true,"Gy":true,"Sv":true,"l":true,"L":true,"ar":true,"t":true,"bar":true,"u":true,"eV":true,"pc":true,"[c]":true,"[h]":true,"[k]":true,"[eps_0]":true,"[mu_0]":true,"[e]":true,"[m_e]":true,"[m_p]":true,"[G]":true,"[g]":true,"[ly]":true,"gf":true,"Ky":true,"Gal":true,"dyn":true,"erg":true,"P":true,"Bi":true,"St":true,"Mx":true,"G":true,"Oe":true,"Gb":true,"sb":true,"Lmb":true,"ph":true,"Ci":true,"R":true,"RAD":true,"REM":true,"cal_[15]":true,"cal_[20]":true,"cal_m":true,"cal_IT":true,"cal_th":true,"cal":true,"tex":true,"m[H2O]":true,"m[Hg]":true,"eq":true,"osm":true,"g%":true,"kat":true,"U":true,"[iU]":true,"[IU]":true,"Np":true,"B":true,"B[SPL]":true,"B[V]":true,"B[mV]":true,"B[uV]":true,"B[10.nV]":true,"B[W]":true,"B[kW]":true,"st":true,"mho":true,"bit":true,"By":true,"Bd":true,"m":true,"s":true,"g":true,"rad":true,"K":true,"C":true,"cd":true}
 
-},{}],359:[function(require,module,exports){
+},{}],373:[function(require,module,exports){
 module.exports={
   "Y": {
     "CODE": "YA",
@@ -95278,7 +97329,7 @@ module.exports={
   }
 }
 
-},{}],360:[function(require,module,exports){
+},{}],374:[function(require,module,exports){
 module.exports={
   "Y": 1e+24,
   "Z": 1e+21,
@@ -95306,7 +97357,7 @@ module.exports={
   "Ti": 1099511627776
 }
 
-},{}],361:[function(require,module,exports){
+},{}],375:[function(require,module,exports){
 module.exports = (function() {
   /*
    * Generated by PEG.js 0.8.0.
@@ -96854,7 +98905,7 @@ module.exports = (function() {
   };
 })();
 
-},{"../lib/helpers":363,"./metrics.json":358,"./prefixMetadata.json":359,"./prefixes.json":360,"./unitMetadata.json":362}],362:[function(require,module,exports){
+},{"../lib/helpers":377,"./metrics.json":372,"./prefixMetadata.json":373,"./prefixes.json":374,"./unitMetadata.json":376}],376:[function(require,module,exports){
 module.exports={
   "10*": {
     "isBase": false,
@@ -103041,7 +105092,7 @@ module.exports={
   }
 }
 
-},{}],363:[function(require,module,exports){
+},{}],377:[function(require,module,exports){
 module.exports = {
 
   multiply: function multiply(t, ms) {
@@ -103111,7 +105162,7 @@ module.exports = {
   }
 }
 
-},{}],364:[function(require,module,exports){
+},{}],378:[function(require,module,exports){
 parser = require('./generated/ucum-parser.js');
 equivalents = require('./generated/equivalents.json');
 helpers = require('./lib/helpers.js');
@@ -103341,8 +105392,10 @@ function unitQuery(criteria, resultFields){
     return obj;
   });
 }
-},{"./generated/equivalents.json":357,"./generated/ucum-parser.js":361,"./generated/unitMetadata.json":362,"./lib/helpers.js":363}],365:[function(require,module,exports){
+},{"./generated/equivalents.json":371,"./generated/ucum-parser.js":375,"./generated/unitMetadata.json":376,"./lib/helpers.js":377}],379:[function(require,module,exports){
+arguments[4][82][0].apply(exports,arguments)
+},{"dup":82}],380:[function(require,module,exports){
 arguments[4][83][0].apply(exports,arguments)
-},{"dup":83}],366:[function(require,module,exports){
+},{"dup":83}],381:[function(require,module,exports){
 arguments[4][84][0].apply(exports,arguments)
-},{"./support/isBuffer":365,"_process":352,"dup":84,"inherits":245}]},{},[67]);
+},{"./support/isBuffer":380,"_process":367,"dup":84,"inherits":379}]},{},[67]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,7 +40,7 @@ class AdverseEvent extends mongoose.Document {
 }
 module.exports.AdverseEvent = AdverseEvent;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],2:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],2:[function(require,module,exports){
 module.exports.Id = require('./Id.js').Id;
 module.exports.IdSchema = require('./Id.js').IdSchema;
 module.exports.PhysicalExamOrder = require('./PhysicalExamOrder.js').PhysicalExamOrder;
@@ -200,7 +200,7 @@ class AllergyIntolerance extends mongoose.Document {
 }
 module.exports.AllergyIntolerance = AllergyIntolerance;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],4:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],4:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -241,7 +241,7 @@ class AssessmentOrder extends mongoose.Document {
 }
 module.exports.AssessmentOrder = AssessmentOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],5:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],5:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -286,7 +286,7 @@ class AssessmentPerformed extends mongoose.Document {
 }
 module.exports.AssessmentPerformed = AssessmentPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],6:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],6:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -327,7 +327,7 @@ class AssessmentRecommended extends mongoose.Document {
 }
 module.exports.AssessmentRecommended = AssessmentRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],7:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],7:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -367,7 +367,7 @@ class CareGoal extends mongoose.Document {
 }
 module.exports.CareGoal = CareGoal;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],8:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],8:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -413,7 +413,7 @@ class CommunicationPerformed extends mongoose.Document {
 }
 module.exports.CommunicationPerformed = CommunicationPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],9:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],9:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -456,7 +456,7 @@ class DeviceApplied extends mongoose.Document {
 }
 module.exports.DeviceApplied = DeviceApplied;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],10:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],10:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -497,7 +497,7 @@ class DeviceOrder extends mongoose.Document {
 }
 module.exports.DeviceOrder = DeviceOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],11:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],11:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -538,7 +538,7 @@ class DeviceRecommended extends mongoose.Document {
 }
 module.exports.DeviceRecommended = DeviceRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],12:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],12:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -580,7 +580,7 @@ class Diagnosis extends mongoose.Document {
 }
 module.exports.Diagnosis = Diagnosis;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],13:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],13:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -621,7 +621,7 @@ class DiagnosticStudyOrder extends mongoose.Document {
 }
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],14:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],14:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -669,7 +669,7 @@ class DiagnosticStudyPerformed extends mongoose.Document {
 }
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],15:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],15:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -710,7 +710,7 @@ class DiagnosticStudyRecommended extends mongoose.Document {
 }
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],16:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],16:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -752,7 +752,7 @@ class EncounterOrder extends mongoose.Document {
 }
 module.exports.EncounterOrder = EncounterOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],17:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],17:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -799,7 +799,7 @@ class EncounterPerformed extends mongoose.Document {
 }
 module.exports.EncounterPerformed = EncounterPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],18:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],18:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -841,7 +841,7 @@ class EncounterRecommended extends mongoose.Document {
 }
 module.exports.EncounterRecommended = EncounterRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],19:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],19:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -881,7 +881,7 @@ class FamilyHistory extends mongoose.Document {
 }
 module.exports.FamilyHistory = FamilyHistory;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],20:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],20:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [Number, String] = [
@@ -904,7 +904,7 @@ class Id extends mongoose.Document {
 }
 module.exports.Id = Id;
 
-},{"mongoose/browser":248}],21:[function(require,module,exports){
+},{"mongoose/browser":247}],21:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -948,7 +948,7 @@ class ImmunizationAdministered extends mongoose.Document {
 }
 module.exports.ImmunizationAdministered = ImmunizationAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],22:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],22:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -993,7 +993,7 @@ class ImmunizationOrder extends mongoose.Document {
 }
 module.exports.ImmunizationOrder = ImmunizationOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],23:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],23:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1034,7 +1034,7 @@ class InterventionOrder extends mongoose.Document {
 }
 module.exports.InterventionOrder = InterventionOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],24:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],24:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1078,7 +1078,7 @@ class InterventionPerformed extends mongoose.Document {
 }
 module.exports.InterventionPerformed = InterventionPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],25:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],25:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1119,7 +1119,7 @@ class InterventionRecommended extends mongoose.Document {
 }
 module.exports.InterventionRecommended = InterventionRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],26:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],26:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1160,7 +1160,7 @@ class LaboratoryTestOrder extends mongoose.Document {
 }
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],27:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],27:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1208,7 +1208,7 @@ class LaboratoryTestPerformed extends mongoose.Document {
 }
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],28:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],28:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1249,7 +1249,7 @@ class LaboratoryTestRecommended extends mongoose.Document {
 }
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],29:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],29:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1291,7 +1291,7 @@ class MedicationActive extends mongoose.Document {
 }
 module.exports.MedicationActive = MedicationActive;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],30:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],30:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1336,7 +1336,7 @@ class MedicationAdministered extends mongoose.Document {
 }
 module.exports.MedicationAdministered = MedicationAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],31:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],31:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1382,7 +1382,7 @@ class MedicationDischarge extends mongoose.Document {
 }
 module.exports.MedicationDischarge = MedicationDischarge;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],32:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],32:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1431,7 +1431,7 @@ class MedicationDispensed extends mongoose.Document {
 }
 module.exports.MedicationDispensed = MedicationDispensed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],33:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],33:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1481,7 +1481,7 @@ class MedicationOrder extends mongoose.Document {
 }
 module.exports.MedicationOrder = MedicationOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],34:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],34:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1519,7 +1519,7 @@ class Participation extends mongoose.Document {
 }
 module.exports.Participation = Participation;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],35:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],35:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1557,7 +1557,7 @@ class PatientCareExperience extends mongoose.Document {
 }
 module.exports.PatientCareExperience = PatientCareExperience;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],36:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],36:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1595,7 +1595,7 @@ class PatientCharacteristic extends mongoose.Document {
 }
 module.exports.PatientCharacteristic = PatientCharacteristic;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],37:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],37:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1634,7 +1634,7 @@ class PatientCharacteristicBirthdate extends mongoose.Document {
 }
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],38:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],38:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1675,7 +1675,7 @@ class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
 }
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],39:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],39:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1713,7 +1713,7 @@ class PatientCharacteristicEthnicity extends mongoose.Document {
 }
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],40:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],40:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1753,7 +1753,7 @@ class PatientCharacteristicExpired extends mongoose.Document {
 }
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],41:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],41:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1792,7 +1792,7 @@ class PatientCharacteristicPayer extends mongoose.Document {
 }
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],42:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],42:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1830,7 +1830,7 @@ class PatientCharacteristicRace extends mongoose.Document {
 }
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],43:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],43:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1868,7 +1868,7 @@ class PatientCharacteristicSex extends mongoose.Document {
 }
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],44:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],44:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1910,7 +1910,7 @@ class PhysicalExamOrder extends mongoose.Document {
 }
 module.exports.PhysicalExamOrder = PhysicalExamOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],45:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],45:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1956,7 +1956,7 @@ class PhysicalExamPerformed extends mongoose.Document {
 }
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],46:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],46:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -1998,7 +1998,7 @@ class PhysicalExamRecommended extends mongoose.Document {
 }
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],47:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],47:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2041,7 +2041,7 @@ class ProcedureOrder extends mongoose.Document {
 }
 module.exports.ProcedureOrder = ProcedureOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],48:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],48:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2090,7 +2090,7 @@ class ProcedurePerformed extends mongoose.Document {
 }
 module.exports.ProcedurePerformed = ProcedurePerformed;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],49:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],49:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2133,7 +2133,7 @@ class ProcedureRecommended extends mongoose.Document {
 }
 module.exports.ProcedureRecommended = ProcedureRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],50:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],50:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2171,7 +2171,7 @@ class ProviderCareExperience extends mongoose.Document {
 }
 module.exports.ProviderCareExperience = ProviderCareExperience;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],51:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],51:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2209,7 +2209,7 @@ class ProviderCharacteristic extends mongoose.Document {
 }
 module.exports.ProviderCharacteristic = ProviderCharacteristic;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],52:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],52:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
@@ -2473,7 +2473,7 @@ class QDMPatient extends mongoose.Document {
 }
 module.exports.QDMPatient = QDMPatient;
 
-},{"./AllDataElements":2,"./basetypes/Code":62,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],53:[function(require,module,exports){
+},{"./AllDataElements":2,"./basetypes/Code":62,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],53:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const PlaceholderResultSchema = mongoose.Schema({
@@ -2508,7 +2508,7 @@ class PlaceholderResult extends mongoose.Document {
 }
 module.exports.PlaceholderResult = PlaceholderResult;
 
-},{"mongoose/browser":248}],54:[function(require,module,exports){
+},{"mongoose/browser":247}],54:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2543,7 +2543,7 @@ class ResultComponent extends mongoose.Document {
 }
 module.exports.ResultComponent = ResultComponent;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],55:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],55:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2587,7 +2587,7 @@ class SubstanceAdministered extends mongoose.Document {
 }
 module.exports.SubstanceAdministered = SubstanceAdministered;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],56:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],56:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2633,7 +2633,7 @@ class SubstanceOrder extends mongoose.Document {
 }
 module.exports.SubstanceOrder = SubstanceOrder;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],57:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],57:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2678,7 +2678,7 @@ class SubstanceRecommended extends mongoose.Document {
 }
 module.exports.SubstanceRecommended = SubstanceRecommended;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],58:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],58:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdSchema } = require('./Id');
@@ -2718,7 +2718,7 @@ class Symptom extends mongoose.Document {
 }
 module.exports.Symptom = Symptom;
 
-},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":248}],59:[function(require,module,exports){
+},{"./Id":20,"./attributes/Component":59,"./attributes/FacilityLocation":60,"./basetypes/Any":61,"./basetypes/Code":62,"./basetypes/DataElement":63,"./basetypes/DateTime":64,"./basetypes/Interval":65,"./basetypes/Quantity":66,"mongoose/browser":247}],59:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -2750,7 +2750,7 @@ class Component extends mongoose.Document {
 }
 module.exports.Component = Component;
 
-},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":248}],60:[function(require,module,exports){
+},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":247}],60:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -2782,7 +2782,7 @@ class FacilityLocation extends mongoose.Document {
 }
 module.exports.FacilityLocation = FacilityLocation;
 
-},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":248}],61:[function(require,module,exports){
+},{"../basetypes/Any":61,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"mongoose/browser":247}],61:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2851,7 +2851,7 @@ Any.prototype.cast = any => RecursiveCast(any);
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;
 
-},{"cql-execution":110,"mongoose/browser":248}],62:[function(require,module,exports){
+},{"cql-execution":110,"mongoose/browser":247}],62:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2887,7 +2887,7 @@ Code.prototype.cast = (code) => {
 mongoose.Schema.Types.Code = Code;
 module.exports = Code;
 
-},{"cql-execution":110,"mongoose/browser":248}],63:[function(require,module,exports){
+},{"cql-execution":110,"mongoose/browser":247}],63:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('./Code.js');
 const cql = require('cql-execution');
@@ -2933,7 +2933,7 @@ function DataElementSchema(add, options) {
 
 module.exports.DataElementSchema = DataElementSchema;
 
-},{"../Id":20,"./Code.js":62,"cql-execution":110,"mongoose/browser":248}],64:[function(require,module,exports){
+},{"../Id":20,"./Code.js":62,"cql-execution":110,"mongoose/browser":247}],64:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -2957,7 +2957,7 @@ DateTime.prototype.cast = (dateTime) => {
 mongoose.Schema.Types.DateTime = DateTime;
 module.exports = DateTime;
 
-},{"cql-execution":110,"mongoose/browser":248}],65:[function(require,module,exports){
+},{"cql-execution":110,"mongoose/browser":247}],65:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 const DateTime = require('./DateTime');
@@ -2996,7 +2996,7 @@ Interval.prototype.cast = (interval) => {
 mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;
 
-},{"./DateTime":64,"cql-execution":110,"mongoose/browser":248}],66:[function(require,module,exports){
+},{"./DateTime":64,"cql-execution":110,"mongoose/browser":247}],66:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -3018,7 +3018,7 @@ Quantity.prototype.cast = (quantity) => {
 mongoose.Schema.Types.Quantity = Quantity;
 module.exports = Quantity;
 
-},{"cql-execution":110,"mongoose/browser":248}],67:[function(require,module,exports){
+},{"cql-execution":110,"mongoose/browser":247}],67:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { StatementDependencySchema } = require('./CQLStatementDependency');
 
@@ -3052,7 +3052,7 @@ class CQLLibrary extends mongoose.Document {
 }
 module.exports.CQLLibrary = CQLLibrary;
 
-},{"./CQLStatementDependency":68,"mongoose/browser":248}],68:[function(require,module,exports){
+},{"./CQLStatementDependency":68,"mongoose/browser":247}],68:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const StatementReferenceSchema = new mongoose.Schema({
@@ -3082,7 +3082,7 @@ class StatementDependency extends mongoose.Document {
 }
 module.exports.StatementDependency = StatementDependency;
 
-},{"mongoose/browser":248}],69:[function(require,module,exports){
+},{"mongoose/browser":247}],69:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -3112,7 +3112,7 @@ class ClauseResult extends mongoose.Document {
 }
 module.exports.ClauseResult = ClauseResult;
 
-},{"mongoose/browser":248}],70:[function(require,module,exports){
+},{"mongoose/browser":247}],70:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const ConceptSchema = new mongoose.Schema({
@@ -3131,7 +3131,7 @@ class Concept extends mongoose.Document {
 }
 module.exports.Concept = Concept;
 
-},{"mongoose/browser":248}],71:[function(require,module,exports){
+},{"mongoose/browser":247}],71:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { ClauseResultSchema } = require('./ClauseResult');
 const { StatementResultSchema } = require('./StatementResult');
@@ -3221,7 +3221,7 @@ class IndividualResult extends mongoose.Document {
 }
 module.exports.IndividualResult = IndividualResult;
 
-},{"./ClauseResult":69,"./StatementResult":77,"mongoose/browser":248}],72:[function(require,module,exports){
+},{"./ClauseResult":69,"./StatementResult":77,"mongoose/browser":247}],72:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -3331,7 +3331,7 @@ class Measure extends mongoose.Document {
 }
 module.exports.Measure = Measure;
 
-},{"../AllDataElements":2,"../basetypes/Code":62,"../basetypes/DataElement":63,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./CQLLibrary":67,"./PopulationSet":75,"mongoose/browser":248}],73:[function(require,module,exports){
+},{"../AllDataElements":2,"../basetypes/Code":62,"../basetypes/DataElement":63,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./CQLLibrary":67,"./PopulationSet":75,"mongoose/browser":247}],73:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 // using mBuffer to not conflict with system Buffer
@@ -3359,7 +3359,7 @@ class MeasurePackage extends mongoose.Document {
 }
 module.exports.MeasurePackage = MeasurePackage;
 
-},{"mongoose/browser":248}],74:[function(require,module,exports){
+},{"mongoose/browser":247}],74:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -3399,7 +3399,7 @@ class Patient extends mongoose.Document {
 }
 module.exports.Patient = Patient;
 
-},{"../QDMPatient":52,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./Provider":76,"mongoose/browser":248}],75:[function(require,module,exports){
+},{"../QDMPatient":52,"../basetypes/Code":62,"../basetypes/DateTime":64,"../basetypes/Interval":65,"../basetypes/Quantity":66,"./Provider":76,"mongoose/browser":247}],75:[function(require,module,exports){
 /* eslint-disable no-unused-vars, no-param-reassign */
 const mongoose = require('mongoose/browser');
 const { StatementReferenceSchema } = require('./CQLStatementDependency');
@@ -3489,7 +3489,7 @@ class PopulationSet extends mongoose.Document {
 }
 module.exports.PopulationSet = PopulationSet;
 
-},{"./CQLStatementDependency":68,"mongoose/browser":248}],76:[function(require,module,exports){
+},{"./CQLStatementDependency":68,"mongoose/browser":247}],76:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Id = require('../Id');
 
@@ -3535,7 +3535,7 @@ class Provider extends mongoose.Document {
 }
 module.exports.Provider = Provider;
 
-},{"../Id":20,"mongoose/browser":248}],77:[function(require,module,exports){
+},{"../Id":20,"mongoose/browser":247}],77:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -3578,7 +3578,7 @@ class StatementResult extends mongoose.Document {
 }
 module.exports.StatementResult = StatementResult;
 
-},{"mongoose/browser":248}],78:[function(require,module,exports){
+},{"mongoose/browser":247}],78:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Concept = require('./Concept.js');
 
@@ -3606,7 +3606,7 @@ class ValueSet extends mongoose.Document {
 }
 module.exports.ValueSet = ValueSet;
 
-},{"./Concept.js":70,"mongoose/browser":248}],79:[function(require,module,exports){
+},{"./Concept.js":70,"mongoose/browser":247}],79:[function(require,module,exports){
 module.exports = require('./AllDataElements.js');
 module.exports.CQL = require('cql-execution');
 module.exports.Result = require('./Result.js').Result;
@@ -3639,6 +3639,8 @@ module.exports.StatementResultSchema = require('./cqm/StatementResult.js').State
 },{"./AllDataElements.js":2,"./Result.js":53,"./cqm/CQLLibrary.js":67,"./cqm/CQLStatementDependency.js":68,"./cqm/ClauseResult.js":69,"./cqm/Concept.js":70,"./cqm/IndividualResult.js":71,"./cqm/Measure.js":72,"./cqm/MeasurePackage.js":73,"./cqm/Patient.js":74,"./cqm/PopulationSet.js":75,"./cqm/Provider.js":76,"./cqm/StatementResult.js":77,"./cqm/ValueSet.js":78,"cql-execution":110}],80:[function(require,module,exports){
 (function (global){
 'use strict';
+
+var objectAssign = require('object-assign');
 
 // compare and isBuffer taken from https://github.com/feross/buffer/blob/680e9e5e488f22aac27599a57dc844a6315928dd/index.js
 // original notice:
@@ -3681,6 +3683,8 @@ function isBuffer(b) {
 }
 
 // based on node assert, original notice:
+// NB: The URL to the CommonJS spec is kept just for tradition.
+//     node-assert has evolved a lot since then, both in API and behavior.
 
 // http://wiki.commonjs.org/wiki/Unit_Testing/1.0
 //
@@ -4121,6 +4125,18 @@ assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
 
 assert.ifError = function(err) { if (err) throw err; };
 
+// Expose a strict only variant of assert
+function strict(value, message) {
+  if (!value) fail(value, true, message, '==', strict);
+}
+assert.strict = objectAssign(strict, assert, {
+  equal: assert.strictEqual,
+  deepEqual: assert.deepStrictEqual,
+  notEqual: assert.notStrictEqual,
+  notDeepEqual: assert.notDeepStrictEqual
+});
+assert.strict.strict = assert.strict;
+
 var objectKeys = Object.keys || function (obj) {
   var keys = [];
   for (var key in obj) {
@@ -4130,7 +4146,7 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"util/":83}],81:[function(require,module,exports){
+},{"object-assign":365,"util/":83}],81:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -4752,7 +4768,7 @@ function hasOwnProperty(obj, prop) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":82,"_process":351,"inherits":81}],84:[function(require,module,exports){
+},{"./support/isBuffer":82,"_process":366,"inherits":81}],84:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -4820,7 +4836,8 @@ function toByteArray (b64) {
     ? validLen - 4
     : validLen
 
-  for (var i = 0; i < len; i += 4) {
+  var i
+  for (i = 0; i < len; i += 4) {
     tmp =
       (revLookup[b64.charCodeAt(i)] << 18) |
       (revLookup[b64.charCodeAt(i + 1)] << 12) |
@@ -10531,7 +10548,7 @@ module.exports = ret;
 },{"./es5":13}]},{},[4])(4)
 });                    ;if (typeof window !== 'undefined' && window !== null) {                               window.P = window.Promise;                                                     } else if (typeof self !== 'undefined' && self !== null) {                             self.P = self.Promise;                                                         }
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
-},{"_process":351,"timers":355}],86:[function(require,module,exports){
+},{"_process":366,"timers":369}],86:[function(require,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -10543,6 +10560,8 @@ module.exports = ret;
 if (typeof global !== 'undefined') {
   var Buffer = require('buffer').Buffer; // TODO just use global Buffer
 }
+
+var utils = require('./parser/utils');
 
 /**
  * A class representation of the BSON Binary type.
@@ -10588,7 +10607,7 @@ function Binary(buffer, subType) {
     if (typeof buffer === 'string') {
       // Different ways of writing the length of the string for the different types
       if (typeof Buffer !== 'undefined') {
-        this.buffer = new Buffer(buffer);
+        this.buffer = utils.toBuffer(buffer);
       } else if (
         typeof Uint8Array !== 'undefined' ||
         Object.prototype.toString.call(buffer) === '[object Array]'
@@ -10603,7 +10622,7 @@ function Binary(buffer, subType) {
     this.position = buffer.length;
   } else {
     if (typeof Buffer !== 'undefined') {
-      this.buffer = new Buffer(Binary.BUFFER_SIZE);
+      this.buffer = utils.allocBuffer(Binary.BUFFER_SIZE);
     } else if (typeof Uint8Array !== 'undefined') {
       this.buffer = new Uint8Array(new ArrayBuffer(Binary.BUFFER_SIZE));
     } else {
@@ -10642,7 +10661,7 @@ Binary.prototype.put = function put(byte_value) {
   } else {
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(this.buffer)) {
       // Create additional overflow buffer
-      var buffer = new Buffer(Binary.BUFFER_SIZE + this.buffer.length);
+      var buffer = utils.allocBuffer(Binary.BUFFER_SIZE + this.buffer.length);
       // Combine the two buffers together
       this.buffer.copy(buffer, 0, 0, this.buffer.length);
       this.buffer = buffer;
@@ -10685,7 +10704,7 @@ Binary.prototype.write = function write(string, offset) {
     var buffer = null;
     // If we are in node.js
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(this.buffer)) {
-      buffer = new Buffer(this.buffer.length + string.length);
+      buffer = utils.allocBuffer(this.buffer.length + string.length);
       this.buffer.copy(buffer, 0, 0, this.buffer.length);
     } else if (Object.prototype.toString.call(this.buffer) === '[object Uint8Array]') {
       // Create a new buffer
@@ -10917,8 +10936,7 @@ module.exports = Binary;
 module.exports.Binary = Binary;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"buffer":106}],87:[function(require,module,exports){
-(function (Buffer){
+},{"./parser/utils":102,"buffer":106}],87:[function(require,module,exports){
 'use strict';
 
 var Map = require('./map'),
@@ -10939,7 +10957,8 @@ var Map = require('./map'),
 // Parts of the parser
 var deserialize = require('./parser/deserializer'),
   serializer = require('./parser/serializer'),
-  calculateObjectSize = require('./parser/calculate_size');
+  calculateObjectSize = require('./parser/calculate_size'),
+  utils = require('./parser/utils');
 
 /**
  * @ignore
@@ -10949,7 +10968,7 @@ var deserialize = require('./parser/deserializer'),
 var MAXSIZE = 1024 * 1024 * 17;
 
 // Current Internal Temporary Serialization Buffer
-var buffer = new Buffer(MAXSIZE);
+var buffer = utils.allocBuffer(MAXSIZE);
 
 var BSON = function() {};
 
@@ -10977,7 +10996,7 @@ BSON.prototype.serialize = function serialize(object, options) {
   
   // Resize the internal serialization buffer if needed
   if (buffer.length < minInternalBufferSize) {
-    buffer = new Buffer(minInternalBufferSize);
+    buffer = utils.allocBuffer(minInternalBufferSize);
   }
 
   // Attempt to serialize
@@ -10992,7 +11011,7 @@ BSON.prototype.serialize = function serialize(object, options) {
     []
   );
   // Create the final buffer
-  var finishedBuffer = new Buffer(serializationIndex);
+  var finishedBuffer = utils.allocBuffer(serializationIndex);
   // Copy into the finished buffer
   buffer.copy(finishedBuffer, 0, 0, finishedBuffer.length);
   // Return the buffer
@@ -11305,8 +11324,7 @@ module.exports.MaxKey = MaxKey;
 module.exports.BSONRegExp = BSONRegExp;
 module.exports.Decimal128 = Decimal128;
 
-}).call(this,require("buffer").Buffer)
-},{"./binary":86,"./code":88,"./db_ref":89,"./decimal128":90,"./double":91,"./int_32":93,"./long":94,"./map":95,"./max_key":96,"./min_key":97,"./objectid":98,"./parser/calculate_size":99,"./parser/deserializer":100,"./parser/serializer":101,"./regexp":103,"./symbol":104,"./timestamp":105,"buffer":106}],88:[function(require,module,exports){
+},{"./binary":86,"./code":88,"./db_ref":89,"./decimal128":90,"./double":91,"./int_32":93,"./long":94,"./map":95,"./max_key":96,"./min_key":97,"./objectid":98,"./parser/calculate_size":99,"./parser/deserializer":100,"./parser/serializer":101,"./parser/utils":102,"./regexp":103,"./symbol":104,"./timestamp":105}],88:[function(require,module,exports){
 /**
  * A class representation of the BSON Code type.
  *
@@ -11367,7 +11385,6 @@ module.exports = DBRef;
 module.exports.DBRef = DBRef;
 
 },{}],90:[function(require,module,exports){
-(function (Buffer){
 'use strict';
 
 var Long = require('./long');
@@ -11439,6 +11456,8 @@ var INF_POSITIVE_BUFFER = [
 ].reverse();
 
 var EXPONENT_REGEX = /^([-+])?(\d+)?$/;
+
+var utils = require('./parser/utils');
 
 // Detect if the value is a digit
 var isDigit = function(value) {
@@ -11513,7 +11532,7 @@ var lessThan = function(left, right) {
 };
 
 // var longtoHex = function(value) {
-//   var buffer = new Buffer(8);
+//   var buffer = utils.allocBuffer(8);
 //   var index = 0;
 //   // Encode the low 64 bits of the decimal
 //   // Encode low bits
@@ -11530,7 +11549,7 @@ var lessThan = function(left, right) {
 // };
 
 // var int32toHex = function(value) {
-//   var buffer = new Buffer(4);
+//   var buffer = utils.allocBuffer(4);
 //   var index = 0;
 //   // Encode the low 64 bits of the decimal
 //   // Encode low bits
@@ -11635,9 +11654,9 @@ Decimal128.fromString = function(string) {
   // Check if user passed Infinity or NaN
   if (!isDigit(string[index]) && string[index] !== '.') {
     if (string[index] === 'i' || string[index] === 'I') {
-      return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+      return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
     } else if (string[index] === 'N') {
-      return new Decimal128(new Buffer(NAN_BUFFER));
+      return new Decimal128(utils.toBuffer(NAN_BUFFER));
     }
   }
 
@@ -11645,7 +11664,7 @@ Decimal128.fromString = function(string) {
   while (isDigit(string[index]) || string[index] === '.') {
     if (string[index] === '.') {
       if (sawRadix) {
-        return new Decimal128(new Buffer(NAN_BUFFER));
+        return new Decimal128(utils.toBuffer(NAN_BUFFER));
       }
 
       sawRadix = true;
@@ -11690,7 +11709,7 @@ Decimal128.fromString = function(string) {
 
     // No digits read
     if (!match || !match[2]) {
-      return new Decimal128(new Buffer(NAN_BUFFER));
+      return new Decimal128(utils.toBuffer(NAN_BUFFER));
     }
 
     // Get exponent
@@ -11702,7 +11721,7 @@ Decimal128.fromString = function(string) {
 
   // Return not a number
   if (string[index]) {
-    return new Decimal128(new Buffer(NAN_BUFFER));
+    return new Decimal128(utils.toBuffer(NAN_BUFFER));
   }
 
   // Done reading input
@@ -11750,7 +11769,7 @@ Decimal128.fromString = function(string) {
         exponent = EXPONENT_MAX;
         break;
       } else {
-        return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+        return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
       }
     }
 
@@ -11782,7 +11801,7 @@ Decimal128.fromString = function(string) {
         exponent = EXPONENT_MAX;
         break;
       } else {
-        return new Decimal128(new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
+        return new Decimal128(utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER));
       }
     }
   }
@@ -11832,7 +11851,7 @@ Decimal128.fromString = function(string) {
               digits[dIdx] = 1;
             } else {
               return new Decimal128(
-                new Buffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER)
+                utils.toBuffer(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER)
               );
             }
           }
@@ -11917,7 +11936,7 @@ Decimal128.fromString = function(string) {
   }
 
   // Encode into a buffer
-  var buffer = new Buffer(16);
+  var buffer = utils.allocBuffer(16);
   index = 0;
 
   // Encode the low 64 bits of the decimal
@@ -12187,8 +12206,7 @@ Decimal128.prototype.toJSON = function() {
 module.exports = Decimal128;
 module.exports.Decimal128 = Decimal128;
 
-}).call(this,require("buffer").Buffer)
-},{"./long":94,"buffer":106}],91:[function(require,module,exports){
+},{"./long":94,"./parser/utils":102}],91:[function(require,module,exports){
 /**
  * A class representation of the BSON Double type.
  *
@@ -13406,6 +13424,8 @@ module.exports.MinKey = MinKey;
 // Custom inspect property name / symbol.
 var inspect = 'inspect';
 
+var utils = require('./parser/utils');
+
 /**
  * Machine id.
  *
@@ -13463,7 +13483,7 @@ var ObjectID = function ObjectID(id) {
       'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
     );
   } else if (valid && typeof id === 'string' && id.length === 24 && hasBufferType) {
-    return new ObjectID(new Buffer(id, 'hex'));
+    return new ObjectID(utils.toBuffer(id, 'hex'));
   } else if (valid && typeof id === 'string' && id.length === 24) {
     return ObjectID.createFromHexString(id);
   } else if (id != null && id.length === 12) {
@@ -13563,7 +13583,7 @@ ObjectID.prototype.generate = function(time) {
       : process.pid) % 0xffff;
   var inc = this.get_inc();
   // Buffer used
-  var buffer = new Buffer(12);
+  var buffer = utils.allocBuffer(12);
   // Encode time
   buffer[3] = time & 0xff;
   buffer[2] = (time >> 8) & 0xff;
@@ -13682,7 +13702,7 @@ ObjectID.createPk = function createPk() {
 * @return {ObjectID} return the created ObjectID
 */
 ObjectID.createFromTime = function createFromTime(time) {
-  var buffer = new Buffer([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  var buffer = utils.toBuffer([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
   // Encode time into first 4 bytes
   buffer[3] = time & 0xff;
   buffer[2] = (time >> 8) & 0xff;
@@ -13720,7 +13740,7 @@ ObjectID.createFromHexString = function createFromHexString(string) {
   }
 
   // Use Buffer.from method if available
-  if (hasBufferType) return new ObjectID(new Buffer(string, 'hex'));
+  if (hasBufferType) return new ObjectID(utils.toBuffer(string, 'hex'));
 
   // Calculate lengths
   var array = new _Buffer(12);
@@ -13792,7 +13812,7 @@ module.exports.ObjectID = ObjectID;
 module.exports.ObjectId = ObjectID;
 
 }).call(this,require('_process'),require("buffer").Buffer)
-},{"_process":351,"buffer":106,"util":365}],99:[function(require,module,exports){
+},{"./parser/utils":102,"_process":366,"buffer":106,"util":380}],99:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -13888,7 +13908,7 @@ function calculateElement(name, value, serializeFunctions, isArray, ignoreUndefi
         value['_bsontype'] === 'MaxKey'
       ) {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + 1;
-      } else if (value instanceof ObjectID || value['_bsontype'] === 'ObjectID') {
+      } else if (value instanceof ObjectID || value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (12 + 1);
       } else if (value instanceof Date || isDate(value)) {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (8 + 1);
@@ -14052,7 +14072,6 @@ module.exports = calculateObjectSize;
 
 }).call(this,require("buffer").Buffer)
 },{"../binary":86,"../code":88,"../db_ref":89,"../decimal128":90,"../double":91,"../long":94,"../max_key":96,"../min_key":97,"../objectid":98,"../regexp":103,"../symbol":104,"../timestamp":105,"./utils":102,"buffer":106}],100:[function(require,module,exports){
-(function (Buffer){
 'use strict';
 
 var Long = require('../long').Long,
@@ -14068,6 +14087,8 @@ var Long = require('../long').Long,
   DBRef = require('../db_ref').DBRef,
   BSONRegExp = require('../regexp').BSONRegExp,
   Binary = require('../binary').Binary;
+
+var utils = require('./utils');
 
 var deserialize = function(buffer, options, isArray) {
   options = options == null ? {} : options;
@@ -14170,7 +14191,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       object[name] = buffer.toString('utf8', index, index + stringSize - 1);
       index = index + stringSize;
     } else if (elementType === BSON.BSON_DATA_OID) {
-      var oid = new Buffer(12);
+      var oid = utils.allocBuffer(12);
       buffer.copy(oid, 0, index, index + 12);
       object[name] = new ObjectID(oid);
       index = index + 12;
@@ -14275,7 +14296,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       }
     } else if (elementType === BSON.BSON_DATA_DECIMAL128) {
       // Buffer to contain the decimal bytes
-      var bytes = new Buffer(16);
+      var bytes = utils.allocBuffer(16);
       // Copy the next 16 bytes into the bytes buffer
       buffer.copy(bytes, 0, index, index + 16);
       // Update index
@@ -14575,7 +14596,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       index = index + stringSize;
 
       // Read the oid
-      var oidBuffer = new Buffer(12);
+      var oidBuffer = utils.allocBuffer(12);
       buffer.copy(oidBuffer, 0, index, index + 12);
       oid = new ObjectID(oidBuffer);
 
@@ -14834,14 +14855,12 @@ var JS_INT_MIN_LONG = Long.fromNumber(-0x20000000000000); // Any integer down to
 
 module.exports = deserialize;
 
-}).call(this,require("buffer").Buffer)
-},{"../binary":86,"../code":88,"../db_ref":89,"../decimal128":90,"../double":91,"../int_32":93,"../long":94,"../max_key":96,"../min_key":97,"../objectid":98,"../regexp":103,"../symbol":104,"../timestamp":105,"buffer":106}],101:[function(require,module,exports){
+},{"../binary":86,"../code":88,"../db_ref":89,"../decimal128":90,"../double":91,"../int_32":93,"../long":94,"../max_key":96,"../min_key":97,"../objectid":98,"../regexp":103,"../symbol":104,"../timestamp":105,"./utils":102}],101:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
 var writeIEEE754 = require('../float_parser').writeIEEE754,
   Long = require('../long').Long,
-  MinKey = require('../min_key').MinKey,
   Map = require('../map'),
   Binary = require('../binary').Binary;
 
@@ -15090,7 +15109,7 @@ var serializeMinMax = function(buffer, key, value, index, isArray) {
   // Write the type of either min or max key
   if (value === null) {
     buffer[index++] = BSON.BSON_DATA_NULL;
-  } else if (value instanceof MinKey) {
+  } else if (value._bsontype === 'MinKey') {
     buffer[index++] = BSON.BSON_DATA_MIN_KEY;
   } else {
     buffer[index++] = BSON.BSON_DATA_MAX_KEY;
@@ -15557,7 +15576,7 @@ var serializeInto = function serializeInto(
         index = serializeNull(buffer, key, value, index, true);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index, true);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index, true);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index, true);
@@ -15665,7 +15684,7 @@ var serializeInto = function serializeInto(
         // } else if (value === undefined && ignoreUndefined === true) {
       } else if (value === null || (value === undefined && ignoreUndefined === false)) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);
@@ -15767,7 +15786,7 @@ var serializeInto = function serializeInto(
         if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectID') {
+      } else if (value['_bsontype'] === 'ObjectID' || value['_bsontype'] === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);
@@ -16022,7 +16041,8 @@ BSON.JS_INT_MIN = -0x20000000000000; // Any integer down to -2^53 can be precise
 module.exports = serializeInto;
 
 }).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":245,"../binary":86,"../float_parser":92,"../long":94,"../map":95,"../min_key":97,"./utils":102}],102:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":244,"../binary":86,"../float_parser":92,"../long":94,"../map":95,"./utils":102}],102:[function(require,module,exports){
+(function (Buffer){
 'use strict';
 
 /**
@@ -16033,12 +16053,27 @@ function normalizedFunctionString(fn) {
   return fn.toString().replace(/function *\(/, 'function (');
 }
 
+function newBuffer(item, encoding) {
+  return new Buffer(item, encoding);
+}
+
+function allocBuffer() {
+  return Buffer.alloc.apply(Buffer, arguments);
+}
+
+function toBuffer() {
+  return Buffer.from.apply(Buffer, arguments);
+}
+
 module.exports = {
-  normalizedFunctionString: normalizedFunctionString
+  normalizedFunctionString: normalizedFunctionString,
+  allocBuffer: typeof Buffer.alloc === 'function' ? allocBuffer : newBuffer,
+  toBuffer: typeof Buffer.from === 'function' ? toBuffer : newBuffer
 };
 
 
-},{}],103:[function(require,module,exports){
+}).call(this,require("buffer").Buffer)
+},{"buffer":106}],103:[function(require,module,exports){
 /**
  * A class representation of the BSON RegExp type.
  *
@@ -16127,7 +16162,7 @@ module.exports = Symbol;
 module.exports.Symbol = Symbol;
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":106,"util":365}],105:[function(require,module,exports){
+},{"buffer":106,"util":380}],105:[function(require,module,exports){
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16984,6 +17019,7 @@ module.exports = Timestamp;
 module.exports.Timestamp = Timestamp;
 
 },{}],106:[function(require,module,exports){
+(function (Buffer){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -16996,6 +17032,10 @@ module.exports.Timestamp = Timestamp;
 
 var base64 = require('base64-js')
 var ieee754 = require('ieee754')
+var customInspectSymbol =
+  (typeof Symbol === 'function' && typeof Symbol.for === 'function')
+    ? Symbol.for('nodejs.util.inspect.custom')
+    : null
 
 exports.Buffer = Buffer
 exports.SlowBuffer = SlowBuffer
@@ -17032,7 +17072,9 @@ function typedArraySupport () {
   // Can typed array instances can be augmented?
   try {
     var arr = new Uint8Array(1)
-    arr.__proto__ = { __proto__: Uint8Array.prototype, foo: function () { return 42 } }
+    var proto = { foo: function () { return 42 } }
+    Object.setPrototypeOf(proto, Uint8Array.prototype)
+    Object.setPrototypeOf(arr, proto)
     return arr.foo() === 42
   } catch (e) {
     return false
@@ -17061,7 +17103,7 @@ function createBuffer (length) {
   }
   // Return an augmented `Uint8Array` instance
   var buf = new Uint8Array(length)
-  buf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(buf, Buffer.prototype)
   return buf
 }
 
@@ -17111,7 +17153,7 @@ function from (value, encodingOrOffset, length) {
   }
 
   if (value == null) {
-    throw TypeError(
+    throw new TypeError(
       'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
       'or Array-like Object. Received type ' + (typeof value)
     )
@@ -17163,8 +17205,8 @@ Buffer.from = function (value, encodingOrOffset, length) {
 
 // Note: Change prototype *after* Buffer.from is defined to workaround Chrome bug:
 // https://github.com/feross/buffer/pull/148
-Buffer.prototype.__proto__ = Uint8Array.prototype
-Buffer.__proto__ = Uint8Array
+Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype)
+Object.setPrototypeOf(Buffer, Uint8Array)
 
 function assertSize (size) {
   if (typeof size !== 'number') {
@@ -17268,7 +17310,8 @@ function fromArrayBuffer (array, byteOffset, length) {
   }
 
   // Return an augmented `Uint8Array` instance
-  buf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(buf, Buffer.prototype)
+
   return buf
 }
 
@@ -17590,6 +17633,9 @@ Buffer.prototype.inspect = function inspect () {
   if (this.length > max) str += ' ... '
   return '<Buffer ' + str + '>'
 }
+if (customInspectSymbol) {
+  Buffer.prototype[customInspectSymbol] = Buffer.prototype.inspect
+}
 
 Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
   if (isInstance(target, Uint8Array)) {
@@ -17715,7 +17761,7 @@ function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
         return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset)
       }
     }
-    return arrayIndexOf(buffer, [ val ], byteOffset, encoding, dir)
+    return arrayIndexOf(buffer, [val], byteOffset, encoding, dir)
   }
 
   throw new TypeError('val must be string, number or Buffer')
@@ -18044,7 +18090,7 @@ function hexSlice (buf, start, end) {
 
   var out = ''
   for (var i = start; i < end; ++i) {
-    out += toHex(buf[i])
+    out += hexSliceLookupTable[buf[i]]
   }
   return out
 }
@@ -18081,7 +18127,8 @@ Buffer.prototype.slice = function slice (start, end) {
 
   var newBuf = this.subarray(start, end)
   // Return an augmented `Uint8Array` instance
-  newBuf.__proto__ = Buffer.prototype
+  Object.setPrototypeOf(newBuf, Buffer.prototype)
+
   return newBuf
 }
 
@@ -18570,6 +18617,8 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
     }
   } else if (typeof val === 'number') {
     val = val & 255
+  } else if (typeof val === 'boolean') {
+    val = Number(val)
   }
 
   // Invalid ranges are not set to a default, so can range check early.
@@ -18625,11 +18674,6 @@ function base64clean (str) {
     str = str + '='
   }
   return str
-}
-
-function toHex (n) {
-  if (n < 16) return '0' + n.toString(16)
-  return n.toString(16)
 }
 
 function utf8ToBytes (string, units) {
@@ -18762,7 +18806,22 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":84,"ieee754":243}],107:[function(require,module,exports){
+// Create lookup table for `toString('hex')`
+// See: https://github.com/feross/buffer/issues/219
+var hexSliceLookupTable = (function () {
+  var alphabet = '0123456789abcdef'
+  var table = new Array(256)
+  for (var i = 0; i < 16; ++i) {
+    var i16 = i * 16
+    for (var j = 0; j < 16; ++j) {
+      table[i16 + j] = alphabet[i] + alphabet[j]
+    }
+  }
+  return table
+})()
+
+}).call(this,require("buffer").Buffer)
+},{"base64-js":84,"buffer":106,"ieee754":243}],107:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Code, CodeService, ValueSet, ref;
@@ -19137,35 +19196,41 @@ function numberIsNaN (obj) {
 
   module.exports.Repository = repository.Repository;
 
+  module.exports.Expression = expression.Expression;
+
   module.exports.Context = context.Context;
+
+  module.exports.Executor = exec.Executor;
 
   module.exports.PatientContext = context.PatientContext;
 
   module.exports.PopulationContext = context.PopulationContext;
 
-  module.exports.Executor = exec.Executor;
-
   module.exports.Results = results.Results;
-
-  module.exports.Code = datatypes.Code;
-
-  module.exports.Quantity = quantity.Quantity;
-
-  module.exports.Ratio = ratio.Ratio;
-
-  module.exports.Expression = expression.Expression;
-
-  module.exports.ValueSet = datatypes.ValueSet;
-
-  module.exports.DateTime = datatypes.DateTime;
-
-  module.exports.Interval = datatypes.Interval;
 
   module.exports.Patient = patient.Patient;
 
   module.exports.PatientSource = patient.PatientSource;
 
   module.exports.CodeService = codeservice.CodeService;
+
+  module.exports.Code = datatypes.Code;
+
+  module.exports.CodeSystem = datatypes.CodeSystem;
+
+  module.exports.Concept = datatypes.Concept;
+
+  module.exports.Date = datatypes.Date;
+
+  module.exports.DateTime = datatypes.DateTime;
+
+  module.exports.Interval = datatypes.Interval;
+
+  module.exports.Quantity = quantity.Quantity;
+
+  module.exports.Ratio = ratio.Ratio;
+
+  module.exports.ValueSet = datatypes.ValueSet;
 
 }).call(this);
 
@@ -20511,7 +20576,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../util/util":241,"./uncertainty":117,"moment":247}],114:[function(require,module,exports){
+},{"../util/util":241,"./uncertainty":117,"moment":246}],114:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Exception;
@@ -22227,7 +22292,7 @@ function numberIsNaN (obj) {
 },{"../util/util":241,"./expressions":127}],121:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
-  var AnyInValueSet, CalculateAge, CalculateAgeAt, CodeDef, CodeRef, CodeSystemDef, Concept, ConceptDef, ConceptRef, Expression, InValueSet, ValueSetDef, ValueSetRef, build, dt,
+  var AnyInValueSet, CalculateAge, CalculateAgeAt, Code, CodeDef, CodeRef, CodeSystemDef, Concept, ConceptDef, ConceptRef, Expression, InValueSet, ValueSetDef, ValueSetRef, build, dt,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
@@ -22264,11 +22329,12 @@ function numberIsNaN (obj) {
     function ValueSetRef(json) {
       ValueSetRef.__super__.constructor.apply(this, arguments);
       this.name = json.name;
+      this.libraryName = json.libraryName;
     }
 
     ValueSetRef.prototype.exec = function(ctx) {
       var valueset;
-      valueset = ctx.getValueSet(this.name);
+      valueset = ctx.getValueSet(this.name, this.libraryName);
       if (valueset instanceof Expression) {
         valueset = valueset.execute(ctx);
       }
@@ -22395,6 +22461,35 @@ function numberIsNaN (obj) {
     };
 
     return CodeRef;
+
+  })(Expression);
+
+  module.exports.Code = Code = (function(superClass) {
+    extend(Code, superClass);
+
+    function Code(json) {
+      Code.__super__.constructor.apply(this, arguments);
+      this.code = json.code;
+      this.systemName = json.system.name;
+      this.version = json.version;
+      this.display = json.display;
+    }
+
+    Object.defineProperties(Code.prototype, {
+      isCode: {
+        get: function() {
+          return true;
+        }
+      }
+    });
+
+    Code.prototype.exec = function(ctx) {
+      var ref, system;
+      system = (ref = ctx.getCodeSystem(this.systemName)) != null ? ref.id : void 0;
+      return new dt.Code(this.code, system, this.version, this.display);
+    };
+
+    return Code;
 
   })(Expression);
 
@@ -23387,6 +23482,9 @@ function numberIsNaN (obj) {
       codes = this.codes;
       if (this.codes && typeof this.codes.exec === 'function') {
         codes = this.codes.execute(ctx);
+        if (codes == null) {
+          return [];
+        }
       }
       if (codes) {
         records = records.filter((function(_this) {
@@ -24307,8 +24405,12 @@ function numberIsNaN (obj) {
       return this.expressions[identifier] || this.includes[identifier];
     };
 
-    Library.prototype.getValueSet = function(identifier) {
-      return this.valuesets[identifier];
+    Library.prototype.getValueSet = function(identifier, libraryName) {
+      var ref;
+      if (this.valuesets[identifier] != null) {
+        return this.valuesets[identifier];
+      }
+      return (ref = this.includes[libraryName]) != null ? ref.valuesets[identifier] : void 0;
     };
 
     Library.prototype.getCodeSystem = function(identifier) {
@@ -26013,7 +26115,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../datatypes/datatypes":112,"../datatypes/exception":114,"../util/math":240,"./builder":120,"./expression":126,"./reusable":141,"ucum":363}],139:[function(require,module,exports){
+},{"../datatypes/datatypes":112,"../datatypes/exception":114,"../util/math":240,"./builder":120,"./expression":126,"./reusable":141,"ucum":377}],139:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var AliasRef, AliasedQuerySource, ByColumn, ByDirection, ByExpression, Context, Expression, LetClause, MultiSource, Query, QueryLetRef, ReturnClause, Sort, SortClause, UnimplementedExpression, With, Without, allTrue, build, equals, ref, ref1, toDistinctList, typeIsArray,
@@ -63915,9 +64017,9 @@ function numberIsNaN (obj) {
       }
     };
 
-    Context.prototype.getValueSet = function(name) {
+    Context.prototype.getValueSet = function(name, library) {
       var ref;
-      return (ref = this.parent) != null ? ref.getValueSet(name) : void 0;
+      return (ref = this.parent) != null ? ref.getValueSet(name, library) : void 0;
     };
 
     Context.prototype.getCodeSystem = function(name) {
@@ -64072,6 +64174,8 @@ function numberIsNaN (obj) {
           return typeof val === "string";
         case "{urn:hl7-org:elm-types:r1}Concept":
           return val != null ? val.isConcept : void 0;
+        case "{urn:hl7-org:elm-types:r1}Code":
+          return val != null ? val.isCode : void 0;
         case "{urn:hl7-org:elm-types:r1}DateTime":
           return val != null ? val.isDateTime : void 0;
         case "{urn:hl7-org:elm-types:r1}Date":
@@ -64095,6 +64199,8 @@ function numberIsNaN (obj) {
           return typeof val === "number" && Math.floor(val) === val;
         case !inst.isStringLiteral:
           return typeof val === "string";
+        case !inst.isCode:
+          return val != null ? val.isCode : void 0;
         case !inst.isConcept:
           return val != null ? val.isConcept : void 0;
         case !inst.isDateTime:
@@ -64220,7 +64326,7 @@ function numberIsNaN (obj) {
 
 
 
-},{"../datatypes/datatypes":112,"../datatypes/exception":114,"../elm/library":131,"../util/util":241,"util":365}],236:[function(require,module,exports){
+},{"../datatypes/datatypes":112,"../datatypes/exception":114,"../elm/library":131,"../util/util":241,"util":380}],236:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.7
 (function() {
   var Executor, PatientContext, PopulationContext, Results, ref;
@@ -65559,8 +65665,6 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 }
 
 },{}],244:[function(require,module,exports){
-arguments[4][81][0].apply(exports,arguments)
-},{"dup":81}],245:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -65583,7 +65687,7 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],246:[function(require,module,exports){
+},{}],245:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -65982,6 +66086,10 @@ Kareem.prototype.pre = function(name, isAsync, fn, error, unshift) {
     ++pres.numAsync;
   }
 
+  if (typeof fn !== 'function') {
+    throw new Error('pre() requires a function, got "' + typeof fn + '"');
+  }
+
   if (unshift) {
     pres.unshift(Object.assign({}, options, { fn: fn, isAsync: isAsync }));
   } else {
@@ -65998,6 +66106,10 @@ Kareem.prototype.post = function(name, options, fn, unshift) {
     unshift = !!fn;
     fn = options;
     options = {};
+  }
+
+  if (typeof fn !== 'function') {
+    throw new Error('post() requires a function, got "' + typeof fn + '"');
   }
 
   if (unshift) {
@@ -66090,7 +66202,7 @@ function decorateNextFn(fn) {
 module.exports = Kareem;
 
 }).call(this,require('_process'))
-},{"_process":351}],247:[function(require,module,exports){
+},{"_process":366}],246:[function(require,module,exports){
 //! moment.js
 
 ;(function (global, factory) {
@@ -70694,7 +70806,7 @@ module.exports = Kareem;
 
 })));
 
-},{}],248:[function(require,module,exports){
+},{}],247:[function(require,module,exports){
 /**
  * Export lib/mongoose
  *
@@ -70704,7 +70816,7 @@ module.exports = Kareem;
 
 module.exports = require('./lib/browser');
 
-},{"./lib/browser":249}],249:[function(require,module,exports){
+},{"./lib/browser":248}],248:[function(require,module,exports){
 (function (Buffer){
 /* eslint-env browser */
 
@@ -70749,7 +70861,7 @@ exports.PromiseProvider = PromiseProvider;
  * @api public
  */
 
-exports.Error = require('./error');
+exports.Error = require('./error/index');
 
 /**
  * The Mongoose [Schema](#schema_Schema) constructor
@@ -70831,6 +70943,17 @@ exports.utils = require('./utils.js');
  */
 exports.Document = DocumentProvider();
 
+/**
+ * function stub for model
+ *
+ * @method model
+ * @api public
+ * @return null
+ */
+exports.model = function() {
+  return null;
+};
+
 /*!
  * Module exports.
  */
@@ -70841,7 +70964,7 @@ if (typeof window !== 'undefined') {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./document_provider.js":259,"./driver":260,"./drivers/browser":264,"./error":268,"./promise_provider":302,"./schema":304,"./schematype.js":325,"./types":332,"./utils.js":336,"./virtualtype":337,"buffer":106}],250:[function(require,module,exports){
+},{"./document_provider.js":258,"./driver":259,"./drivers/browser":263,"./error/index":267,"./promise_provider":313,"./schema":315,"./schematype.js":336,"./types":344,"./utils.js":348,"./virtualtype":349,"buffer":106}],249:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -70850,7 +70973,7 @@ if (typeof window !== 'undefined') {
 
 const NodeJSDocument = require('./document');
 const EventEmitter = require('events').EventEmitter;
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
 const Schema = require('./schema');
 const ObjectId = require('./types/objectid');
 const ValidationError = MongooseError.ValidationError;
@@ -70945,7 +71068,7 @@ utils.each(
 Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
-},{"./document":258,"./error":268,"./helpers/model/applyHooks":287,"./schema":304,"./types/objectid":334,"./utils":336,"events":242}],251:[function(require,module,exports){
+},{"./document":257,"./error/index":267,"./helpers/model/applyHooks":288,"./schema":315,"./types/objectid":346,"./utils":348,"events":242}],250:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -70973,6 +71096,12 @@ const ALLOWED_GEOWITHIN_GEOJSON_TYPES = ['Polygon', 'MultiPolygon'];
 module.exports = function cast(schema, obj, options, context) {
   if (Array.isArray(obj)) {
     throw new Error('Query filter must be an object, got an array ', util.inspect(obj));
+  }
+
+  // bson 1.x has the unfortunate tendency to remove filters that have a top-level
+  // `_bsontype` property. Should remove this when we upgrade to bson 4.x. See gh-8222
+  if (obj.hasOwnProperty('_bsontype')) {
+    delete obj._bsontype;
   }
 
   const paths = Object.keys(obj);
@@ -71185,7 +71314,7 @@ module.exports = function cast(schema, obj, options, context) {
             'schema, strict mode is `true`, and upsert is `true`.');
         } else if (options.strictQuery === 'throw') {
           throw new StrictModeError(path, 'Path "' + path + '" is not in ' +
-            'schema and strictQuery is true.');
+            'schema and strictQuery is \'throw\'.');
         } else if (options.strictQuery) {
           delete obj[path];
         }
@@ -71193,7 +71322,7 @@ module.exports = function cast(schema, obj, options, context) {
         continue;
       } else if (val.constructor.name === 'Object') {
         any$conditionals = Object.keys(val).some(function(k) {
-          return k.charAt(0) === '$' && k !== '$id' && k !== '$ref';
+          return k.startsWith('$') && k !== '$id' && k !== '$ref';
         });
 
         if (!any$conditionals) {
@@ -71214,7 +71343,7 @@ module.exports = function cast(schema, obj, options, context) {
             if ($cond === '$not') {
               if (nested && schematype && !schematype.caster) {
                 _keys = Object.keys(nested);
-                if (_keys.length && _keys[0].charAt(0) === '$') {
+                if (_keys.length && _keys[0].startsWith('$')) {
                   for (const key in nested) {
                     nested[key] = schematype.castForQueryWrapper({
                       $conditional: key,
@@ -71286,7 +71415,7 @@ function _cast(val, numbertype, context) {
     }
   }
 }
-},{"./error/strict":277,"./helpers/get":285,"./schema/index":312,"./schema/operators/text":321,"./utils":336,"util":365}],252:[function(require,module,exports){
+},{"./error/strict":276,"./helpers/get":286,"./schema/index":323,"./schema/operators/text":332,"./utils":348,"util":380}],251:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -71319,7 +71448,7 @@ module.exports = function castBoolean(value, path) {
 module.exports.convertToTrue = new Set([true, 'true', 1, '1', 'yes']);
 module.exports.convertToFalse = new Set([false, 'false', 0, '0', 'no']);
 
-},{"../error/cast":266}],253:[function(require,module,exports){
+},{"../error/cast":265}],252:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71361,7 +71490,7 @@ module.exports = function castDate(value) {
 
   assert.ok(false);
 };
-},{"assert":80}],254:[function(require,module,exports){
+},{"assert":80}],253:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -71400,7 +71529,7 @@ module.exports = function castDecimal128(value) {
   assert.ok(false);
 };
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../types/decimal128":329,"assert":80}],255:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../types/decimal128":341,"assert":80}],254:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71432,7 +71561,7 @@ module.exports = function castNumber(val) {
 
   assert.ok(!isNaN(val));
   if (val instanceof Number) {
-    return val;
+    return val.valueOf();
   }
   if (typeof val === 'number') {
     return val;
@@ -71441,13 +71570,13 @@ module.exports = function castNumber(val) {
     return Number(val.valueOf());
   }
   if (val.toString && !Array.isArray(val) && val.toString() == Number(val)) {
-    return new Number(val);
+    return Number(val);
   }
 
   assert.ok(false);
 };
 
-},{"assert":80}],256:[function(require,module,exports){
+},{"assert":80}],255:[function(require,module,exports){
 'use strict';
 
 const ObjectId = require('../driver').get().ObjectId;
@@ -71477,7 +71606,7 @@ module.exports = function castObjectId(value) {
 
   assert.ok(false);
 };
-},{"../driver":260,"assert":80}],257:[function(require,module,exports){
+},{"../driver":259,"assert":80}],256:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -71507,14 +71636,16 @@ module.exports = function castString(value, path) {
   // Re: gh-647 and gh-3030, we're ok with casting using `toString()`
   // **unless** its the default Object.toString, because "[object Object]"
   // doesn't really qualify as useful data
-  if (value.toString && value.toString !== Object.prototype.toString) {
+  if (value.toString &&
+      value.toString !== Object.prototype.toString &&
+      !Array.isArray(value)) {
     return value.toString();
   }
 
   throw new CastError('string', value, path);
 };
 
-},{"../error/cast":266}],258:[function(require,module,exports){
+},{"../error/cast":265}],257:[function(require,module,exports){
 (function (Buffer,process){
 'use strict';
 
@@ -71524,7 +71655,7 @@ module.exports = function castString(value, path) {
 
 const EventEmitter = require('events').EventEmitter;
 const InternalCache = require('./internal');
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
 const MixedSchema = require('./schema/mixed');
 const ObjectExpectedError = require('./error/objectExpected');
 const ObjectParameterError = require('./error/objectParameter');
@@ -71550,8 +71681,11 @@ const clone = utils.clone;
 const deepEqual = utils.deepEqual;
 const isMongooseObject = utils.isMongooseObject;
 
+const arrayAtomicsSymbol = require('./helpers/symbols').arrayAtomicsSymbol;
 const documentArrayParent = require('./helpers/symbols').documentArrayParent;
+const documentSchemaSymbol = require('./helpers/symbols').documentSchemaSymbol;
 const getSymbol = require('./helpers/symbols').getSymbol;
+const populateModelSymbol = require('./helpers/symbols').populateModelSymbol;
 
 let DocumentArray;
 let MongooseArray;
@@ -71618,13 +71752,15 @@ function Document(obj, fields, skipId, options) {
     $__hasIncludedChildren(fields) :
     {};
 
-  this.$__buildDoc(obj, fields, skipId, exclude, hasIncludedChildren, false);
+  if (this._doc == null) {
+    this.$__buildDoc(obj, fields, skipId, exclude, hasIncludedChildren, false);
 
-  // By default, defaults get applied **before** setting initial values
-  // Re: gh-6155
-  $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, true, {
-    isNew: this.isNew
-  });
+    // By default, defaults get applied **before** setting initial values
+    // Re: gh-6155
+    $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, true, {
+      isNew: this.isNew
+    });
+  }
 
   if (obj) {
     if (obj instanceof Document) {
@@ -71642,7 +71778,7 @@ function Document(obj, fields, skipId, options) {
   // see the full doc rather than an empty one, unless they opt out.
   // Re: gh-3781, gh-6155
   if (options.willInit) {
-    this.once('init', () => {
+    EventEmitter.prototype.once.call(this, 'init', () => {
       $__applyDefaults(this, fields, skipId, exclude, hasIncludedChildren, false, options.skipDefaults, {
         isNew: this.isNew
       });
@@ -71654,6 +71790,7 @@ function Document(obj, fields, skipId, options) {
   }
 
   this.$__._id = this._id;
+  this.$locals = {};
 
   if (!schema.options.strict && obj) {
     const _this = this;
@@ -71694,6 +71831,35 @@ Document.prototype.constructor = Document;
  */
 
 Document.prototype.schema;
+
+/**
+ * Empty object that you can use for storing properties on the document. This
+ * is handy for passing data to middleware without conflicting with Mongoose
+ * internals.
+ *
+ * ####Example:
+ *
+ *     schema.pre('save', function() {
+ *       // Mongoose will set `isNew` to `false` if `save()` succeeds
+ *       this.$locals.wasNew = this.isNew;
+ *     });
+ *
+ *     schema.post('save', function() {
+ *       // Prints true if `isNew` was set before `save()`
+ *       console.log(this.$locals.wasNew);
+ *     });
+ *
+ * @api public
+ * @property $locals
+ * @memberOf Document
+ * @instance
+ */
+
+Object.defineProperty(Document.prototype, '$locals', {
+  configurable: false,
+  enumerable: false,
+  writable: true
+});
 
 /**
  * Boolean flag specifying if the document is new.
@@ -71965,11 +72131,12 @@ Document.prototype.init = function(doc, opts, fn) {
 Document.prototype.$__init = function(doc, opts) {
   this.isNew = false;
   this.$init = true;
+  opts = opts || {};
 
   // handle docs with populated paths
   // If doc._id is not null or undefined
   if (doc._id !== null && doc._id !== undefined &&
-    opts && opts.populated && opts.populated.length) {
+    opts.populated && opts.populated.length) {
     const id = String(doc._id);
     for (let i = 0; i < opts.populated.length; ++i) {
       const item = opts.populated[i];
@@ -71981,7 +72148,7 @@ Document.prototype.$__init = function(doc, opts) {
     }
   }
 
-  init(this, doc, this._doc);
+  init(this, doc, this._doc, opts);
 
   this.emit('init', this);
   this.constructor.emit('init', this);
@@ -72000,7 +72167,7 @@ Document.prototype.$__init = function(doc, opts) {
  * @api private
  */
 
-function init(self, obj, doc, prefix) {
+function init(self, obj, doc, opts, prefix) {
   prefix = prefix || '';
 
   const keys = Object.keys(obj);
@@ -72031,7 +72198,7 @@ function init(self, obj, doc, prefix) {
       if (!doc[i]) {
         doc[i] = {};
       }
-      init(self, obj[i], doc[i], path + '.');
+      init(self, obj[i], doc[i], opts, path + '.');
     } else if (!schema) {
       doc[i] = obj[i];
     } else {
@@ -72040,6 +72207,7 @@ function init(self, obj, doc, prefix) {
       } else if (obj[i] !== undefined) {
         const intCache = obj[i].$__ || {};
         const wasPopulated = intCache.wasPopulated || null;
+
         if (schema && !wasPopulated) {
           try {
             doc[i] = schema.cast(obj[i], self, true);
@@ -72204,6 +72372,36 @@ Document.prototype.$session = function $session(session) {
 };
 
 /**
+ * Overwrite all values in this document with the values of `obj`, except
+ * for immutable properties. Behaves similarly to `set()`, except for it
+ * unsets all properties that aren't in `obj`.
+ *
+ * @param {Object} obj the object to overwrite this document with
+ * @method overwrite
+ * @name overwrite
+ * @memberOf Document
+ * @instance
+ * @api public
+ */
+
+Document.prototype.overwrite = function overwrite(obj) {
+  const keys = Array.from(new Set(Object.keys(this._doc).concat(Object.keys(obj))));
+
+  for (const key of keys) {
+    if (key === '_id') {
+      continue;
+    }
+    // Explicitly skip version key
+    if (this.schema.options.versionKey && key === this.schema.options.versionKey) {
+      continue;
+    }
+    this.$set(key, obj[key]);
+  }
+
+  return this;
+};
+
+/**
  * Alias for `set()`, used internally to avoid conflicts
  *
  * @param {String|Object} path path or object of key/vals to set
@@ -72276,6 +72474,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
       return this;
     }
+  } else {
+    this.$__.$setCalled.add(path);
   }
 
   function _handleIndex(i) {
@@ -72294,14 +72494,18 @@ Document.prototype.$set = function $set(path, val, type, options) {
       delete this._doc[key];
     }
 
-    if (utils.isPOJO(path[key]) &&
+    if (typeof path[key] === 'object' &&
+        !utils.isNativeObject(path[key]) &&
+        !utils.isMongooseType(path[key]) &&
+        path[key] != null &&
         pathtype !== 'virtual' &&
         pathtype !== 'real' &&
         !(this.$__path(pathName) instanceof MixedSchema) &&
         !(this.schema.paths[pathName] &&
         this.schema.paths[pathName].options &&
         this.schema.paths[pathName].options.ref)) {
-      this.$set(path[key], prefix + key, constructing);
+      this.$__.$setCalled.add(prefix + key);
+      this.$set(path[key], prefix + key, constructing, options);
     } else if (strict) {
       // Don't overwrite defaults with undefined keys (gh-3981)
       if (constructing && path[key] === void 0 &&
@@ -72321,10 +72525,10 @@ Document.prototype.$set = function $set(path, val, type, options) {
             path[key] instanceof Document) {
           p = p.toObject({ virtuals: false, transform: false });
         }
-        this.$set(prefix + key, p, constructing);
+        this.$set(prefix + key, p, constructing, options);
       } else if (pathtype === 'nested' && path[key] instanceof Document) {
         this.$set(prefix + key,
-          path[key].toObject({transform: false}), constructing);
+          path[key].toObject({transform: false}), constructing, options);
       } else if (strict === 'throw') {
         if (pathtype === 'nested') {
           throw new ObjectExpectedError(key, path[key]);
@@ -72333,22 +72537,32 @@ Document.prototype.$set = function $set(path, val, type, options) {
         }
       }
     } else if (path[key] !== void 0) {
-      this.$set(prefix + key, path[key], constructing);
+      this.$set(prefix + key, path[key], constructing, options);
     }
   }
 
-  const pathType = this.schema.pathType(path);
+  let pathType = this.schema.pathType(path);
+  if (pathType === 'adhocOrUndefined') {
+    pathType = getEmbeddedDiscriminatorPath(this, path, { typeOnly: true });
+  }
+
+  // Assume this is a Mongoose document that was copied into a POJO using
+  // `Object.assign()` or `{...doc}`
+  if (utils.isPOJO(val) && val.$__ != null && val._doc != null) {
+    val = val._doc;
+  }
+
   if (pathType === 'nested' && val) {
-    if (utils.isPOJO(val)) {
+    if (typeof val === 'object' && val != null) {
       if (!merge) {
-        this.setValue(path, null);
+        this.$__setValue(path, null);
         cleanModifiedSubpaths(this, path);
       } else {
         return this.$set(val, path, constructing);
       }
 
       const keys = Object.keys(val);
-      this.setValue(path, {});
+      this.$__setValue(path, {});
       for (const key of keys) {
         this.$set(path + '.' + key, val[key], constructing);
       }
@@ -72362,6 +72576,11 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
   let schema;
   const parts = path.split('.');
+
+  // Might need to change path for top-level alias
+  if (typeof this.schema.aliases[parts[0]] == 'string') {
+    parts[0] = this.schema.aliases[parts[0]];
+  }
 
   if (pathType === 'adhocOrUndefined' && strict) {
     // check for roots that are Mixed types
@@ -72423,7 +72642,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
       if (!this.isSelected(curPath)) {
         this.unmarkModified(curPath);
       }
-      cur = this.getValue(curPath);
+      cur = this.$__getValue(curPath);
     }
   }
 
@@ -72437,7 +72656,7 @@ Document.prototype.$set = function $set(path, val, type, options) {
   } else {
     for (i = 0; i < parts.length; ++i) {
       const subpath = parts.slice(0, i + 1).join('.');
-      if (this.get(subpath) === null) {
+      if (this.get(subpath, null, { getters: false }) === null) {
         pathToMark = subpath;
         break;
       }
@@ -72451,16 +72670,28 @@ Document.prototype.$set = function $set(path, val, type, options) {
   // if this doc is being constructed we should not trigger getters
   const priorVal = (() => {
     if (this.$__.$options.priorDoc != null) {
-      return this.$__.$options.priorDoc.getValue(path);
+      return this.$__.$options.priorDoc.$__getValue(path);
     }
     if (constructing) {
       return void 0;
     }
-    return this.getValue(path);
+    return this.$__getValue(path);
   })();
 
   if (!schema) {
     this.$__set(pathToMark, path, constructing, parts, schema, val, priorVal);
+    return this;
+  }
+
+  if (schema.$isSingleNested && val != null && merge) {
+    if (val instanceof Document) {
+      val = val.toObject({ virtuals: false, transform: false });
+    }
+    const keys = Object.keys(val);
+    for (const key of keys) {
+      this.$set(path + '.' + key, val[key], constructing, options);
+    }
+
     return this;
   }
 
@@ -72499,9 +72730,9 @@ Document.prototype.$set = function $set(path, val, type, options) {
     if (refMatches && val instanceof Document) {
       if (this.ownerDocument) {
         this.ownerDocument().populated(this.$__fullPath(path),
-          val._id, {model: val.constructor});
+          val._id, { [populateModelSymbol]: val.constructor });
       } else {
-        this.populated(path, val._id, {model: val.constructor});
+        this.populated(path, val._id, { [populateModelSymbol]: val.constructor });
       }
       didPopulate = true;
     }
@@ -72517,25 +72748,22 @@ Document.prototype.$set = function $set(path, val, type, options) {
         val[0].constructor.modelName &&
         (schema.options[this.schema.options.typeKey][0].ref === val[0].constructor.baseModelName || schema.options[this.schema.options.typeKey][0].ref === val[0].constructor.modelName)) {
       if (this.ownerDocument) {
-        popOpts = { model: val[0].constructor };
+        popOpts = { [populateModelSymbol]: val[0].constructor };
         this.ownerDocument().populated(this.$__fullPath(path),
           val.map(function(v) { return v._id; }), popOpts);
       } else {
-        popOpts = { model: val[0].constructor };
+        popOpts = { [populateModelSymbol]: val[0].constructor };
         this.populated(path, val.map(function(v) { return v._id; }), popOpts);
       }
       didPopulate = true;
     }
 
-    // If this path is underneath a single nested schema, we'll call the setter
-    // later in `$__set()` because we don't take `_doc` when we iterate through
-    // a single nested doc. That's to make sure we get the correct context.
-    // Otherwise we would double-call the setter, see gh-7196.
     if (this.schema.singleNestedPaths[path] == null) {
-      const setterContext = constructing && this.$__.$options.priorDoc ?
-        this.$__.$options.priorDoc :
-        this;
-      val = schema.applySetters(val, setterContext, false, priorVal);
+      // If this path is underneath a single nested schema, we'll call the setter
+      // later in `$__set()` because we don't take `_doc` when we iterate through
+      // a single nested doc. That's to make sure we get the correct context.
+      // Otherwise we would double-call the setter, see gh-7196.
+      val = schema.applySetters(val, this, false, priorVal);
     }
 
     if (!didPopulate && this.$__.populated) {
@@ -72544,8 +72772,12 @@ Document.prototype.$set = function $set(path, val, type, options) {
 
     this.$markValid(path);
   } catch (e) {
-    this.invalidate(path,
-      new MongooseError.CastError(schema.instance, val, path, e));
+    if (e instanceof MongooseError.StrictModeError && e.isImmutableError) {
+      this.invalidate(path, e);
+    } else {
+      this.invalidate(path,
+        new MongooseError.CastError(schema.instance, val, path, e));
+    }
     shouldSet = false;
   }
 
@@ -72688,7 +72920,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
       // Small hack for gh-1638: if we're overwriting the entire array, ignore
       // paths that were modified before the array overwrite
       this.$__.activePaths.forEach(function(modifiedPath) {
-        if (modifiedPath.indexOf(path + '.') === 0) {
+        if (modifiedPath.startsWith(path + '.')) {
           _this.$__.activePaths.ignore(modifiedPath);
         }
       });
@@ -72738,7 +72970,7 @@ Document.prototype.$__set = function(pathToMark, path, constructing, parts, sche
  * @api private
  */
 
-Document.prototype.getValue = function(path) {
+Document.prototype.$__getValue = function(path) {
   return utils.getValue(path, this._doc);
 };
 
@@ -72750,7 +72982,7 @@ Document.prototype.getValue = function(path) {
  * @api private
  */
 
-Document.prototype.setValue = function(path, val) {
+Document.prototype.$__setValue = function(path, val) {
   utils.setValue(path, val, this._doc);
   return this;
 };
@@ -72768,6 +73000,9 @@ Document.prototype.setValue = function(path, val) {
  *
  * @param {String} path
  * @param {Schema|String|Number|Buffer|*} [type] optionally specify a type for on-the-fly attributes
+ * @param {Object} [options]
+ * @param {Boolean} [options.virtuals=false] Apply virtuals before getting this path
+ * @param {Boolean} [options.getters=true] If false, skip applying getters and just get the raw value
  * @api public
  */
 
@@ -72778,7 +73013,16 @@ Document.prototype.get = function(path, type, options) {
     adhoc = this.schema.interpretAsType(path, type, this.schema.options);
   }
 
-  const schema = this.$__path(path) || this.schema.virtualpath(path);
+  let schema = this.$__path(path);
+  if (schema == null) {
+    schema = this.schema.virtualpath(path);
+  }
+  if (schema instanceof MixedSchema) {
+    const virtual = this.schema.virtualpath(path);
+    if (virtual != null) {
+      schema = virtual;
+    }
+  }
   const pieces = path.split('.');
   let obj = this._doc;
 
@@ -72787,6 +73031,11 @@ Document.prototype.get = function(path, type, options) {
       return void 0;
     }
     return schema.applyGetters(null, this);
+  }
+
+  // Might need to change path for top-level alias
+  if (typeof this.schema.aliases[pieces[0]] == 'string') {
+    pieces[0] = this.schema.aliases[pieces[0]];
   }
 
   for (let i = 0, l = pieces.length; i < l; i++) {
@@ -72809,11 +73058,11 @@ Document.prototype.get = function(path, type, options) {
     obj = adhoc.cast(obj);
   }
 
-  if (schema != null) {
+  if (schema != null && options.getters !== false) {
     obj = schema.applyGetters(obj, this);
   } else if (this.schema.nested[path] && options.virtuals) {
     // Might need to apply virtuals if this is a nested path
-    return applyGetters(this, utils.clone(obj), 'virtuals', { path: path });
+    return applyVirtuals(this, utils.clone(obj) || {}, { path: path });
   }
 
   return obj;
@@ -72907,6 +73156,95 @@ Document.prototype.$ignore = function(path) {
 };
 
 /**
+ * Returns the list of paths that have been directly modified. A direct
+ * modified path is a path that you explicitly set, whether via `doc.foo = 'bar'`,
+ * `Object.assign(doc, { foo: 'bar' })`, or `doc.set('foo', 'bar')`.
+ *
+ * A path `a` may be in `modifiedPaths()` but not in `directModifiedPaths()`
+ * because a child of `a` was directly modified.
+ *
+ * ####Example
+ *     const schema = new Schema({ foo: String, nested: { bar: String } });
+ *     const Model = mongoose.model('Test', schema);
+ *     await Model.create({ foo: 'original', nested: { bar: 'original' } });
+ *
+ *     const doc = await Model.findOne();
+ *     doc.nested.bar = 'modified';
+ *     doc.directModifiedPaths(); // ['nested.bar']
+ *     doc.modifiedPaths(); // ['nested', 'nested.bar']
+ *
+ * @return {Array}
+ * @api public
+ */
+
+Document.prototype.directModifiedPaths = function() {
+  return Object.keys(this.$__.activePaths.states.modify);
+};
+
+/**
+ * Returns true if the given path is nullish or only contains empty objects.
+ * Useful for determining whether this subdoc will get stripped out by the
+ * [minimize option](/docs/guide.html#minimize).
+ *
+ * ####Example:
+ *     const schema = new Schema({ nested: { foo: String } });
+ *     const Model = mongoose.model('Test', schema);
+ *     const doc = new Model({});
+ *     doc.$isEmpty('nested'); // true
+ *     doc.nested.$isEmpty(); // true
+ *
+ *     doc.nested.foo = 'bar';
+ *     doc.$isEmpty('nested'); // false
+ *     doc.nested.$isEmpty(); // false
+ *
+ * @memberOf Document
+ * @instance
+ * @api public
+ * @method $isEmpty
+ * @return {Boolean}
+ */
+
+Document.prototype.$isEmpty = function(path) {
+  const isEmptyOptions = {
+    minimize: true,
+    virtuals: false,
+    getters: false,
+    transform: false
+  };
+
+  if (arguments.length > 0) {
+    const v = this.get(path);
+    if (v == null) {
+      return true;
+    }
+    if (typeof v !== 'object') {
+      return false;
+    }
+    if (utils.isPOJO(v)) {
+      return _isEmpty(v);
+    }
+    return Object.keys(v.toObject(isEmptyOptions)).length === 0;
+  }
+
+  return Object.keys(this.toObject(isEmptyOptions)).length === 0;
+};
+
+function _isEmpty(v) {
+  if (v == null) {
+    return true;
+  }
+  if (typeof v !== 'object' || Array.isArray(v)) {
+    return false;
+  }
+  for (const key of Object.keys(v)) {
+    if (!_isEmpty(v[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Returns the list of paths that have been modified.
  *
  * @param {Object} [options]
@@ -72995,7 +73333,7 @@ Document.prototype.isModified = function(paths, modifiedPaths) {
     });
     return isModifiedChild || paths.some(function(path) {
       return directModifiedPaths.some(function(mod) {
-        return mod === path || path.indexOf(mod + '.') === 0;
+        return mod === path || path.startsWith(mod + '.');
       });
     });
   }
@@ -73143,11 +73481,11 @@ Document.prototype.isSelected = function isSelected(path) {
         continue;
       }
 
-      if (cur.indexOf(pathDot) === 0) {
+      if (cur.startsWith(pathDot)) {
         return inclusive || cur !== pathDot;
       }
 
-      if (pathDot.indexOf(cur + '.') === 0) {
+      if (pathDot.startsWith(cur + '.')) {
         return inclusive;
       }
     }
@@ -73243,9 +73581,11 @@ Document.prototype.validate = function(options, callback) {
     options = null;
   }
 
-  return utils.promiseOrCallback(callback, cb => this.$__validate(function(error) {
-    cb(error);
-  }), this.constructor.events);
+  return utils.promiseOrCallback(callback, cb => {
+    this.$__validate(options, function(error) {
+      cb(error);
+    });
+  }, this.constructor.events);
 };
 
 /*!
@@ -73325,11 +73665,19 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
-    if (val) {
+    const val = doc.$__getValue(path);
+    _pushNestedArrayPaths(val, paths, path);
+  }
+
+  function _pushNestedArrayPaths(val, paths, path) {
+    if (val != null) {
       const numElements = val.length;
       for (let j = 0; j < numElements; ++j) {
-        paths.push(path + '.' + j);
+        if (Array.isArray(val[j])) {
+          _pushNestedArrayPaths(val[j], paths, path + '.' + j);
+        } else {
+          paths.push(path + '.' + j);
+        }
       }
     }
   }
@@ -73339,15 +73687,12 @@ function _getPathsToValidate(doc) {
   for (i = 0; i < len; ++i) {
     const pathToCheck = paths[i];
     if (doc.schema.nested[pathToCheck]) {
-      let _v = doc.getValue(pathToCheck);
+      let _v = doc.$__getValue(pathToCheck);
       if (isMongooseObject(_v)) {
         _v = _v.toObject({ transform: false });
       }
-      const flat = flatten(_v, '', flattenOptions);
-      const _subpaths = Object.keys(flat).map(function(p) {
-        return pathToCheck + '.' + p;
-      });
-      paths = paths.concat(_subpaths);
+      const flat = flatten(_v, pathToCheck, flattenOptions, doc.schema);
+      paths = paths.concat(Object.keys(flat));
     }
   }
 
@@ -73359,7 +73704,7 @@ function _getPathsToValidate(doc) {
       continue;
     }
 
-    const val = doc.getValue(path);
+    const val = doc.$__getValue(path);
     if (val == null) {
       continue;
     }
@@ -73375,11 +73720,41 @@ function _getPathsToValidate(doc) {
  * ignore
  */
 
-Document.prototype.$__validate = function(callback) {
+Document.prototype.$__validate = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
+
   const _this = this;
   const _complete = () => {
-    const err = this.$__.validationError;
+    let err = this.$__.validationError;
     this.$__.validationError = undefined;
+
+    if (shouldValidateModifiedOnly && err != null) {
+      // Remove any validation errors that aren't from modified paths
+      const errors = Object.keys(err.errors);
+      for (const errPath of errors) {
+        if (!this.isModified(errPath)) {
+          delete err.errors[errPath];
+        }
+      }
+      if (Object.keys(err.errors).length === 0) {
+        err = void 0;
+      }
+    }
+
     this.$__.cachedRequired = {};
     this.emit('validate', _this);
     this.constructor.emit('validate', _this);
@@ -73397,7 +73772,9 @@ Document.prototype.$__validate = function(callback) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  const paths = pathDetails[0];
+  const paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (paths.length === 0) {
@@ -73446,7 +73823,15 @@ Document.prototype.$__validate = function(callback) {
         return;
       }
 
-      const val = _this.getValue(path);
+      let val = _this.$__getValue(path);
+
+      // If you `populate()` and get back a null value, required validators
+      // shouldn't fail (gh-8018). We should always fall back to the populated
+      // value.
+      let pop;
+      if (val == null && (pop = _this.populated(path))) {
+        val = pop;
+      }
       const scope = path in _this.$__.pathsToScopes ?
         _this.$__.pathsToScopes[path] :
         _this;
@@ -73461,7 +73846,7 @@ Document.prototype.$__validate = function(callback) {
           _this.invalidate(path, err, undefined, true);
         }
         --total || complete();
-      }, scope, { skipSchemaValidators: skipSchemaValidators[path] });
+      }, scope, { skipSchemaValidators: skipSchemaValidators[path], path: path });
     });
   };
 
@@ -73492,8 +73877,19 @@ Document.prototype.$__validate = function(callback) {
  * @api public
  */
 
-Document.prototype.validateSync = function(pathsToValidate) {
+Document.prototype.validateSync = function(pathsToValidate, options) {
   const _this = this;
+
+  const hasValidateModifiedOnlyOption = options &&
+      (typeof options === 'object') &&
+      ('validateModifiedOnly' in options);
+
+  let shouldValidateModifiedOnly;
+  if (hasValidateModifiedOnlyOption) {
+    shouldValidateModifiedOnly = !!options.validateModifiedOnly;
+  } else {
+    shouldValidateModifiedOnly = this.schema.options.validateModifiedOnly;
+  }
 
   if (typeof pathsToValidate === 'string') {
     pathsToValidate = pathsToValidate.split(' ');
@@ -73501,7 +73897,9 @@ Document.prototype.validateSync = function(pathsToValidate) {
 
   // only validate required fields when necessary
   const pathDetails = _getPathsToValidate(this);
-  let paths = pathDetails[0];
+  let paths = shouldValidateModifiedOnly ?
+    pathDetails[0].filter((path) => this.isModified(path)) :
+    pathDetails[0];
   const skipSchemaValidators = pathDetails[1];
 
   if (pathsToValidate && pathsToValidate.length) {
@@ -73531,9 +73929,10 @@ Document.prototype.validateSync = function(pathsToValidate) {
       return;
     }
 
-    const val = _this.getValue(path);
+    const val = _this.$__getValue(path);
     const err = p.doValidateSync(val, _this, {
-      skipSchemaValidators: skipSchemaValidators[path]
+      skipSchemaValidators: skipSchemaValidators[path],
+      path: path
     });
     if (err && (!p.$isMongooseDocumentArray || err.$isArrayValidatorError)) {
       if (p.$isSingleNested &&
@@ -73703,7 +74102,7 @@ Document.prototype.$__reset = function reset() {
 
   this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     })
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;
@@ -73718,14 +74117,14 @@ Document.prototype.$__reset = function reset() {
         doc.$__reset();
       }
 
-      _this.$__.activePaths.init(array._path);
+      _this.$__.activePaths.init(array.$path());
 
-      array._atomics = {};
+      array[arrayAtomicsSymbol] = {};
     });
 
   this.$__.activePaths.
     map('init', 'modify', function(i) {
-      return _this.getValue(i);
+      return _this.$__getValue(i);
     }).
     filter(function(val) {
       return val && val.$isSingleNested;
@@ -73739,8 +74138,8 @@ Document.prototype.$__reset = function reset() {
   this.$__dirty().forEach(function(dirt) {
     const type = dirt.value;
 
-    if (type && type._atomics) {
-      type._atomics = {};
+    if (type && type[arrayAtomicsSymbol]) {
+      type[arrayAtomicsSymbol] = {};
     }
   });
 
@@ -73772,7 +74171,7 @@ Document.prototype.$__dirty = function() {
   let all = this.$__.activePaths.map('modify', function(path) {
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   });
@@ -73780,12 +74179,12 @@ Document.prototype.$__dirty = function() {
   // gh-2558: if we had to set a default and the value is not undefined,
   // we have to save as well
   all = all.concat(this.$__.activePaths.map('default', function(path) {
-    if (path === '_id' || _this.getValue(path) == null) {
+    if (path === '_id' || _this.$__getValue(path) == null) {
       return;
     }
     return {
       path: path,
-      value: _this.getValue(path),
+      value: _this.$__getValue(path),
       schema: _this.$__path(path)
     };
   }));
@@ -73804,19 +74203,20 @@ Document.prototype.$__dirty = function() {
     if (!item) {
       return;
     }
-    if (item.path.indexOf(lastPath) !== 0) {
+    if (lastPath == null || item.path.indexOf(lastPath) !== 0) {
       lastPath = item.path + '.';
       minimal.push(item);
       top = item;
-    } else {
+    } else if (top != null &&
+        top.value != null &&
+        top.value[arrayAtomicsSymbol] != null &&
+        top.value.hasAtomics()) {
       // special case for top level MongooseArrays
-      if (top.value && top.value._atomics && top.value.hasAtomics()) {
-        // the `top` array itself and a sub path of `top` are being modified.
-        // the only way to honor all of both modifications is through a $set
-        // of entire array.
-        top.value._atomics = {};
-        top.value._atomics.$set = top.value;
-      }
+      // the `top` array itself and a sub path of `top` are being modified.
+      // the only way to honor all of both modifications is through a $set
+      // of entire array.
+      top.value[arrayAtomicsSymbol] = {};
+      top.value[arrayAtomicsSymbol].$set = top.value;
     }
   });
 
@@ -73844,6 +74244,7 @@ Document.prototype.$__setSchema = function(schema) {
   }
 
   this.schema = schema;
+  this[documentSchemaSymbol] = schema;
 };
 
 
@@ -73862,7 +74263,7 @@ Document.prototype.$__getArrayPathsToValidate = function() {
   // validate all document arrays.
   return this.$__.activePaths
     .map('init', 'modify', function(i) {
-      return this.getValue(i);
+      return this.$__getValue(i);
     }.bind(this))
     .filter(function(val) {
       return val && val instanceof Array && val.isMongooseDocumentArray && val.length;
@@ -73889,39 +74290,41 @@ Document.prototype.$__getAllSubdocs = function() {
   Embedded = Embedded || require('./types/embedded');
 
   function docReducer(doc, seed, path) {
-    const val = path ? doc[path] : doc;
+    let val = doc;
+    if (path) {
+      if (doc instanceof Document && doc[documentSchemaSymbol].paths[path]) {
+        val = doc._doc[path];
+      } else {
+        val = doc[path];
+      }
+    }
     if (val instanceof Embedded) {
       seed.push(val);
-    }
-    else if (val instanceof Map) {
+    } else if (val instanceof Map) {
       seed = Array.from(val.keys()).reduce(function(seed, path) {
         return docReducer(val.get(path), seed, null);
       }, seed);
-    }
-    else if (val && val.$isSingleNested) {
+    } else if (val && val.$isSingleNested) {
       seed = Object.keys(val._doc).reduce(function(seed, path) {
         return docReducer(val._doc, seed, path);
       }, seed);
       seed.push(val);
-    }
-    else if (val && val.isMongooseDocumentArray) {
+    } else if (val && val.isMongooseDocumentArray) {
       val.forEach(function _docReduce(doc) {
         if (!doc || !doc._doc) {
           return;
         }
-        if (doc instanceof Embedded) {
-          seed.push(doc);
-        }
         seed = Object.keys(doc._doc).reduce(function(seed, path) {
           return docReducer(doc._doc, seed, path);
         }, seed);
+        if (doc instanceof Embedded) {
+          seed.push(doc);
+        }
       });
     } else if (val instanceof Document && val.$__isNested) {
-      if (val) {
-        seed = Object.keys(val).reduce(function(seed, path) {
-          return docReducer(val, seed, path);
-        }, seed);
-      }
+      seed = Object.keys(val).reduce(function(seed, path) {
+        return docReducer(val, seed, path);
+      }, seed);
     }
     return seed;
   }
@@ -74041,7 +74444,7 @@ Document.prototype.$toObject = function(options, json) {
   let ret = clone(this._doc, cloneOptions) || {};
 
   if (options.getters) {
-    applyGetters(this, ret, 'paths', cloneOptions);
+    applyGetters(this, ret, cloneOptions);
     // applyGetters for paths will add nested empty objects;
     // if minimize is set, we need to remove them.
     if (options.minimize) {
@@ -74050,7 +74453,7 @@ Document.prototype.$toObject = function(options, json) {
   }
 
   if (options.virtuals || options.getters && options.virtuals !== false) {
-    applyGetters(this, ret, 'virtuals', cloneOptions);
+    applyVirtuals(this, ret, cloneOptions, options);
   }
 
   if (options.versionKey === false && this.schema.options.versionKey) {
@@ -74188,7 +74591,7 @@ Document.prototype.$toObject = function(options, json) {
  *
  * Transforms are applied _only to the document and are not applied to sub-documents_.
  *
- * Transforms, like all of these options, are also available for `toJSON`.
+ * Transforms, like all of these options, are also available for `toJSON`. See [this guide to `JSON.stringify()`](https://thecodebarbarian.com/the-80-20-guide-to-json-stringify-in-javascript.html) to learn why `toJSON()` and `toObject()` are separate functions.
  *
  * See [schema options](/docs/guide.html#toObject) for some more details.
  *
@@ -74196,7 +74599,8 @@ Document.prototype.$toObject = function(options, json) {
  *
  * @param {Object} [options]
  * @param {Boolean} [options.getters=false] if true, apply all getters, including virtuals
- * @param {Boolean} [options.virtuals=false] if true, apply virtuals. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals
+ * @param {Boolean} [options.virtuals=false] if true, apply virtuals, including aliases. Use `{ getters: true, virtuals: false }` to just apply getters, not virtuals
+ * @param {Boolean} [options.aliases=true] if `options.virtuals = true`, you can set `options.aliases = false` to skip applying aliases. This option is a no-op if `options.virtuals = false`.
  * @param {Boolean} [options.minimize=true] if true, omit any empty objects from the output
  * @param {Function|null} [options.transform=null] if set, mongoose will call this function to allow you to transform the returned object
  * @param {Boolean} [options.depopulate=false] if true, replace any conventionally populated paths with the original id in the output. Has no affect on virtual populated paths.
@@ -74250,55 +74654,76 @@ function minimize(obj) {
 
 /*!
  * Applies virtuals properties to `json`.
- *
- * @param {Document} self
- * @param {Object} json
- * @param {String} type either `virtuals` or `paths`
- * @return {Object} `json`
  */
 
-function applyGetters(self, json, type, options) {
+function applyVirtuals(self, json, options, toObjectOptions) {
   const schema = self.schema;
-  const paths = Object.keys(schema[type]);
+  const paths = Object.keys(schema.virtuals);
   let i = paths.length;
   const numPaths = i;
   let path;
   let assignPath;
   let cur = self._doc;
   let v;
+  const aliases = get(toObjectOptions, 'aliases', true);
 
   if (!cur) {
     return json;
   }
 
-  if (type === 'virtuals') {
-    options = options || {};
-    for (i = 0; i < numPaths; ++i) {
-      path = paths[i];
-      // We may be applying virtuals to a nested object, for example if calling
-      // `doc.nestedProp.toJSON()`. If so, the path we assign to, `assignPath`,
-      // will be a trailing substring of the `path`.
-      assignPath = path;
-      if (options.path != null) {
-        if (!path.startsWith(options.path + '.')) {
-          continue;
-        }
-        assignPath = path.substr(options.path.length + 1);
-      }
-      const parts = assignPath.split('.');
-      v = clone(self.get(path), options);
-      if (v === void 0) {
-        continue;
-      }
-      const plen = parts.length;
-      cur = json;
-      for (let j = 0; j < plen - 1; ++j) {
-        cur[parts[j]] = cur[parts[j]] || {};
-        cur = cur[parts[j]];
-      }
-      cur[parts[plen - 1]] = v;
+  options = options || {};
+  for (i = 0; i < numPaths; ++i) {
+    path = paths[i];
+
+    // Allow skipping aliases with `toObject({ virtuals: true, aliases: false })`
+    if (!aliases && schema.aliases.hasOwnProperty(path)) {
+      continue;
     }
 
+    // We may be applying virtuals to a nested object, for example if calling
+    // `doc.nestedProp.toJSON()`. If so, the path we assign to, `assignPath`,
+    // will be a trailing substring of the `path`.
+    assignPath = path;
+    if (options.path != null) {
+      if (!path.startsWith(options.path + '.')) {
+        continue;
+      }
+      assignPath = path.substr(options.path.length + 1);
+    }
+    const parts = assignPath.split('.');
+    v = clone(self.get(path), options);
+    if (v === void 0) {
+      continue;
+    }
+    const plen = parts.length;
+    cur = json;
+    for (let j = 0; j < plen - 1; ++j) {
+      cur[parts[j]] = cur[parts[j]] || {};
+      cur = cur[parts[j]];
+    }
+    cur[parts[plen - 1]] = v;
+  }
+
+  return json;
+}
+
+/*!
+ * Applies virtuals properties to `json`.
+ *
+ * @param {Document} self
+ * @param {Object} json
+ * @return {Object} `json`
+ */
+
+function applyGetters(self, json, options) {
+  const schema = self.schema;
+  const paths = Object.keys(schema.paths);
+  let i = paths.length;
+  let path;
+  let cur = self._doc;
+  let v;
+
+  if (!cur) {
     return json;
   }
 
@@ -74311,6 +74736,10 @@ function applyGetters(self, json, type, options) {
     let branch = json;
     let part;
     cur = self._doc;
+
+    if (!self.isSelected(path)) {
+      continue;
+    }
 
     for (let ii = 0; ii < plen; ++ii) {
       part = parts[ii];
@@ -74350,6 +74779,7 @@ function applyGetters(self, json, type, options) {
  * @param {Object} options
  * @return {Object}
  * @see Document#toObject #document_Document-toObject
+ * @see JSON.stringify() in JavaScript https://thecodebarbarian.com/the-80-20-guide-to-json-stringify-in-javascript.html
  * @api public
  * @memberOf Document
  * @instance
@@ -74375,7 +74805,15 @@ Document.prototype.inspect = function(options) {
     opts = options;
     opts.minimize = false;
   }
-  return this.toObject(opts);
+  const ret = this.toObject(opts);
+
+  if (ret == null) {
+    // If `toObject()` returns null, `this` is still an object, so if `inspect()`
+    // prints out null this can cause some serious confusion. See gh-7942.
+    return 'MongooseDocument { ' + ret + ' }';
+  }
+
+  return ret;
 };
 
 if (inspect.custom) {
@@ -74396,7 +74834,11 @@ if (inspect.custom) {
  */
 
 Document.prototype.toString = function() {
-  return inspect(this.inspect());
+  const ret = this.inspect();
+  if (typeof ret === 'string') {
+    return ret;
+  }
+  return inspect(ret);
 };
 
 /**
@@ -74596,7 +75038,6 @@ Document.prototype.populated = function(path, val, options) {
   }
 
   // internal
-
   if (val === true) {
     if (!this.$__.populated) {
       return undefined;
@@ -74606,6 +75047,22 @@ Document.prototype.populated = function(path, val, options) {
 
   this.$__.populated || (this.$__.populated = {});
   this.$__.populated[path] = {value: val, options: options};
+
+  // If this was a nested populate, make sure each populated doc knows
+  // about its populated children (gh-7685)
+  const pieces = path.split('.');
+  for (let i = 0; i < pieces.length - 1; ++i) {
+    const subpath = pieces.slice(0, i + 1).join('.');
+    const subdoc = this.get(subpath);
+    if (subdoc != null && subdoc.$__ != null && this.populated(subpath)) {
+      const rest = pieces.slice(i + 1).join('.');
+      subdoc.populated(rest, val, options);
+      // No need to continue because the above recursion should take care of
+      // marking the rest of the docs as populated
+      break;
+    }
+  }
+
   return val;
 };
 
@@ -74666,7 +75123,7 @@ Document.prototype.depopulate = function(path) {
     if (virtualKeys.indexOf(path[i]) !== -1) {
       delete this.$$populatedVirtuals[path[i]];
       delete this._doc[path[i]];
-    } else {
+    } else if (populatedIds) {
       this.$set(path[i], populatedIds);
     }
   }
@@ -74698,7 +75155,7 @@ Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")},require('_process'))
-},{"../../is-buffer/index.js":245,"./error":268,"./error/objectExpected":273,"./error/objectParameter":274,"./error/strict":277,"./helpers/common":281,"./helpers/document/cleanModifiedSubpaths":282,"./helpers/document/compile":283,"./helpers/document/getEmbeddedDiscriminatorPath":284,"./helpers/get":285,"./helpers/projection/isDefiningProjection":290,"./helpers/projection/isExclusive":291,"./helpers/symbols":296,"./internal":299,"./options":300,"./plugins/idGetter":301,"./schema/mixed":314,"./schematype":325,"./types/array":327,"./types/documentarray":330,"./types/embedded":331,"./utils":336,"./virtualtype":337,"_process":351,"events":242,"mpath":339,"util":365}],259:[function(require,module,exports){
+},{"../../is-buffer/index.js":244,"./error/index":267,"./error/objectExpected":272,"./error/objectParameter":273,"./error/strict":276,"./helpers/common":280,"./helpers/document/cleanModifiedSubpaths":283,"./helpers/document/compile":284,"./helpers/document/getEmbeddedDiscriminatorPath":285,"./helpers/get":286,"./helpers/projection/isDefiningProjection":291,"./helpers/projection/isExclusive":292,"./helpers/symbols":299,"./internal":302,"./options":303,"./plugins/idGetter":312,"./schema/mixed":325,"./schematype":336,"./types/array":338,"./types/documentarray":342,"./types/embedded":343,"./utils":348,"./virtualtype":349,"_process":366,"events":242,"mpath":352,"util":380}],258:[function(require,module,exports){
 'use strict';
 
 /* eslint-env browser */
@@ -74730,7 +75187,7 @@ module.exports.setBrowser = function(flag) {
   isBrowser = flag;
 };
 
-},{"./browserDocument.js":250,"./document.js":258}],260:[function(require,module,exports){
+},{"./browserDocument.js":249,"./document.js":257}],259:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -74747,7 +75204,7 @@ module.exports.set = function(v) {
   driver = v;
 };
 
-},{}],261:[function(require,module,exports){
+},{}],260:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -74756,7 +75213,7 @@ module.exports.set = function(v) {
 
 module.exports = function() {};
 
-},{}],262:[function(require,module,exports){
+},{}],261:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -74772,7 +75229,7 @@ const Binary = require('bson').Binary;
 
 module.exports = exports = Binary;
 
-},{"bson":87}],263:[function(require,module,exports){
+},{"bson":87}],262:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -74781,7 +75238,7 @@ module.exports = exports = Binary;
 
 module.exports = require('bson').Decimal128;
 
-},{"bson":87}],264:[function(require,module,exports){
+},{"bson":87}],263:[function(require,module,exports){
 /*!
  * Module exports.
  */
@@ -74796,7 +75253,7 @@ exports.Decimal128 = require('./decimal128');
 exports.ObjectId = require('./objectid');
 exports.ReadPreference = require('./ReadPreference');
 
-},{"./ReadPreference":261,"./binary":262,"./decimal128":263,"./objectid":265}],265:[function(require,module,exports){
+},{"./ReadPreference":260,"./binary":261,"./decimal128":262,"./objectid":264}],264:[function(require,module,exports){
 
 /*!
  * [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) ObjectId
@@ -74826,7 +75283,7 @@ Object.defineProperty(ObjectId.prototype, '_id', {
 
 module.exports = exports = ObjectId;
 
-},{"bson":87}],266:[function(require,module,exports){
+},{"bson":87}],265:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -74848,7 +75305,7 @@ const util = require('util');
 function CastError(type, value, path, reason) {
   let stringValue = util.inspect(value);
   stringValue = stringValue.replace(/^'/, '"').replace(/'$/, '"');
-  if (stringValue.charAt(0) !== '"') {
+  if (!stringValue.startsWith('"')) {
     stringValue = '"' + stringValue + '"';
   }
   MongooseError.call(this, 'Cast to ' + type + ' failed for value ' +
@@ -74890,7 +75347,7 @@ CastError.prototype.setModel = function(model) {
 
 module.exports = CastError;
 
-},{"./mongooseError":271,"util":365}],267:[function(require,module,exports){
+},{"./mongooseError":270,"util":380}],266:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -74940,10 +75397,52 @@ DivergentArrayError.prototype.constructor = MongooseError;
 
 module.exports = DivergentArrayError;
 
-},{"./":268}],268:[function(require,module,exports){
+},{"./":267}],267:[function(require,module,exports){
 'use strict';
 
+/**
+ * MongooseError constructor. MongooseError is the base class for all
+ * Mongoose-specific errors.
+ *
+ * ####Example:
+ *     const Model = mongoose.model('Test', new Schema({ answer: Number }));
+ *     const doc = new Model({ answer: 'not a number' });
+ *     const err = doc.validateSync();
+ *
+ *     err instanceof mongoose.Error; // true
+ *
+ * @constructor Error
+ * @param {String} msg Error message
+ * @inherits Error https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
+ */
+
 const MongooseError = require('./mongooseError');
+
+/**
+ * The name of the error. The name uniquely identifies this Mongoose error. The
+ * possible values are:
+ *
+ * - `MongooseError`: general Mongoose error
+ * - `CastError`: Mongoose could not convert a value to the type defined in the schema path. May be in a `ValidationError` class' `errors` property.
+ * - `DisconnectedError`: This [connection](connections.html) timed out in trying to reconnect to MongoDB and will not successfully reconnect to MongoDB unless you explicitly reconnect.
+ * - `DivergentArrayError`: You attempted to `save()` an array that was modified after you loaded it with a `$elemMatch` or similar projection
+ * - `MissingSchemaError`: You tried to access a model with [`mongoose.model()`](api.html#mongoose_Mongoose-model) that was not defined
+ * - `DocumentNotFoundError`: The document you tried to [`save()`](api.html#document_Document-save) was not found
+ * - `ValidatorError`: error from an individual schema path's validator
+ * - `ValidationError`: error returned from [`validate()`](api.html#document_Document-validate) or [`validateSync()`](api.html#document_Document-validateSync). Contains zero or more `ValidatorError` instances in `.errors` property.
+ * - `MissingSchemaError`: You called `mongoose.Document()` without a schema
+ * - `ObjectExpectedError`: Thrown when you set a nested path to a non-object value with [strict mode set](guide.html#strict).
+ * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a paramter
+ * - `OverwriteModelError`: Thrown when you call [`mongoose.model()`](api.html#mongoose_Mongoose-model) to re-define a model that was already defined.
+ * - `ParallelSaveError`: Thrown when you call [`save()`](api.html#model_Model-save) on a document when the same document instance is already saving.
+ * - `StrictModeError`: Thrown when you set a path that isn't the schema and [strict mode](guide.html#strict) is set to `throw`.
+ * - `VersionError`: Thrown when the [document is out of sync](guide.html#versionKey)
+ *
+ * @api public
+ * @property {String} name
+ * @memberOf Error
+ * @instance
+ */
 
 /*!
  * Module exports.
@@ -74956,6 +75455,8 @@ module.exports = exports = MongooseError;
  *
  * @see Error.messages #error_messages_MongooseError-messages
  * @api public
+ * @memberOf Error
+ * @static messages
  */
 
 MongooseError.messages = require('./messages');
@@ -74971,6 +75472,8 @@ MongooseError.Messages = MongooseError.messages;
  * the document.
  *
  * @api public
+ * @memberOf Error
+ * @static DocumentNotFoundError
  */
 
 MongooseError.DocumentNotFoundError = require('./notFound');
@@ -74980,6 +75483,8 @@ MongooseError.DocumentNotFoundError = require('./notFound');
  * cast a value.
  *
  * @api public
+ * @memberOf Error
+ * @static CastError
  */
 
 MongooseError.CastError = require('./cast');
@@ -74990,6 +75495,8 @@ MongooseError.CastError = require('./cast');
  * instances of CastError or ValidationError.
  *
  * @api public
+ * @memberOf Error
+ * @static ValidationError
  */
 
 MongooseError.ValidationError = require('./validation');
@@ -74998,6 +75505,8 @@ MongooseError.ValidationError = require('./validation');
  * A `ValidationError` has a hash of `errors` that contain individual `ValidatorError` instances
  *
  * @api public
+ * @memberOf Error
+ * @static ValidatorError
  */
 
 MongooseError.ValidatorError = require('./validator');
@@ -75008,6 +75517,8 @@ MongooseError.ValidatorError = require('./validator');
  * the [`versionKey` option](/docs/guide.html#versionKey) for more information.
  *
  * @api public
+ * @memberOf Error
+ * @static VersionError
  */
 
 MongooseError.VersionError = require('./version');
@@ -75018,6 +75529,8 @@ MongooseError.VersionError = require('./version');
  * information.
  *
  * @api public
+ * @memberOf Error
+ * @static ParallelSaveError
  */
 
 MongooseError.ParallelSaveError = require('./parallelSave');
@@ -75027,6 +75540,8 @@ MongooseError.ParallelSaveError = require('./parallelSave');
  * See [the FAQ about `OverwriteModelError`](/docs/faq.html#overwrite-model-error).
  *
  * @api public
+ * @memberOf Error
+ * @static OverwriteModelError
  */
 
 MongooseError.OverwriteModelError = require('./overwriteModel');
@@ -75035,6 +75550,8 @@ MongooseError.OverwriteModelError = require('./overwriteModel');
  * Thrown when you try to access a model that has not been registered yet
  *
  * @api public
+ * @memberOf Error
+ * @static MissingSchemaError
  */
 
 MongooseError.MissingSchemaError = require('./missingSchema');
@@ -75044,11 +75561,25 @@ MongooseError.MissingSchemaError = require('./missingSchema');
  * and then modified the array in an unsafe way.
  *
  * @api public
+ * @memberOf Error
+ * @static DivergentArrayError
  */
 
 MongooseError.DivergentArrayError = require('./divergentArray');
 
-},{"./cast":266,"./divergentArray":267,"./messages":269,"./missingSchema":270,"./mongooseError":271,"./notFound":272,"./overwriteModel":275,"./parallelSave":276,"./validation":278,"./validator":279,"./version":280}],269:[function(require,module,exports){
+/**
+ * Thrown when your try to pass values to model contrtuctor that
+ * were not specified in schema or change immutable properties when
+ * `strict` mode is `"throw"`
+ *
+ * @api public
+ * @memberOf Error
+ * @static StrictModeError
+ */
+
+MongooseError.StrictModeError = require('./strict');
+
+},{"./cast":265,"./divergentArray":266,"./messages":268,"./missingSchema":269,"./mongooseError":270,"./notFound":271,"./overwriteModel":274,"./parallelSave":275,"./strict":276,"./validation":277,"./validator":278,"./version":279}],268:[function(require,module,exports){
 
 /**
  * The default built-in validator error messages. These may be customized.
@@ -75096,7 +75627,7 @@ msg.String.match = 'Path `{PATH}` is invalid ({VALUE}).';
 msg.String.minlength = 'Path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).';
 msg.String.maxlength = 'Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length ({MAXLENGTH}).';
 
-},{}],270:[function(require,module,exports){
+},{}],269:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -75137,15 +75668,11 @@ MissingSchemaError.prototype.constructor = MongooseError;
 
 module.exports = MissingSchemaError;
 
-},{"./":268}],271:[function(require,module,exports){
+},{"./":267}],270:[function(require,module,exports){
 'use strict';
 
-/**
- * MongooseError constructor. MongooseError is the base class for all
- * Mongoose-specific errors.
- *
- * @param {String} msg Error message
- * @inherits Error https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
+/*!
+ * ignore
  */
 
 function MongooseError(msg) {
@@ -75166,35 +75693,8 @@ function MongooseError(msg) {
 MongooseError.prototype = Object.create(Error.prototype);
 MongooseError.prototype.constructor = Error;
 
-/**
- * The name of the error. The name uniquely identifies this Mongoose error. The
- * possible values are:
- *
- * - `MongooseError`: general Mongoose error
- * - `CastError`: Mongoose could not convert a value to the type defined in the schema path. May be in a `ValidationError` class' `errors` property.
- * - `DisconnectedError`: This [connection](connections.html) timed out in trying to reconnect to MongoDB and will not successfully reconnect to MongoDB unless you explicitly reconnect.
- * - `DivergentArrayError`: You attempted to `save()` an array that was modified after you loaded it with a `$elemMatch` or similar projection
- * - `MissingSchemaError`: You tried to access a model with [`mongoose.model()`](api.html#mongoose_Mongoose-model) that was not defined
- * - `DocumentNotFoundError`: The document you tried to [`save()`](api.html#document_Document-save) was not found
- * - `ValidatorError`: error from an individual schema path's validator
- * - `ValidationError`: error returned from [`validate()`](api.html#document_Document-validate) or [`validateSync()`](api.html#document_Document-validateSync). Contains zero or more `ValidatorError` instances in `.errors` property.
- * - `MissingSchemaError`: You called `mongoose.Document()` without a schema
- * - `ObjectExpectedError`: Thrown when you set a nested path to a non-object value with [strict mode set](guide.html#strict).
- * - `ObjectParameterError`: Thrown when you pass a non-object value to a function which expects an object as a paramter
- * - `OverwriteModelError`: Thrown when you call [`mongoose.model()`](api.html#mongoose_Mongoose-model) to re-define a model that was already defined.
- * - `ParallelSaveError`: Thrown when you call [`save()`](api.html#model_Model-save) on a document when the same document instance is already saving.
- * - `StrictModeError`: Thrown when you set a path that isn't the schema and [strict mode](guide.html#strict) is set to `throw`.
- * - `VersionError`: Thrown when the [document is out of sync](guide.html#versionKey)
- *
- * @api public
- * @property name
- * @memberOf MongooseError
- * @instance
- */
-
 module.exports = MongooseError;
-
-},{}],272:[function(require,module,exports){
+},{}],271:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75210,20 +75710,23 @@ const util = require('util');
  * @inherits MongooseError
  */
 
-function DocumentNotFoundError(filter) {
+function DocumentNotFoundError(filter, model, numAffected, result) {
   let msg;
   const messages = MongooseError.messages;
   if (messages.DocumentNotFoundError != null) {
     msg = typeof messages.DocumentNotFoundError === 'function' ?
-      messages.DocumentNotFoundError(filter) :
+      messages.DocumentNotFoundError(filter, model) :
       messages.DocumentNotFoundError;
   } else {
-    msg = 'No document found for query "' + util.inspect(filter) + '"';
+    msg = 'No document found for query "' + util.inspect(filter) +
+      '" on model "' + model + '"';
   }
 
   MongooseError.call(this, msg);
 
   this.name = 'DocumentNotFoundError';
+  this.result = result;
+  this.numAffected = numAffected;
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
@@ -75248,7 +75751,7 @@ DocumentNotFoundError.prototype.constructor = MongooseError;
 
 module.exports = DocumentNotFoundError;
 
-},{"./":268,"util":365}],273:[function(require,module,exports){
+},{"./":267,"util":380}],272:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75267,8 +75770,9 @@ const MongooseError = require('./');
  */
 
 function ObjectExpectedError(path, val) {
+  const typeDescription = Array.isArray(val) ? 'array' : 'primitive value';
   MongooseError.call(this, 'Tried to set nested object field `' + path +
-    '` to primitive value `' + val + '` and strict mode is set to throw.');
+    `\` to ${typeDescription} \`` + val + '` and strict mode is set to throw.');
   this.name = 'ObjectExpectedError';
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
@@ -75287,7 +75791,7 @@ ObjectExpectedError.prototype.constructor = MongooseError;
 
 module.exports = ObjectExpectedError;
 
-},{"./":268}],274:[function(require,module,exports){
+},{"./":267}],273:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75327,7 +75831,7 @@ ObjectParameterError.prototype.constructor = MongooseError;
 
 module.exports = ObjectParameterError;
 
-},{"./":268}],275:[function(require,module,exports){
+},{"./":267}],274:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -75366,7 +75870,7 @@ OverwriteModelError.prototype.constructor = MongooseError;
 
 module.exports = OverwriteModelError;
 
-},{"./":268}],276:[function(require,module,exports){
+},{"./":267}],275:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75401,7 +75905,7 @@ ParallelSaveError.prototype.constructor = MongooseError;
 
 module.exports = ParallelSaveError;
 
-},{"./":268}],277:[function(require,module,exports){
+},{"./":267}],276:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75419,11 +75923,12 @@ const MongooseError = require('./');
  * @api private
  */
 
-function StrictModeError(path, msg) {
+function StrictModeError(path, msg, immutable) {
   msg = msg || 'Field `' + path + '` is not in schema and strict ' +
     'mode is set to throw.';
   MongooseError.call(this, msg);
   this.name = 'StrictModeError';
+  this.isImmutableError = !!immutable;
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
@@ -75441,7 +75946,7 @@ StrictModeError.prototype.constructor = MongooseError;
 
 module.exports = StrictModeError;
 
-},{"./":268}],278:[function(require,module,exports){
+},{"./":267}],277:[function(require,module,exports){
 /*!
  * Module requirements
  */
@@ -75462,19 +75967,21 @@ const util = require('util');
 function ValidationError(instance) {
   this.errors = {};
   this._message = '';
+
+  MongooseError.call(this, this._message);
   if (instance && instance.constructor.name === 'model') {
     this._message = instance.constructor.modelName + ' validation failed';
-    MongooseError.call(this, this._message);
   } else {
     this._message = 'Validation failed';
-    MongooseError.call(this, this._message);
   }
   this.name = 'ValidationError';
+
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this);
   } else {
     this.stack = new Error().stack;
   }
+
   if (instance) {
     instance.errors = this.errors;
   }
@@ -75555,7 +76062,7 @@ function _generateMessage(err) {
 
 module.exports = exports = ValidationError;
 
-},{"./":268,"util":365}],279:[function(require,module,exports){
+},{"./":267,"util":380}],278:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -75646,7 +76153,7 @@ ValidatorError.prototype.toString = function() {
 
 module.exports = ValidatorError;
 
-},{"./":268}],280:[function(require,module,exports){
+},{"./":267}],279:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75684,7 +76191,7 @@ VersionError.prototype.constructor = MongooseError;
 
 module.exports = VersionError;
 
-},{"./":268}],281:[function(require,module,exports){
+},{"./":267}],280:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -75692,6 +76199,7 @@ module.exports = VersionError;
  * Module dependencies.
  */
 
+const Decimal128 = require('../types/decimal128');
 const ObjectId = require('../types/objectid');
 const utils = require('../utils');
 
@@ -75702,7 +76210,7 @@ exports.modifiedPaths = modifiedPaths;
  * ignore
  */
 
-function flatten(update, path, options) {
+function flatten(update, path, options, schema) {
   let keys;
   if (update && utils.isMongooseObject(update) && !Buffer.isBuffer(update)) {
     keys = Object.keys(update.toObject({ transform: false, virtuals: false }));
@@ -75718,11 +76226,16 @@ function flatten(update, path, options) {
     const key = keys[i];
     const val = update[key];
     result[path + key] = val;
+
+    // Avoid going into mixed paths if schema is specified
+    const keySchema = schema && schema.path && schema.path(path + key);
+    if (keySchema && keySchema.instance === 'Mixed') continue;
+
     if (shouldFlatten(val)) {
       if (options && options.skipArrays && Array.isArray(val)) {
         continue;
       }
-      const flat = flatten(val, path + key, options);
+      const flat = flatten(val, path + key, options, schema);
       for (const k in flat) {
         result[k] = flat[k];
       }
@@ -75771,11 +76284,51 @@ function shouldFlatten(val) {
     !(val instanceof Date) &&
     !(val instanceof ObjectId) &&
     (!Array.isArray(val) || val.length > 0) &&
-    !(val instanceof Buffer);
+    !(val instanceof Buffer) &&
+    !(val instanceof Decimal128);
 }
 
 }).call(this,require("buffer").Buffer)
-},{"../types/objectid":334,"../utils":336,"buffer":106}],282:[function(require,module,exports){
+},{"../types/decimal128":341,"../types/objectid":346,"../utils":348,"buffer":106}],281:[function(require,module,exports){
+'use strict';
+
+module.exports = function checkEmbeddedDiscriminatorKeyProjection(userProjection, path, schema, selected, addedPaths) {
+  const userProjectedInPath = Object.keys(userProjection).
+    reduce((cur, key) => cur || key.startsWith(path + '.'), false);
+  const _discriminatorKey = path + '.' + schema.options.discriminatorKey;
+  if (!userProjectedInPath &&
+      addedPaths.length === 1 &&
+      addedPaths[0] === _discriminatorKey) {
+    selected.splice(selected.indexOf(_discriminatorKey), 1);
+  }
+};
+},{}],282:[function(require,module,exports){
+'use strict';
+
+const getDiscriminatorByValue = require('../../queryhelpers').getDiscriminatorByValue;
+
+/*!
+ * Find the correct constructor, taking into account discriminators
+ */
+
+module.exports = function getConstructor(Constructor, value) {
+  const discriminatorKey = Constructor.schema.options.discriminatorKey;
+  if (value != null &&
+      Constructor.discriminators &&
+      value[discriminatorKey] != null) {
+    if (Constructor.discriminators[value[discriminatorKey]]) {
+      Constructor = Constructor.discriminators[value[discriminatorKey]];
+    } else {
+      const constructorByValue = getDiscriminatorByValue(Constructor, value[discriminatorKey]);
+      if (constructorByValue) {
+        Constructor = constructorByValue;
+      }
+    }
+  }
+
+  return Constructor;
+};
+},{"../../queryhelpers":314}],283:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -75787,6 +76340,9 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   const skipDocArrays = options.skipDocArrays;
 
   let deleted = 0;
+  if (!doc) {
+    return deleted;
+  }
   for (const modifiedPath of Object.keys(doc.$__.activePaths.states.modify)) {
     if (skipDocArrays) {
       const schemaType = doc.schema.path(modifiedPath);
@@ -75794,7 +76350,7 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
         continue;
       }
     }
-    if (modifiedPath.indexOf(path + '.') === 0) {
+    if (modifiedPath.startsWith(path + '.')) {
       delete doc.$__.activePaths.states.modify[modifiedPath];
       ++deleted;
     }
@@ -75802,9 +76358,10 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   return deleted;
 };
 
-},{}],283:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 'use strict';
 
+const documentSchemaSymbol = require('../../helpers/symbols').documentSchemaSymbol;
 const get = require('../../helpers/get');
 const getSymbol = require('../../helpers/symbols').getSymbol;
 const utils = require('../../utils');
@@ -75876,6 +76433,13 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
             value: prototype.schema
           });
 
+          Object.defineProperty(nested, documentSchemaSymbol, {
+            enumerable: false,
+            configurable: true,
+            writable: false,
+            value: prototype.schema
+          });
+
           Object.defineProperty(nested, 'toObject', {
             enumerable: false,
             configurable: true,
@@ -75903,6 +76467,21 @@ function defineKey(prop, subprops, prototype, prefix, keys, options) {
             configurable: true,
             writable: false,
             value: true
+          });
+
+          const _isEmptyOptions = Object.freeze({
+            minimize: true,
+            virtuals: false,
+            getters: false,
+            transform: false
+          });
+          Object.defineProperty(nested, '$isEmpty', {
+            enumerable: false,
+            configurable: true,
+            writable: false,
+            value: function() {
+              return Object.keys(this.get(path, null, _isEmptyOptions) || {}).length === 0;
+            }
           });
 
           compile(subprops, nested, path, options);
@@ -75945,13 +76524,13 @@ function getOwnPropertyDescriptors(object) {
       delete result[key];
       return;
     }
-    result[key].enumerable = ['isNew', '$__', 'errors', '_doc'].indexOf(key) === -1;
+    result[key].enumerable = ['isNew', '$__', 'errors', '_doc', '$locals'].indexOf(key) === -1;
   });
 
   return result;
 }
 
-},{"../../document":258,"../../helpers/get":285,"../../helpers/symbols":296,"../../utils":336}],284:[function(require,module,exports){
+},{"../../document":257,"../../helpers/get":286,"../../helpers/symbols":299,"../../utils":348}],285:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -75972,7 +76551,11 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
     const subpath = parts.slice(0, i + 1).join('.');
     schema = doc.schema.path(subpath);
     if (schema == null) {
+      type = 'adhocOrUndefined';
       continue;
+    }
+    if (schema.instance === 'Mixed') {
+      return typeOnly ? 'real' : schema;
     }
     type = doc.schema.pathType(subpath);
     if ((schema.$isSingleNested || schema.$isMongooseDocumentArrayElement) &&
@@ -75984,11 +76567,7 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
         continue;
       }
       const rest = parts.slice(i + 1).join('.');
-      schema = discriminators[discriminatorKey].path(rest);
-      if (schema != null) {
-        type = discriminators[discriminatorKey].pathType(rest);
-        break;
-      }
+      return getEmbeddedDiscriminatorPath(doc.get(subpath), rest, options);
     }
   }
 
@@ -75996,7 +76575,7 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
   return typeOnly ? type : schema;
 };
 
-},{"../get":285}],285:[function(require,module,exports){
+},{"../get":286}],286:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76036,7 +76615,7 @@ function getProperty(obj, prop) {
   }
   return obj[prop];
 }
-},{}],286:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 (function (process){
 /*!
  * Centralize this so we can more easily work around issues with people
@@ -76052,7 +76631,7 @@ module.exports = function immediate(cb) {
 };
 
 }).call(this,require('_process'))
-},{"_process":351}],287:[function(require,module,exports){
+},{"_process":366}],288:[function(require,module,exports){
 'use strict';
 
 const symbols = require('../../schema/symbols');
@@ -76069,6 +76648,7 @@ module.exports = applyHooks;
  */
 
 applyHooks.middlewareFunctions = [
+  'deleteOne',
   'save',
   'validate',
   'remove',
@@ -76095,12 +76675,22 @@ function applyHooks(model, schema, options) {
   const objToDecorate = options.decorateDoc ? model : model.prototype;
 
   model.$appliedHooks = true;
-  for (let i = 0; i < schema.childSchemas.length; ++i) {
-    const childModel = schema.childSchemas[i].model;
+  for (const key of Object.keys(schema.paths)) {
+    const type = schema.paths[key];
+    let childModel = null;
+    if (type.$isSingleNested) {
+      childModel = type.caster;
+    } else if (type.$isMongooseDocumentArray) {
+      childModel = type.Constructor;
+    } else {
+      continue;
+    }
+
     if (childModel.$appliedHooks) {
       continue;
     }
-    applyHooks(childModel, schema.childSchemas[i].schema, options);
+
+    applyHooks(childModel, type.schema, options);
     if (childModel.discriminators != null) {
       const keys = Object.keys(childModel.discriminators);
       for (let j = 0; j < keys.length; ++j) {
@@ -76116,7 +76706,7 @@ function applyHooks(model, schema, options) {
 
   const middleware = schema.s.hooks.
     filter(hook => {
-      if (hook.name === 'updateOne') {
+      if (hook.name === 'updateOne' || hook.name === 'deleteOne') {
         return !!hook['document'];
       }
       if (hook.name === 'remove') {
@@ -76137,10 +76727,14 @@ function applyHooks(model, schema, options) {
 
   objToDecorate.$__save = middleware.
     createWrapper('save', objToDecorate.$__save, null, kareemOptions);
+
+  objToDecorate.$__originalValidate = objToDecorate.$__originalValidate || objToDecorate.$__validate;
   objToDecorate.$__validate = middleware.
-    createWrapper('validate', objToDecorate.$__validate, null, kareemOptions);
+    createWrapper('validate', objToDecorate.$__originalValidate, null, kareemOptions);
   objToDecorate.$__remove = middleware.
     createWrapper('remove', objToDecorate.$__remove, null, kareemOptions);
+  objToDecorate.$__deleteOne = middleware.
+    createWrapper('deleteOne', objToDecorate.$__deleteOne, null, kareemOptions);
   objToDecorate.$__init = middleware.
     createWrapperSync('init', objToDecorate.$__init, null, kareemOptions);
 
@@ -76176,7 +76770,7 @@ function applyHooks(model, schema, options) {
   }
 }
 
-},{"../../schema/symbols":324,"../../utils":336}],288:[function(require,module,exports){
+},{"../../schema/symbols":335,"../../utils":348}],289:[function(require,module,exports){
 'use strict';
 
 const defineKey = require('../document/compile').defineKey;
@@ -76217,15 +76811,23 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
 
   const key = model.schema.options.discriminatorKey;
 
-  const baseSchemaAddition = {};
-  baseSchemaAddition[key] = {
-    default: void 0,
-    select: true,
-    $skipDiscriminatorCheck: true
-  };
-  baseSchemaAddition[key][model.schema.options.typeKey] = String;
-  model.schema.add(baseSchemaAddition);
-  defineKey(key, null, model.prototype, null, [key], model.schema.options);
+  const existingPath = model.schema.path(key);
+  if (existingPath != null) {
+    if (!utils.hasUserDefinedProperty(existingPath.options, 'select')) {
+      existingPath.options.select = true;
+    }
+    existingPath.options.$skipDiscriminatorCheck = true;
+  } else {
+    const baseSchemaAddition = {};
+    baseSchemaAddition[key] = {
+      default: void 0,
+      select: true,
+      $skipDiscriminatorCheck: true
+    };
+    baseSchemaAddition[key][model.schema.options.typeKey] = String;
+    model.schema.add(baseSchemaAddition);
+    defineKey(key, null, model.prototype, null, [key], model.schema.options);
+  }
 
   if (schema.path(key) && schema.path(key).options.$skipDiscriminatorCheck !== true) {
     throw new Error('Discriminator "' + name +
@@ -76239,7 +76841,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
 
   function merge(schema, baseSchema) {
     // Retain original schema before merging base schema
-    schema._originalSchema = schema.clone();
+    schema._baseSchema = baseSchema;
     if (baseSchema.paths._id &&
         baseSchema.paths._id.options &&
         !baseSchema.paths._id.options.auto) {
@@ -76261,7 +76863,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     }
 
     utils.merge(schema, baseSchema, {
-      omit: { discriminators: true, $parentSchema: true },
+      omit: { discriminators: true },
       omitNested: conflictingPaths.reduce((cur, path) => {
         cur['tree.' + path] = true;
         return cur;
@@ -76272,6 +76874,11 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
     for (let i = 0; i < conflictingPaths.length; ++i) {
       delete schema.paths[conflictingPaths[i]];
     }
+
+    // Rebuild schema models because schemas may have been merged re: #7884
+    schema.childSchemas.forEach(obj => {
+      obj.model.prototype.$__setSchema(obj.schema);
+    });
 
     const obj = {};
     obj[key] = {
@@ -76285,7 +76892,9 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
       },
       $skipDiscriminatorCheck: true
     };
-    obj[key][schema.options.typeKey] = String;
+    obj[key][schema.options.typeKey] = existingPath ?
+      existingPath.instance :
+      String;
     schema.add(obj);
     schema.discriminatorMapping = {key: key, value: value, isRoot: false};
 
@@ -76350,7 +76959,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
   return schema;
 };
 
-},{"../../utils":336,"../document/compile":283,"../get":285}],289:[function(require,module,exports){
+},{"../../utils":348,"../document/compile":284,"../get":286}],290:[function(require,module,exports){
 'use strict';
 
 const MongooseError = require('../../error/mongooseError');
@@ -76370,7 +76979,7 @@ function validateRef(ref, path) {
   throw new MongooseError('Invalid ref at path "' + path + '". Got ' +
     util.inspect(ref, { depth: 0 }));
 }
-},{"../../error/mongooseError":271,"util":365}],290:[function(require,module,exports){
+},{"../../error/mongooseError":270,"util":380}],291:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76390,7 +76999,7 @@ module.exports = function isDefiningProjection(val) {
   return true;
 };
 
-},{}],291:[function(require,module,exports){
+},{}],292:[function(require,module,exports){
 'use strict';
 
 const isDefiningProjection = require('./isDefiningProjection');
@@ -76420,7 +77029,7 @@ module.exports = function isExclusive(projection) {
   return exclude;
 };
 
-},{"./isDefiningProjection":290}],292:[function(require,module,exports){
+},{"./isDefiningProjection":291}],293:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76438,6 +77047,7 @@ applyQueryMiddleware.middlewareFunctions = [
   'countDocuments',
   'deleteMany',
   'deleteOne',
+  'distinct',
   'estimatedDocumentCount',
   'find',
   'findOne',
@@ -76449,7 +77059,8 @@ applyQueryMiddleware.middlewareFunctions = [
   'replaceOne',
   'update',
   'updateMany',
-  'updateOne'
+  'updateOne',
+  'validate'
 ];
 
 /*!
@@ -76467,10 +77078,13 @@ function applyQueryMiddleware(Query, model) {
   };
 
   const middleware = model.hooks.filter(hook => {
-    if (hook.name === 'updateOne') {
+    if (hook.name === 'updateOne' || hook.name === 'deleteOne') {
       return hook.query == null || !!hook.query;
     }
     if (hook.name === 'remove') {
+      return !!hook.query;
+    }
+    if (hook.name === 'validate') {
       return !!hook.query;
     }
     return true;
@@ -76479,16 +77093,36 @@ function applyQueryMiddleware(Query, model) {
   // `update()` thunk has a different name because `_update` was already taken
   Query.prototype._execUpdate = middleware.createWrapper('update',
     Query.prototype._execUpdate, null, kareemOptions);
+  // `distinct()` thunk has a different name because `_distinct` was already taken
+  Query.prototype.__distinct = middleware.createWrapper('distinct',
+    Query.prototype.__distinct, null, kareemOptions);
+
+  // `validate()` doesn't have a thunk because it doesn't execute a query.
+  Query.prototype.validate = middleware.createWrapper('validate',
+    Query.prototype.validate, null, kareemOptions);
 
   applyQueryMiddleware.middlewareFunctions.
-    filter(v => v !== 'update').
+    filter(v => v !== 'update' && v !== 'distinct' && v !== 'validate').
     forEach(fn => {
       Query.prototype[`_${fn}`] = middleware.createWrapper(fn,
         Query.prototype[`_${fn}`], null, kareemOptions);
     });
 }
 
-},{}],293:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
+'use strict';
+
+/**
+ * For consistency's sake, we replace positional operator `$` and array filters
+ * `$[]` and `$[foo]` with `0` when looking up schema paths.
+ */
+
+module.exports = function cleanPositionalOperators(path) {
+  return path.
+    replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
+    replace(/\.(\[[^\]]*\])?\$$/g, '.0');
+};
+},{}],295:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -76504,7 +77138,7 @@ module.exports = function getIndexes(schema) {
   const schemaStack = new WeakMap();
   const indexTypes = schema.constructor.indexTypes;
 
-  const collectIndexes = function(schema, prefix) {
+  const collectIndexes = function(schema, prefix, baseSchema) {
     // Ignore infinitely nested schemas, if we've already seen this schema
     // along this path there must be a cycle
     if (schemaStack.has(schema)) {
@@ -76519,6 +77153,11 @@ module.exports = function getIndexes(schema) {
     for (let i = 0; i < length; ++i) {
       const key = keys[i];
       const path = schema.paths[key];
+      if (baseSchema != null && baseSchema.paths[key]) {
+        // If looking at an embedded discriminator schema, don't look at paths
+        // that the
+        continue;
+      }
 
       if (path.$isMongooseDocumentArray || path.$isSingleNested) {
         if (get(path, 'options.excludeIndexes') !== true &&
@@ -76530,8 +77169,8 @@ module.exports = function getIndexes(schema) {
           const discriminators = path.schema.discriminators;
           const discriminatorKeys = Object.keys(discriminators);
           for (const discriminatorKey of discriminatorKeys) {
-            collectIndexes(discriminators[discriminatorKey]._originalSchema,
-              prefix + key + '.');
+            collectIndexes(discriminators[discriminatorKey],
+              prefix + key + '.', path.schema);
           }
         }
 
@@ -76614,7 +77253,7 @@ module.exports = function getIndexes(schema) {
   }
 };
 
-},{"../../utils":336,"../get":285}],294:[function(require,module,exports){
+},{"../../utils":348,"../get":286}],296:[function(require,module,exports){
 'use strict';
 
 module.exports = handleTimestampOption;
@@ -76639,11 +77278,11 @@ function handleTimestampOption(arg, prop) {
   }
   return arg[prop];
 }
-},{}],295:[function(require,module,exports){
+},{}],297:[function(require,module,exports){
 'use strict';
 
 module.exports = function merge(s1, s2) {
-  s1.add(s2.obj);
+  s1.add(s2.obj || {});
 
   s1.callQueue = s1.callQueue.concat(s2.callQueue);
   s1.method(s2.methods);
@@ -76654,26 +77293,76 @@ module.exports = function merge(s1, s2) {
   }
 
   for (const virtual in s2.virtuals) {
-    s1.virtual[virtual] = s2.virtual[virtual].clone();
+    s1.virtuals[virtual] = s2.virtuals[virtual].clone();
   }
 
   s1.s.hooks.merge(s2.s.hooks, false);
 };
-},{}],296:[function(require,module,exports){
+
+},{}],298:[function(require,module,exports){
 'use strict';
 
-exports.validatorErrorSymbol = Symbol.for('mongoose:validatorError');
+const StrictModeError = require('../../error/strict');
 
-exports.documentArrayParent = Symbol.for('mongoose:documentArrayParent');
+/*!
+ * ignore
+ */
 
-exports.modelSymbol = Symbol.for('mongoose#Model');
+module.exports = function(schematype) {
+  if (schematype.$immutable) {
+    schematype.$immutableSetter = createImmutableSetter(schematype.path,
+      schematype.options.immutable);
+    schematype.set(schematype.$immutableSetter);
+  } else if (schematype.$immutableSetter) {
+    schematype.setters = schematype.setters.
+      filter(fn => fn !== schematype.$immutableSetter);
+    delete schematype.$immutableSetter;
+  }
+};
 
-exports.getSymbol = Symbol.for('mongoose#Document#get');
+function createImmutableSetter(path, immutable) {
+  return function immutableSetter(v) {
+    if (this == null || this.$__ == null) {
+      return v;
+    }
+    if (this.isNew) {
+      return v;
+    }
 
-exports.objectIdSymbol = Symbol.for('mongoose#ObjectId');
-},{}],297:[function(require,module,exports){
+    const _immutable = typeof immutable === 'function' ?
+      immutable.call(this, this) :
+      immutable;
+    if (!_immutable) {
+      return v;
+    }
+    if (this.$__.strictMode === 'throw' && v !== this[path]) {
+      throw new StrictModeError(path, 'Path `' + path + '` is immutable ' +
+        'and strict mode is set to throw.', true);
+    }
+
+    return this[path];
+  };
+}
+
+},{"../../error/strict":276}],299:[function(require,module,exports){
 'use strict';
 
+exports.arrayAtomicsSymbol = Symbol('mongoose#Array#_atomics');
+exports.arrayParentSymbol = Symbol('mongoose#Array#_parent');
+exports.arrayPathSymbol = Symbol('mongoose#Array#_path');
+exports.arraySchemaSymbol = Symbol('mongoose#Array#_schema');
+exports.documentArrayParent = Symbol('mongoose:documentArrayParent');
+exports.documentSchemaSymbol = Symbol('mongoose#Document#schema');
+exports.getSymbol = Symbol('mongoose#Document#get');
+exports.modelSymbol = Symbol('mongoose#Model');
+exports.objectIdSymbol = Symbol('mongoose#ObjectId');
+exports.populateModelSymbol = Symbol('mongoose.PopulateOptions#Model');
+exports.schemaTypeSymbol = Symbol('mongoose#schemaType');
+exports.validatorErrorSymbol = Symbol('mongoose:validatorError');
+},{}],300:[function(require,module,exports){
+'use strict';
+
+const cleanPositionalOperators = require('../schema/cleanPositionalOperators');
 const handleTimestampOption = require('../schema/handleTimestampOption');
 
 module.exports = applyTimestampsToChildren;
@@ -76694,7 +77383,7 @@ function applyTimestampsToChildren(now, update, schema) {
   let timestamps;
   let path;
 
-  const hasDollarKey = keys.length && keys[0].charAt(0) === '$';
+  const hasDollarKey = keys.length && keys[0].startsWith('$');
 
   if (hasDollarKey) {
     if (update.$push) {
@@ -76731,53 +77420,61 @@ function applyTimestampsToChildren(now, update, schema) {
       const keys = Object.keys(update.$set);
       for (key of keys) {
         // Replace positional operator `$` and array filters `$[]` and `$[.*]`
-        const keyToSearch = key.
-          replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
-          replace(/\.(\[[^\]]*\])?\$$/, '.0');
+        const keyToSearch = cleanPositionalOperators(key);
         path = schema.path(keyToSearch);
         if (!path) {
           continue;
         }
+
+        let parentSchemaType = null;
+        const pieces = keyToSearch.split('.');
+        for (let i = pieces.length - 1; i > 0; --i) {
+          const s = schema.path(pieces.slice(0, i).join('.'));
+          if (s != null &&
+              (s.$isMongooseDocumentArray || s.$isSingleNested)) {
+            parentSchemaType = s;
+            break;
+          }
+        }
+
         if (Array.isArray(update.$set[key]) && path.$isMongooseDocumentArray) {
           applyTimestampsToDocumentArray(update.$set[key], path, now);
         } else if (update.$set[key] && path.$isSingleNested) {
           applyTimestampsToSingleNested(update.$set[key], path, now);
-        } else if (path.$parentSchema !== schema && path.$parentSchema != null) {
-          const parentPath = path.$parentSchema.$schemaType;
-
-          if (parentPath == null) {
-            continue;
-          }
-
-          timestamps = parentPath.schema.options.timestamps;
+        } else if (parentSchemaType != null) {
+          timestamps = parentSchemaType.schema.options.timestamps;
           createdAt = handleTimestampOption(timestamps, 'createdAt');
           updatedAt = handleTimestampOption(timestamps, 'updatedAt');
 
-          if (updatedAt == null) {
+          if (!timestamps || updatedAt == null) {
             continue;
           }
 
-          if (parentPath.$isSingleNested) {
+          if (parentSchemaType.$isSingleNested) {
             // Single nested is easy
-            update.$set[parentPath.path + '.' + updatedAt] = now;
+            update.$set[parentSchemaType.path + '.' + updatedAt] = now;
             continue;
           }
 
-          let childPath = key.substr(parentPath.path.length + 1);
+          let childPath = key.substr(parentSchemaType.path.length + 1);
+
+          if (/^\d+$/.test(childPath)) {
+            update.$set[parentSchemaType.path + '.' + childPath][updatedAt] = now;
+            continue;
+          }
+
           const firstDot = childPath.indexOf('.');
+          childPath = firstDot !== -1 ? childPath.substr(0, firstDot) : childPath;
 
-          // Shouldn't happen, but if it does ignore this path
-          if (firstDot === -1) {
-            continue;
-          }
-
-          childPath = childPath.substr(0, firstDot);
-
-          update.$set[parentPath.path + '.' + childPath + '.' + updatedAt] = now;
-        } else if (path.schema != null && path.schema != schema) {
+          update.$set[parentSchemaType.path + '.' + childPath + '.' + updatedAt] = now;
+        } else if (path.schema != null && path.schema != schema && update.$set[key]) {
           timestamps = path.schema.options.timestamps;
           createdAt = handleTimestampOption(timestamps, 'createdAt');
           updatedAt = handleTimestampOption(timestamps, 'updatedAt');
+
+          if (!timestamps) {
+            continue;
+          }
 
           if (updatedAt != null) {
             update.$set[key][updatedAt] = now;
@@ -76792,9 +77489,7 @@ function applyTimestampsToChildren(now, update, schema) {
     const keys = Object.keys(update).filter(key => !key.startsWith('$'));
     for (key of keys) {
       // Replace positional operator `$` and array filters `$[]` and `$[.*]`
-      const keyToSearch = key.
-        replace(/\.\$(\[[^\]]*\])?\./g, '.0.').
-        replace(/\.(\[[^\]]*\])?\$$/, '.0');
+      const keyToSearch = cleanPositionalOperators(key);
       path = schema.path(keyToSearch);
       if (!path) {
         continue;
@@ -76845,7 +77540,7 @@ function applyTimestampsToSingleNested(subdoc, schematype, now) {
     subdoc[createdAt] = now;
   }
 }
-},{"../schema/handleTimestampOption":294}],298:[function(require,module,exports){
+},{"../schema/cleanPositionalOperators":294,"../schema/handleTimestampOption":296}],301:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76871,29 +77566,35 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
     return currentUpdate;
   }
 
+  const skipCreatedAt = timestamps != null && timestamps.createdAt === false;
+  const skipUpdatedAt = timestamps != null && timestamps.updatedAt === false;
+
   if (overwrite) {
     if (currentUpdate && currentUpdate.$set) {
       currentUpdate = currentUpdate.$set;
       updates.$set = {};
       _updates = updates.$set;
     }
-    if (updatedAt && !currentUpdate[updatedAt]) {
+    if (!skipUpdatedAt && updatedAt && !currentUpdate[updatedAt]) {
       _updates[updatedAt] = now;
     }
-    if (createdAt && !currentUpdate[createdAt]) {
+    if (!skipCreatedAt && createdAt && !currentUpdate[createdAt]) {
       _updates[createdAt] = now;
     }
     return updates;
   }
-  updates.$set = updates.$set || {};
   currentUpdate = currentUpdate || {};
 
-  if (updatedAt &&
+  updates.$set = updates.$set || {};
+  if (!skipUpdatedAt && updatedAt &&
       (!currentUpdate.$currentDate || !currentUpdate.$currentDate[updatedAt])) {
     updates.$set[updatedAt] = now;
+    if (updates.hasOwnProperty(updatedAt)) {
+      delete updates[updatedAt];
+    }
   }
 
-  if (createdAt) {
+  if (!skipCreatedAt && createdAt) {
     if (currentUpdate[createdAt]) {
       delete currentUpdate[createdAt];
     }
@@ -76912,7 +77613,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
   return updates;
 }
 
-},{"../get":285}],299:[function(require,module,exports){
+},{"../get":286}],302:[function(require,module,exports){
 /*!
  * Dependencies
  */
@@ -76945,13 +77646,14 @@ function InternalCache() {
   this.pathsToScopes = {};
   this.cachedRequired = {};
   this.session = null;
+  this.$setCalled = new Set();
 
   // embedded docs
   this.ownerDocument = undefined;
   this.fullPath = undefined;
 }
 
-},{"./statemachine":326}],300:[function(require,module,exports){
+},{"./statemachine":337}],303:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76967,7 +77669,568 @@ exports.internalToObjectOptions = {
   flattenDecimals: false
 };
 
-},{}],301:[function(require,module,exports){
+},{}],304:[function(require,module,exports){
+'use strict';
+
+const utils = require('../utils');
+
+class PopulateOptions {
+  constructor(obj) {
+    this._docs = {};
+
+    if (obj == null) {
+      return;
+    }
+    obj = utils.clone(obj);
+    Object.assign(this, obj);
+    if (typeof obj.subPopulate === 'object') {
+      this.populate = obj.subPopulate;
+    }
+  }
+}
+
+/**
+ * The connection used to look up models by name. If not specified, Mongoose
+ * will default to using the connection associated with the model in
+ * `PopulateOptions#model`.
+ *
+ * @memberOf PopulateOptions
+ * @property {Connection} connection
+ * @api public
+ */
+
+module.exports = PopulateOptions;
+},{"../utils":348}],305:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on an Array schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ tags: [String] });
+ *     schema.path('tags').options; // SchemaArrayOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaArrayOptions
+ */
+
+class SchemaArrayOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If this is an array of strings, an array of allowed values for this path.
+ * Throws an error if this array isn't an array of strings.
+ *
+ * @api public
+ * @property enum
+ * @memberOf SchemaArrayOptions
+ * @type Array
+ * @instance
+ */
+
+Object.defineProperty(SchemaArrayOptions.prototype, 'enum', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaArrayOptions;
+},{"./SchemaTypeOptions":311}],306:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Buffer schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ bitmap: Buffer });
+ *     schema.path('bitmap').options; // SchemaBufferOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaBufferOptions
+ */
+
+class SchemaBufferOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * Set the default subtype for this buffer.
+ *
+ * @api public
+ * @property subtype
+ * @memberOf SchemaBufferOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaBufferOptions.prototype, 'subtype', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaBufferOptions;
+},{"./SchemaTypeOptions":311}],307:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Date schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ startedAt: Date });
+ *     schema.path('startedAt').options; // SchemaDateOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaDateOptions
+ */
+
+class SchemaDateOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is after the
+ * given `min`.
+ *
+ * @api public
+ * @property min
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'min', opts);
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is before the
+ * given `max`.
+ *
+ * @api public
+ * @property max
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'max', opts);
+
+/**
+ * If set, Mongoose creates a TTL index on this path.
+ *
+ * @api public
+ * @property expires
+ * @memberOf SchemaDateOptions
+ * @type Date
+ * @instance
+ */
+
+Object.defineProperty(SchemaDateOptions.prototype, 'expires', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaDateOptions;
+},{"./SchemaTypeOptions":311}],308:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a Number schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ count: Number });
+ *     schema.path('count').options; // SchemaNumberOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaNumberOptions
+ */
+
+class SchemaNumberOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is at least the
+ * given `min`.
+ *
+ * @api public
+ * @property min
+ * @memberOf SchemaNumberOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaNumberOptions.prototype, 'min', opts);
+
+/**
+ * If set, Mongoose adds a validator that checks that this path is less than the
+ * given `max`.
+ *
+ * @api public
+ * @property max
+ * @memberOf SchemaNumberOptions
+ * @type Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaNumberOptions.prototype, 'max', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaNumberOptions;
+},{"./SchemaTypeOptions":311}],309:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on an ObjectId schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ testId: mongoose.ObjectId });
+ *     schema.path('testId').options; // SchemaObjectIdOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaObjectIdOptions
+ */
+
+class SchemaObjectIdOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * If truthy, uses Mongoose's default built-in ObjectId path.
+ *
+ * @api public
+ * @property auto
+ * @memberOf SchemaObjectIdOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaObjectIdOptions.prototype, 'auto', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaObjectIdOptions;
+},{"./SchemaTypeOptions":311}],310:[function(require,module,exports){
+'use strict';
+
+const SchemaTypeOptions = require('./SchemaTypeOptions');
+
+/**
+ * The options defined on a string schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ name: String });
+ *     schema.path('name').options; // SchemaStringOptions instance
+ *
+ * @api public
+ * @inherits SchemaTypeOptions
+ * @constructor SchemaStringOptions
+ */
+
+class SchemaStringOptions extends SchemaTypeOptions {}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * Array of allowed values for this path
+ *
+ * @api public
+ * @property enum
+ * @memberOf SchemaStringOptions
+ * @type Array
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'enum', opts);
+
+/**
+ * Attach a validator that succeeds if the data string matches the given regular
+ * expression, and fails otherwise.
+ *
+ * @api public
+ * @property match
+ * @memberOf SchemaStringOptions
+ * @type RegExp
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'match', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that lowercases this string
+ * using JavaScript's built-in `String#toLowerCase()`.
+ *
+ * @api public
+ * @property lowercase
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'lowercase', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that removes leading and trailing
+ * whitespace using JavaScript's built-in `String#trim()`.
+ *
+ * @api public
+ * @property trim
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'trim', opts);
+
+/**
+ * If truthy, Mongoose will add a custom setter that uppercases this string
+ * using JavaScript's built-in `String#toUpperCase()`.
+ *
+ * @api public
+ * @property uppercase
+ * @memberOf SchemaStringOptions
+ * @type Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaStringOptions.prototype, 'uppercase', opts);
+
+/*!
+ * ignore
+ */
+
+module.exports = SchemaStringOptions;
+},{"./SchemaTypeOptions":311}],311:[function(require,module,exports){
+'use strict';
+
+const utils = require('../utils');
+
+/**
+ * The options defined on a schematype.
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({ name: String });
+ *     schema.path('name').options instanceof mongoose.SchemaTypeOptions; // true
+ *
+ * @api public
+ * @constructor SchemaTypeOptions
+ */
+
+class SchemaTypeOptions {
+  constructor(obj) {
+    if (obj == null) {
+      return this;
+    }
+    Object.assign(this, utils.clone(obj));
+  }
+}
+
+const opts = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  value: null
+};
+
+/**
+ * The type to cast this path to.
+ *
+ * @api public
+ * @property type
+ * @memberOf SchemaTypeOptions
+ * @type Function|String|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'type', opts);
+
+/**
+ * Function or object describing how to validate this schematype.
+ *
+ * @api public
+ * @property validate
+ * @memberOf SchemaTypeOptions
+ * @type Function|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'validate', opts);
+
+/**
+ * If true, attach a required validator to this path, which ensures this path
+ * path cannot be set to a nullish value. If a function, Mongoose calls the
+ * function and only checks for nullish values if the function returns a truthy value.
+ *
+ * @api public
+ * @property required
+ * @memberOf SchemaTypeOptions
+ * @type Function|Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'required', opts);
+
+/**
+ * The default value for this path. If a function, Mongoose executes the function
+ * and uses the return value as the default.
+ *
+ * @api public
+ * @property default
+ * @memberOf SchemaTypeOptions
+ * @type Function|Any
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'default', opts);
+
+/**
+ * The model that `populate()` should use if populating this path.
+ *
+ * @api public
+ * @property ref
+ * @memberOf SchemaTypeOptions
+ * @type Function|String
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'ref', opts);
+
+/**
+ * Whether to include or exclude this path by default when loading documents
+ * using `find()`, `findOne()`, etc.
+ *
+ * @api public
+ * @property select
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'select', opts);
+
+/**
+ * If truthy, Mongoose will build an index on this path when the model is
+ * compiled.
+ *
+ * @api public
+ * @property index
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'index', opts);
+
+/**
+ * If truthy, Mongoose will build a unique index on this path when the
+ * model is compiled. [The `unique` option is **not** a validator](/docs/validation.html#the-unique-option-is-not-a-validator).
+ *
+ * @api public
+ * @property unique
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'unique', opts);
+
+/**
+ * If truthy, Mongoose will disallow changes to this path once the document
+ * is saved to the database for the first time. Read more about [immutability in Mongoose here](http://thecodebarbarian.com/whats-new-in-mongoose-5-6-immutable-properties.html).
+ *
+ * @api public
+ * @property immutable
+ * @memberOf SchemaTypeOptions
+ * @type Function|Boolean
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'immutable', opts);
+
+/**
+ * If truthy, Mongoose will build a sparse index on this path.
+ *
+ * @api public
+ * @property sparse
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'sparse', opts);
+
+/**
+ * If truthy, Mongoose will build a text index on this path.
+ *
+ * @api public
+ * @property text
+ * @memberOf SchemaTypeOptions
+ * @type Boolean|Number|Object
+ * @instance
+ */
+
+Object.defineProperty(SchemaTypeOptions.prototype, 'text', opts);
+
+module.exports = SchemaTypeOptions;
+},{"../utils":348}],312:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76997,7 +78260,7 @@ function idGetter() {
   return null;
 }
 
-},{}],302:[function(require,module,exports){
+},{}],313:[function(require,module,exports){
 (function (global){
 /*!
  * ignore
@@ -77050,13 +78313,15 @@ store.set(global.Promise);
 module.exports = store;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"assert":80,"mquery":345}],303:[function(require,module,exports){
+},{"assert":80,"mquery":358}],314:[function(require,module,exports){
 'use strict';
 
 /*!
  * Module dependencies
  */
 
+const checkEmbeddedDiscriminatorKeyProjection =
+  require('./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection');
 const get = require('./helpers/get');
 const isDefiningProjection = require('./helpers/projection/isDefiningProjection');
 const utils = require('./utils');
@@ -77248,9 +78513,12 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
     // check for parent exclusions
     const pieces = path.split('.');
-    const root = pieces[0];
-    if (~excluded.indexOf(root)) {
-      return;
+    let cur = '';
+    for (let i = 0; i < pieces.length; ++i) {
+      cur += cur.length ? '.' + pieces[i] : pieces[i];
+      if (excluded.indexOf(cur) !== -1) {
+        return;
+      }
     }
 
     // Special case: if user has included a parent path of a discriminator key,
@@ -77268,6 +78536,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
     }
 
     (type.selected ? selected : excluded).push(path);
+    return path;
   };
 
   analyzeSchema(schema);
@@ -77295,7 +78564,7 @@ exports.applyPaths = function applyPaths(fields, schema) {
       }
       // Any leftover plus paths must in the schema, so delete them (gh-7017)
       for (const key of Object.keys(fields || {})) {
-        if (key.charAt(0) === '+') {
+        if (key.startsWith('+')) {
           delete fields[key];
         }
       }
@@ -77313,22 +78582,34 @@ exports.applyPaths = function applyPaths(fields, schema) {
 
     // avoid recursion
     if (stack.indexOf(schema) !== -1) {
-      return;
+      return [];
     }
     stack.push(schema);
 
+    const addedPaths = [];
     schema.eachPath(function(path, type) {
       if (prefix) path = prefix + '.' + path;
 
-      analyzePath(path, type);
+      const addedPath = analyzePath(path, type);
+      if (addedPath != null) {
+        addedPaths.push(addedPath);
+      }
 
-      // array of subdocs?
+      // nested schemas
       if (type.schema) {
-        analyzeSchema(type.schema, path);
+        const _addedPaths = analyzeSchema(type.schema, path);
+
+        // Special case: if discriminator key is the only field that would
+        // be projected in, remove it.
+        if (exclude === false) {
+          checkEmbeddedDiscriminatorKeyProjection(fields, path, type.schema,
+            selected, _addedPaths);
+        }
       }
     });
 
     stack.pop();
+    return addedPaths;
   }
 };
 
@@ -77354,12 +78635,18 @@ exports.handleDeleteWriteOpResult = function handleDeleteWriteOpResult(callback)
     if (error) {
       return callback(error);
     }
-    return callback(null,
-      Object.assign({}, res.result, {deletedCount: res.deletedCount }));
+    const mongooseResult = Object.assign({}, res.result);
+    if (get(res, 'result.n', null) != null) {
+      mongooseResult.deletedCount = res.result.n;
+    }
+    if (res.deletedCount != null) {
+      mongooseResult.deletedCount = res.deletedCount;
+    }
+    return callback(null, mongooseResult);
   };
 };
 
-},{"./helpers/get":285,"./helpers/projection/isDefiningProjection":290,"./utils":336}],304:[function(require,module,exports){
+},{"./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection":281,"./helpers/get":286,"./helpers/projection/isDefiningProjection":291,"./utils":348}],315:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -77373,6 +78660,7 @@ const SchemaType = require('./schematype');
 const VirtualType = require('./virtualtype');
 const applyTimestampsToChildren = require('./helpers/update/applyTimestampsToChildren');
 const applyTimestampsToUpdate = require('./helpers/update/applyTimestampsToUpdate');
+const arrayParentSymbol = require('./helpers/symbols').arrayParentSymbol;
 const get = require('./helpers/get');
 const getIndexes = require('./helpers/schema/getIndexes');
 const handleTimestampOption = require('./helpers/schema/handleTimestampOption');
@@ -77415,11 +78703,12 @@ let id = 0;
  * - [collection](/docs/guide.html#collection): string - no default
  * - [id](/docs/guide.html#id): bool - defaults to true
  * - [_id](/docs/guide.html#_id): bool - defaults to true
- * - `minimize`: bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true
+ * - [minimize](/docs/guide.html#minimize): bool - controls [document#toObject](#document_Document-toObject) behavior when called manually - defaults to true
  * - [read](/docs/guide.html#read): string
  * - [writeConcern](/docs/guide.html#writeConcern): object - defaults to null, use to override [the MongoDB server's default write concern settings](https://docs.mongodb.com/manual/reference/write-concern/)
- * - [shardKey](/docs/guide.html#shardKey): bool - defaults to `null`
+ * - [shardKey](/docs/guide.html#shardKey): object - defaults to `null`
  * - [strict](/docs/guide.html#strict): bool - defaults to true
+ * - [strictQuery](/docs/guide.html#strictQuery): bool - defaults to false
  * - [toJSON](/docs/guide.html#toJSON) - object - no default
  * - [toObject](/docs/guide.html#toObject) - object - no default
  * - [typeKey](/docs/guide.html#typeKey) - string - defaults to 'type'
@@ -77428,6 +78717,9 @@ let id = 0;
  * - [versionKey](/docs/guide.html#versionKey): string - defaults to "__v"
  * - [collation](/docs/guide.html#collation): object - defaults to null (which means use no collation)
  * - [selectPopulatedPaths](/docs/guide.html#selectPopulatedPaths): boolean - defaults to `true`
+ * - [skipVersioning](/docs/guide.html#skipVersioning): object - paths to exclude from versioning
+ * - [timestamps](/docs/guide.html#timestamps): object or boolean - defaults to `false`. If true, Mongoose adds `createdAt` and `updatedAt` properties to your schema and manages those properties for you.
+ * - [storeSubdocValidationError](/docs/guide.html#storeSubdocValidationError): boolean - Defaults to true. If false, Mongoose will wrap validation errors in single nested document subpaths into a single validation error on the single nested subdoc's path.
  *
  * ####Note:
  *
@@ -77656,25 +78948,23 @@ Schema.prototype.clone = function() {
   s.plugins = Array.prototype.slice.call(this.plugins);
   s._indexes = utils.clone(this._indexes);
   s.s.hooks = this.s.hooks.clone();
-  s._originalSchema = this._originalSchema == null ?
-    this._originalSchema :
-    this._originalSchema.clone();
 
   s.tree = utils.clone(this.tree);
   s.paths = utils.clone(this.paths);
   s.nested = utils.clone(this.nested);
   s.subpaths = utils.clone(this.subpaths);
-  s.childSchemas = this.childSchemas.slice();
   s.singleNestedPaths = utils.clone(this.singleNestedPaths);
+  s.childSchemas = gatherChildSchemas(s);
 
   s.virtuals = utils.clone(this.virtuals);
   s.$globalPluginsApplied = this.$globalPluginsApplied;
   s.$isRootDiscriminator = this.$isRootDiscriminator;
+  s.$implicitlyCreated = this.$implicitlyCreated;
 
   if (this.discriminatorMapping != null) {
     s.discriminatorMapping = Object.assign({}, this.discriminatorMapping);
   }
-  if (s.discriminators != null) {
+  if (this.discriminators != null) {
     s.discriminators = Object.assign({}, this.discriminators);
   }
 
@@ -77755,10 +79045,13 @@ Schema.prototype.defaultOptions = function(options) {
 Schema.prototype.add = function add(obj, prefix) {
   if (obj instanceof Schema) {
     merge(this, obj);
-    return;
+    return this;
   }
 
-  if (obj._id === false) {
+  // Special case: setting top-level `_id` to false should convert to disabling
+  // the `_id` option. This behavior never worked before 5.4.11 but numerous
+  // codebases use it (see gh-7516, gh-7512).
+  if (obj._id === false && prefix == null) {
     delete obj._id;
     this.options._id = false;
   }
@@ -77768,26 +79061,29 @@ Schema.prototype.add = function add(obj, prefix) {
 
   for (let i = 0; i < keys.length; ++i) {
     const key = keys[i];
+    const fullPath = prefix + key;
 
     if (obj[key] == null) {
-      throw new TypeError('Invalid value for schema path `' + prefix + key + '`');
+      throw new TypeError('Invalid value for schema path `' + fullPath +
+        '`, got value "' + obj[key] + '"');
     }
 
     if (Array.isArray(obj[key]) && obj[key].length === 1 && obj[key][0] == null) {
-      throw new TypeError('Invalid value for schema Array path `' + prefix + key + '`');
+      throw new TypeError('Invalid value for schema Array path `' + fullPath +
+        '`, got value "' + obj[key][0] + '"');
     }
 
     if (utils.isPOJO(obj[key]) &&
         (!obj[key][this.options.typeKey] || (this.options.typeKey === 'type' && obj[key].type.type))) {
       if (Object.keys(obj[key]).length) {
         // nested object { last: { name: String }}
-        this.nested[prefix + key] = true;
-        this.add(obj[key], prefix + key + '.');
+        this.nested[fullPath] = true;
+        this.add(obj[key], fullPath + '.');
       } else {
         if (prefix) {
           this.nested[prefix.substr(0, prefix.length - 1)] = true;
         }
-        this.path(prefix + key, obj[key]); // mixed type
+        this.path(fullPath, obj[key]); // mixed type
       }
     } else {
       if (prefix) {
@@ -77806,9 +79102,33 @@ Schema.prototype.add = function add(obj, prefix) {
 /**
  * Reserved document keys.
  *
- * Keys in this object are names that are rejected in schema declarations b/c they conflict with mongoose functionality. Using these key name will throw an error.
+ * Keys in this object are names that are rejected in schema declarations
+ * because they conflict with Mongoose functionality. If you create a schema
+ * using `new Schema()` with one of these property names, Mongoose will throw
+ * an error.
  *
- *      on, emit, _events, db, get, set, init, isNew, errors, schema, options, modelName, collection, _pres, _posts, toObject
+ * - prototype
+ * - emit
+ * - on
+ * - once
+ * - listeners
+ * - removeListener
+ * - collection
+ * - db
+ * - errors
+ * - init
+ * - isModified
+ * - isNew
+ * - get
+ * - modelName
+ * - save
+ * - schema
+ * - toObject
+ * - validate
+ * - remove
+ * - populated
+ * - _pres
+ * - _posts
  *
  * _NOTE:_ Use of these terms as method names is permitted, but play at your own risk, as they may be existing mongoose document methods you are stomping on.
  *
@@ -77841,9 +79161,7 @@ reserved.schema =
 reserved.toObject =
 reserved.validate =
 reserved.remove =
-reserved.populated =
-// hooks.js
-reserved._pres = reserved._posts = 1;
+reserved.populated = 1;
 
 /*!
  * Document keys to print warnings for
@@ -77870,26 +79188,24 @@ warnings.increment = '`increment` should not be used as a schema path name ' +
  */
 
 Schema.prototype.path = function(path, obj) {
+  // Convert to '.$' to check subpaths re: gh-6405
+  const cleanPath = _pathToPositionalSyntax(path);
   if (obj === undefined) {
-    if (this.paths.hasOwnProperty(path)) {
-      return this.paths[path];
-    }
-    if (this.subpaths.hasOwnProperty(path)) {
-      return this.subpaths[path];
-    }
-    if (this.singleNestedPaths.hasOwnProperty(path)) {
-      return this.singleNestedPaths[path];
+    let schematype = _getPath(this, path, cleanPath);
+    if (schematype != null) {
+      return schematype;
     }
 
     // Look for maps
-    for (const _path of Object.keys(this.paths)) {
-      if (!_path.includes('.$*')) {
-        continue;
-      }
-      const re = new RegExp('^' + _path.replace(/\.\$\*/g, '.[^.]+') + '$');
-      if (re.test(path)) {
-        return this.paths[_path];
-      }
+    const mapPath = getMapPath(this, path);
+    if (mapPath != null) {
+      return mapPath;
+    }
+
+    // Look if a parent of this path is mixed
+    schematype = this.hasMixedParent(cleanPath);
+    if (schematype != null) {
+      return schematype;
     }
 
     // subpaths?
@@ -77907,7 +79223,7 @@ Schema.prototype.path = function(path, obj) {
     console.log('WARN: ' + warnings[path]);
   }
 
-  if (typeof obj === 'object' && 'ref' in obj) {
+  if (typeof obj === 'object' && utils.hasUserDefinedProperty(obj, 'ref')) {
     validateRef(obj.ref, path);
   }
 
@@ -77941,9 +79257,16 @@ Schema.prototype.path = function(path, obj) {
     // The '$' is to imply this path should never be stored in MongoDB so we
     // can easily build a regexp out of this path, and '*' to imply "any key."
     const mapPath = path + '.$*';
-    this.paths[path + '.$*'] = this.interpretAsType(mapPath,
-      obj.of || { type: {} }, this.options);
-    schemaType.$__schemaType = this.paths[path + '.$*'];
+    let _mapType = { type: {} };
+    if (utils.hasUserDefinedProperty(obj, 'of')) {
+      const isInlineSchema = utils.isPOJO(obj.of) &&
+        Object.keys(obj.of).length > 0 &&
+        !utils.hasUserDefinedProperty(obj.of, this.options.typeKey);
+      _mapType = isInlineSchema ? new Schema(obj.of) : obj.of;
+    }
+    this.paths[mapPath] = this.interpretAsType(mapPath,
+      _mapType, this.options);
+    schemaType.$__schemaType = this.paths[mapPath];
   }
 
   if (schemaType.$isSingleNested) {
@@ -77953,6 +79276,10 @@ Schema.prototype.path = function(path, obj) {
     for (const key in schemaType.schema.singleNestedPaths) {
       this.singleNestedPaths[path + '.' + key] =
         schemaType.schema.singleNestedPaths[key];
+    }
+    for (const key in schemaType.schema.subpaths) {
+      this.singleNestedPaths[path + '.' + key] =
+        schemaType.schema.subpaths[key];
     }
 
     Object.defineProperty(schemaType.schema, 'base', {
@@ -77982,8 +79309,107 @@ Schema.prototype.path = function(path, obj) {
     });
   }
 
+  if (schemaType.$isMongooseArray && schemaType.caster instanceof SchemaType) {
+    let arrayPath = path;
+    let _schemaType = schemaType;
+
+    let toAdd = [];
+    while (_schemaType.$isMongooseArray) {
+      arrayPath = arrayPath + '.$';
+
+      // Skip arrays of document arrays
+      if (_schemaType.$isMongooseDocumentArray) {
+        toAdd = [];
+        break;
+      }
+      _schemaType = _schemaType.caster.clone();
+      _schemaType.path = arrayPath;
+      toAdd.push(_schemaType);
+    }
+
+    for (const _schemaType of toAdd) {
+      this.subpaths[_schemaType.path] = _schemaType;
+    }
+  }
+
+  if (schemaType.$isMongooseDocumentArray) {
+    for (const key of Object.keys(schemaType.schema.paths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.paths[key];
+      schemaType.schema.paths[key].$isUnderneathDocArray = true;
+    }
+    for (const key of Object.keys(schemaType.schema.subpaths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.subpaths[key];
+      schemaType.schema.subpaths[key].$isUnderneathDocArray = true;
+    }
+    for (const key of Object.keys(schemaType.schema.singleNestedPaths)) {
+      this.subpaths[path + '.' + key] = schemaType.schema.singleNestedPaths[key];
+      schemaType.schema.singleNestedPaths[key].$isUnderneathDocArray = true;
+    }
+  }
+
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+function gatherChildSchemas(schema) {
+  const childSchemas = [];
+
+  for (const path of Object.keys(schema.paths)) {
+    const schematype = schema.paths[path];
+    if (schematype.$isMongooseDocumentArray || schematype.$isSingleNested) {
+      childSchemas.push({ schema: schematype.schema, model: schematype.caster });
+    }
+  }
+
+  return childSchemas;
+}
+
+/*!
+ * ignore
+ */
+
+function _getPath(schema, path, cleanPath) {
+  if (schema.paths.hasOwnProperty(path)) {
+    return schema.paths[path];
+  }
+  if (schema.subpaths.hasOwnProperty(cleanPath)) {
+    return schema.subpaths[cleanPath];
+  }
+  if (schema.singleNestedPaths.hasOwnProperty(cleanPath)) {
+    return schema.singleNestedPaths[cleanPath];
+  }
+
+  return null;
+}
+
+/*!
+ * ignore
+ */
+
+function _pathToPositionalSyntax(path) {
+  return path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
+}
+
+/*!
+ * ignore
+ */
+
+function getMapPath(schema, path) {
+  for (const _path of Object.keys(schema.paths)) {
+    if (!_path.includes('.$*')) {
+      continue;
+    }
+    const re = new RegExp('^' + _path.replace(/\.\$\*/g, '\\.[^.]+') + '$');
+    if (re.test(path)) {
+      return schema.paths[_path];
+    }
+  }
+
+  return null;
+}
 
 /**
  * The Mongoose instance this schema is associated with
@@ -78090,7 +79516,7 @@ Schema.prototype.interpretAsType = function(path, obj, options) {
         ? type
         : type.schemaName || utils.getFunctionName(type);
 
-      if (!(name in MongooseTypes)) {
+      if (!MongooseTypes.hasOwnProperty(name)) {
         throw new TypeError('Invalid schema configuration: ' +
           `\`${name}\` is not a valid type within the array \`${path}\`.` +
           'See http://bit.ly/mongoose-schematypes for a list of valid schema types.');
@@ -78230,31 +79656,29 @@ Schema.prototype.indexedPaths = function indexedPaths() {
  */
 
 Schema.prototype.pathType = function(path) {
-  if (path in this.paths) {
+  // Convert to '.$' to check subpaths re: gh-6405
+  const cleanPath = path.replace(/\.\d+\./g, '.$.').replace(/\.\d+$/, '.$');
+
+  if (this.paths.hasOwnProperty(path)) {
     return 'real';
   }
-  if (path in this.virtuals) {
+  if (this.virtuals.hasOwnProperty(path)) {
     return 'virtual';
   }
-  if (path in this.nested) {
+  if (this.nested.hasOwnProperty(path)) {
     return 'nested';
   }
-  if (path in this.subpaths) {
+  if (this.subpaths.hasOwnProperty(cleanPath)) {
     return 'real';
   }
-  if (path in this.singleNestedPaths) {
+  if (this.singleNestedPaths.hasOwnProperty(cleanPath)) {
     return 'real';
   }
 
   // Look for maps
-  for (const _path of Object.keys(this.paths)) {
-    if (!_path.includes('.$*')) {
-      continue;
-    }
-    const re = new RegExp('^' + _path.replace(/\.\$\*/g, '.[^.]+') + '$');
-    if (re.test(path)) {
-      return 'real';
-    }
+  const mapPath = getMapPath(this, path);
+  if (mapPath != null) {
+    return 'real';
   }
 
   if (/\.\d+\.|\.\d+$/.test(path)) {
@@ -78278,11 +79702,11 @@ Schema.prototype.hasMixedParent = function(path) {
     path = i > 0 ? path + '.' + subpaths[i] : subpaths[i];
     if (path in this.paths &&
         this.paths[path] instanceof MongooseTypes.Mixed) {
-      return true;
+      return this.paths[path];
     }
   }
 
-  return false;
+  return null;
 };
 
 /**
@@ -78320,23 +79744,27 @@ Schema.prototype.setupTimestamp = function(timestamps) {
   this.add(schemaAdditions);
 
   this.pre('save', function(next) {
-    if (get(this, '$__.saveOptions.timestamps') === false) {
+    const timestampOption = get(this, '$__.saveOptions.timestamps');
+    if (timestampOption === false) {
       return next();
     }
+
+    const skipUpdatedAt = timestampOption != null && timestampOption.updatedAt === false;
+    const skipCreatedAt = timestampOption != null && timestampOption.createdAt === false;
 
     const defaultTimestamp = (this.ownerDocument ? this.ownerDocument() : this).
       constructor.base.now();
     const auto_id = this._id && this._id.auto;
 
-    if (createdAt && !this.get(createdAt) && this.isSelected(createdAt)) {
+    if (!skipCreatedAt && createdAt && !this.get(createdAt) && this.isSelected(createdAt)) {
       this.set(createdAt, auto_id ? this._id.getTimestamp() : defaultTimestamp);
     }
 
-    if (updatedAt && (this.isNew || this.isModified())) {
+    if (!skipUpdatedAt && updatedAt && (this.isNew || this.isModified())) {
       let ts = defaultTimestamp;
       if (this.isNew) {
         if (createdAt != null) {
-          ts = this.getValue(createdAt);
+          ts = this.$__getValue(createdAt);
         } else if (auto_id) {
           ts = this._id.getTimestamp();
         }
@@ -78359,11 +79787,12 @@ Schema.prototype.setupTimestamp = function(timestamps) {
 
   _setTimestampsOnUpdate[symbols.builtInMiddleware] = true;
 
-  this.pre('findOneAndUpdate', _setTimestampsOnUpdate);
-  this.pre('replaceOne', _setTimestampsOnUpdate);
-  this.pre('update', _setTimestampsOnUpdate);
-  this.pre('updateOne', _setTimestampsOnUpdate);
-  this.pre('updateMany', _setTimestampsOnUpdate);
+  const opts = { query: true, model: false };
+  this.pre('findOneAndUpdate', opts, _setTimestampsOnUpdate);
+  this.pre('replaceOne', opts, _setTimestampsOnUpdate);
+  this.pre('update', opts, _setTimestampsOnUpdate);
+  this.pre('updateOne', opts, _setTimestampsOnUpdate);
+  this.pre('updateMany', opts, _setTimestampsOnUpdate);
 
   function _setTimestampsOnUpdate(next) {
     const now = this.model.base.now();
@@ -78375,19 +79804,21 @@ Schema.prototype.setupTimestamp = function(timestamps) {
 };
 
 /*!
- * ignore
+ * ignore. Deprecated re: #6405
  */
 
 function getPositionalPathType(self, path) {
   const subpaths = path.split(/\.(\d+)\.|\.(\d+)$/).filter(Boolean);
   if (subpaths.length < 2) {
-    return self.paths.hasOwnProperty(subpaths[0]) ? self.paths[subpaths[0]] : null;
+    return self.paths.hasOwnProperty(subpaths[0]) ?
+      self.paths[subpaths[0]] :
+      'adhocOrUndefined';
   }
 
   let val = self.path(subpaths[0]);
   let isNested = false;
   if (!val) {
-    return val;
+    return 'adhocOrUndefined';
   }
 
   const last = subpaths.length - 1;
@@ -78419,6 +79850,10 @@ function getPositionalPathType(self, path) {
 
     // ignore if its just a position segment: path.0.subpath
     if (!/\D/.test(subpath)) {
+      // Nested array
+      if (val instanceof MongooseTypes.Array && i !== last) {
+        val = val.caster;
+      }
       continue;
     }
 
@@ -78492,15 +79927,19 @@ Schema.prototype.queue = function(name, args) {
  *
  *     // Equivalent to calling `pre()` on `find`, `findOne`, `findOneAndUpdate`.
  *     toySchema.pre(/^find/, function(next) {
- *       console.log(this.getQuery());
+ *       console.log(this.getFilter());
  *     });
  *
- * @param {String|RegExp} method or regular expression to match method name
+ *     // Equivalent to calling `pre()` on `updateOne`, `findOneAndUpdate`.
+ *     toySchema.pre(['updateOne', 'findOneAndUpdate'], function(next) {
+ *       console.log(this.getFilter());
+ *     });
+ *
+ * @param {String|RegExp} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
  * @param {Function} callback
- * @see hooks.js https://github.com/bnoguchi/hooks-js/tree/31ec571cef0332e21121ee7157e0cf9728572cc3
  * @api public
  */
 
@@ -78511,6 +79950,13 @@ Schema.prototype.pre = function(name) {
       if (name.test(fn)) {
         this.pre.apply(this, [fn].concat(remainingArgs));
       }
+    }
+    return this;
+  }
+  if (Array.isArray(name)) {
+    const remainingArgs = Array.prototype.slice.call(arguments, 1);
+    for (const el of name) {
+      this.pre.apply(this, [el].concat(remainingArgs));
     }
     return this;
   }
@@ -78545,7 +79991,7 @@ Schema.prototype.pre = function(name) {
  *       console.log('this fires after the post find hook');
  *     });
  *
- * @param {String|RegExp} method or regular expression to match method name
+ * @param {String|RegExp} The method name or regular expression to match method name
  * @param {Object} [options]
  * @param {Boolean} [options.document] If `name` is a hook for both document and query middleware, set to `true` to run on document middleware.
  * @param {Boolean} [options.query] If `name` is a hook for both document and query middleware, set to `true` to run on query middleware.
@@ -78565,6 +80011,13 @@ Schema.prototype.post = function(name) {
     }
     return this;
   }
+  if (Array.isArray(name)) {
+    const remainingArgs = Array.prototype.slice.call(arguments, 1);
+    for (const el of name) {
+      this.post.apply(this, [el].concat(remainingArgs));
+    }
+    return this;
+  }
   this.s.hooks.post.apply(this.s.hooks, arguments);
   return this;
 };
@@ -78576,7 +80029,7 @@ Schema.prototype.post = function(name) {
  *
  *     const s = new Schema({ name: String });
  *     s.plugin(schema => console.log(schema.path('name').path));
- *     mongoose.model('Test', schema); // Prints 'name'
+ *     mongoose.model('Test', s); // Prints 'name'
  *
  * @param {Function} plugin callback
  * @param {Object} [opts]
@@ -78656,21 +80109,21 @@ Schema.prototype.method = function(name, fn, options) {
  *
  * ####Example
  *
- *     var schema = new Schema(..);
- *     schema.static('findByName', function (name, callback) {
- *       return this.find({ name: name }, callback);
+ *     const schema = new Schema(..);
+ *     // Equivalent to `schema.statics.findByName = function(name) {}`;
+ *     schema.static('findByName', function(name) {
+ *       return this.find({ name: name });
  *     });
  *
- *     var Drink = mongoose.model('Drink', schema);
- *     Drink.findByName('sanpellegrino', function (err, drinks) {
- *       //
- *     });
+ *     const Drink = mongoose.model('Drink', schema);
+ *     await Drink.findByName('LaCroix');
  *
  * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as statics.
  *
  * @param {String|Object} name
  * @param {Function} [fn]
  * @api public
+ * @see Statics /docs/guide.html#statics
  */
 
 Schema.prototype.static = function(name, fn) {
@@ -78840,7 +80293,7 @@ Schema.prototype.indexes = function() {
  */
 
 Schema.prototype.virtual = function(name, options) {
-  if (options && options.ref) {
+  if (utils.hasUserDefinedProperty(options, ['ref', 'refPath'])) {
     if (!options.localField) {
       throw new Error('Reference virtuals require `localField` option');
     }
@@ -78877,10 +80330,10 @@ Schema.prototype.virtual = function(name, options) {
         if (!this.$$populatedVirtuals) {
           this.$$populatedVirtuals = {};
         }
-        if (name in this.$$populatedVirtuals) {
+        if (this.$$populatedVirtuals.hasOwnProperty(name)) {
           return this.$$populatedVirtuals[name];
         }
-        return null;
+        return void 0;
       }).
       set(function(_v) {
         if (!this.$$populatedVirtuals) {
@@ -78922,6 +80375,24 @@ Schema.prototype.virtual = function(name, options) {
     return mem[part];
   }, this.tree);
 
+  // Workaround for gh-8198: if virtual is under document array, make a fake
+  // virtual. See gh-8210
+  let cur = parts[0];
+  for (let i = 0; i < parts.length - 1; ++i) {
+    if (this.paths[cur] != null && this.paths[cur].$isMongooseDocumentArray) {
+      const remnant = parts.slice(i + 1).join('.');
+      const v = this.paths[cur].schema.virtual(remnant);
+      v.get((v, virtual, doc) => {
+        const parent = doc.__parentArray[arrayParentSymbol];
+        const path = cur + '.' + doc.__index + '.' + remnant;
+        return parent.get(path);
+      });
+      break;
+    }
+
+    cur += '.' + parts[i + 1];
+  }
+
   return virtuals[name];
 };
 
@@ -78956,21 +80427,45 @@ Schema.prototype.remove = function(path) {
   }
   if (Array.isArray(path)) {
     path.forEach(function(name) {
-      if (this.path(name)) {
-        delete this.paths[name];
-
-        const pieces = name.split('.');
-        const last = pieces.pop();
-        let branch = this.tree;
-        for (let i = 0; i < pieces.length; ++i) {
-          branch = branch[pieces[i]];
-        }
-        delete branch[last];
+      if (this.path(name) == null && !this.nested[name]) {
+        return;
       }
+      if (this.nested[name]) {
+        const allKeys = Object.keys(this.paths).
+          concat(Object.keys(this.nested));
+        for (const path of allKeys) {
+          if (path.startsWith(name + '.')) {
+            delete this.paths[path];
+            delete this.nested[path];
+            _deletePath(this, path);
+          }
+        }
+
+        delete this.nested[name];
+        _deletePath(this, name);
+        return;
+      }
+
+      delete this.paths[name];
+      _deletePath(this, name);
     }, this);
   }
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+function _deletePath(schema, name) {
+  const pieces = name.split('.');
+  const last = pieces.pop();
+  let branch = schema.tree;
+  for (let i = 0; i < pieces.length; ++i) {
+    branch = branch[pieces[i]];
+  }
+  delete branch[last];
+}
 
 /**
  * Loads an ES6 class into a schema. Maps [setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) + [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get), [static methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static),
@@ -79201,8 +80696,7 @@ Schema.prototype._getPathType = function(path) {
  */
 
 function isArrayFilter(piece) {
-  return piece.indexOf('$[') === 0 &&
-    piece.lastIndexOf(']') === piece.length - 1;
+  return piece.startsWith('$[') && piece.endsWith(']');
 }
 
 /*!
@@ -79249,7 +80743,313 @@ Schema.Types = MongooseTypes = require('./schema/index');
 exports.ObjectId = MongooseTypes.ObjectId;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":245,"./driver":260,"./helpers/get":285,"./helpers/model/applyHooks":287,"./helpers/populate/validateRef":289,"./helpers/query/applyQueryMiddleware":292,"./helpers/schema/getIndexes":293,"./helpers/schema/handleTimestampOption":294,"./helpers/schema/merge":295,"./helpers/update/applyTimestampsToChildren":297,"./helpers/update/applyTimestampsToUpdate":298,"./schema/index":312,"./schema/symbols":324,"./schematype":325,"./utils":336,"./virtualtype":337,"events":242,"kareem":246,"mpath":339,"util":365}],305:[function(require,module,exports){
+},{"../../is-buffer/index.js":244,"./driver":259,"./helpers/get":286,"./helpers/model/applyHooks":288,"./helpers/populate/validateRef":290,"./helpers/query/applyQueryMiddleware":293,"./helpers/schema/getIndexes":295,"./helpers/schema/handleTimestampOption":296,"./helpers/schema/merge":297,"./helpers/symbols":299,"./helpers/update/applyTimestampsToChildren":300,"./helpers/update/applyTimestampsToUpdate":301,"./schema/index":323,"./schema/symbols":335,"./schematype":336,"./utils":348,"./virtualtype":349,"events":242,"kareem":245,"mpath":352,"util":380}],316:[function(require,module,exports){
+'use strict';
+
+/*!
+ * Module dependencies.
+ */
+
+const CastError = require('../error/cast');
+const EventEmitter = require('events').EventEmitter;
+const ObjectExpectedError = require('../error/objectExpected');
+const SchemaType = require('../schematype');
+const $exists = require('./operators/exists');
+const castToNumber = require('./operators/helpers').castToNumber;
+const discriminator = require('../helpers/model/discriminator');
+const geospatial = require('./operators/geospatial');
+const get = require('../helpers/get');
+const getConstructor = require('../helpers/discriminator/getConstructor');
+const internalToObjectOptions = require('../options').internalToObjectOptions;
+
+let Subdocument;
+
+module.exports = SingleNestedPath;
+
+/**
+ * Single nested subdocument SchemaType constructor.
+ *
+ * @param {Schema} schema
+ * @param {String} key
+ * @param {Object} options
+ * @inherits SchemaType
+ * @api public
+ */
+
+function SingleNestedPath(schema, path, options) {
+  this.caster = _createConstructor(schema);
+  this.caster.path = path;
+  this.caster.prototype.$basePath = path;
+  this.schema = schema;
+  this.$isSingleNested = true;
+  SchemaType.call(this, path, options, 'Embedded');
+}
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype = Object.create(SchemaType.prototype);
+SingleNestedPath.prototype.constructor = SingleNestedPath;
+
+/*!
+ * ignore
+ */
+
+function _createConstructor(schema, baseClass) {
+  // lazy load
+  Subdocument || (Subdocument = require('../types/subdocument'));
+
+  const _embedded = function SingleNested(value, path, parent) {
+    const _this = this;
+
+    this.$parent = parent;
+    Subdocument.apply(this, arguments);
+
+    this.$session(this.ownerDocument().$session());
+
+    if (parent) {
+      parent.on('save', function() {
+        _this.emit('save', _this);
+        _this.constructor.emit('save', _this);
+      });
+
+      parent.on('isNew', function(val) {
+        _this.isNew = val;
+        _this.emit('isNew', val);
+        _this.constructor.emit('isNew', val);
+      });
+    }
+  };
+
+  const proto = baseClass != null ? baseClass.prototype : Subdocument.prototype;
+  _embedded.prototype = Object.create(proto);
+  _embedded.prototype.$__setSchema(schema);
+  _embedded.prototype.constructor = _embedded;
+  _embedded.schema = schema;
+  _embedded.$isSingleNested = true;
+  _embedded.events = new EventEmitter();
+  _embedded.prototype.toBSON = function() {
+    return this.toObject(internalToObjectOptions);
+  };
+
+  // apply methods
+  for (const i in schema.methods) {
+    _embedded.prototype[i] = schema.methods[i];
+  }
+
+  // apply statics
+  for (const i in schema.statics) {
+    _embedded[i] = schema.statics[i];
+  }
+
+  for (const i in EventEmitter.prototype) {
+    _embedded[i] = EventEmitter.prototype[i];
+  }
+
+  return _embedded;
+}
+
+/*!
+ * Special case for when users use a common location schema to represent
+ * locations for use with $geoWithin.
+ * https://docs.mongodb.org/manual/reference/operator/query/geoWithin/
+ *
+ * @param {Object} val
+ * @api private
+ */
+
+SingleNestedPath.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val) {
+  return { $geometry: this.castForQuery(val.$geometry) };
+};
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype.$conditionalHandlers.$near =
+SingleNestedPath.prototype.$conditionalHandlers.$nearSphere = geospatial.cast$near;
+
+SingleNestedPath.prototype.$conditionalHandlers.$within =
+SingleNestedPath.prototype.$conditionalHandlers.$geoWithin = geospatial.cast$within;
+
+SingleNestedPath.prototype.$conditionalHandlers.$geoIntersects =
+  geospatial.cast$geoIntersects;
+
+SingleNestedPath.prototype.$conditionalHandlers.$minDistance = castToNumber;
+SingleNestedPath.prototype.$conditionalHandlers.$maxDistance = castToNumber;
+
+SingleNestedPath.prototype.$conditionalHandlers.$exists = $exists;
+
+/**
+ * Casts contents
+ *
+ * @param {Object} value
+ * @api private
+ */
+
+SingleNestedPath.prototype.cast = function(val, doc, init, priorVal) {
+  if (val && val.$isSingleNested) {
+    return val;
+  }
+
+  if (val != null && (typeof val !== 'object' || Array.isArray(val))) {
+    throw new ObjectExpectedError(this.path, val);
+  }
+
+  const Constructor = getConstructor(this.caster, val);
+
+  let subdoc;
+
+  // Only pull relevant selected paths and pull out the base path
+  const parentSelected = get(doc, '$__.selected', {});
+  const path = this.path;
+  const selected = Object.keys(parentSelected).reduce((obj, key) => {
+    if (key.startsWith(path + '.')) {
+      obj[key.substr(path.length + 1)] = parentSelected[key];
+    }
+    return obj;
+  }, {});
+
+  if (init) {
+    subdoc = new Constructor(void 0, selected, doc);
+    subdoc.init(val);
+  } else {
+    if (Object.keys(val).length === 0) {
+      return new Constructor({}, selected, doc);
+    }
+
+    return new Constructor(val, selected, doc, undefined, { priorDoc: priorVal });
+  }
+
+  return subdoc;
+};
+
+/**
+ * Casts contents for query
+ *
+ * @param {string} [$conditional] optional query operator (like `$eq` or `$in`)
+ * @param {any} value
+ * @api private
+ */
+
+SingleNestedPath.prototype.castForQuery = function($conditional, val) {
+  let handler;
+  if (arguments.length === 2) {
+    handler = this.$conditionalHandlers[$conditional];
+    if (!handler) {
+      throw new Error('Can\'t use ' + $conditional);
+    }
+    return handler.call(this, val);
+  }
+  val = $conditional;
+  if (val == null) {
+    return val;
+  }
+
+  if (this.options.runSetters) {
+    val = this._applySetters(val);
+  }
+
+  const Constructor = getConstructor(this.caster, val);
+
+  try {
+    val = new Constructor(val);
+  } catch (error) {
+    // Make sure we always wrap in a CastError (gh-6803)
+    if (!(error instanceof CastError)) {
+      throw new CastError('Embedded', val, this.path, error);
+    }
+    throw error;
+  }
+  return val;
+};
+
+/**
+ * Async validation on this single nested doc.
+ *
+ * @api private
+ */
+
+SingleNestedPath.prototype.doValidate = function(value, fn, scope, options) {
+  const Constructor = getConstructor(this.caster, value);
+
+  if (options && options.skipSchemaValidators) {
+    if (!(value instanceof Constructor)) {
+      value = new Constructor(value, null, scope);
+    }
+
+    return value.validate(fn);
+  }
+
+  SchemaType.prototype.doValidate.call(this, value, function(error) {
+    if (error) {
+      return fn(error);
+    }
+    if (!value) {
+      return fn(null);
+    }
+
+    value.validate(fn);
+  }, scope);
+};
+
+/**
+ * Synchronously validate this single nested doc
+ *
+ * @api private
+ */
+
+SingleNestedPath.prototype.doValidateSync = function(value, scope, options) {
+  if (!options || !options.skipSchemaValidators) {
+    const schemaTypeError = SchemaType.prototype.doValidateSync.call(this, value, scope);
+    if (schemaTypeError) {
+      return schemaTypeError;
+    }
+  }
+  if (!value) {
+    return;
+  }
+  return value.validateSync();
+};
+
+/**
+ * Adds a discriminator to this single nested subdocument.
+ *
+ * ####Example:
+ *     const shapeSchema = Schema({ name: String }, { discriminatorKey: 'kind' });
+ *     const schema = Schema({ shape: shapeSchema });
+ *
+ *     const singleNestedPath = parentSchema.path('child');
+ *     singleNestedPath.discriminator('Circle', Schema({ radius: Number }));
+ *
+ * @param {String} name
+ * @param {Schema} schema fields to add to the schema for instances of this sub-class
+ * @see discriminators /docs/discriminators.html
+ * @api public
+ */
+
+SingleNestedPath.prototype.discriminator = function(name, schema, tiedValue) {
+  discriminator(this.caster, name, schema, tiedValue);
+
+  this.caster.discriminators[name] = _createConstructor(schema, this.caster);
+
+  return this.caster.discriminators[name];
+};
+
+/*!
+ * ignore
+ */
+
+SingleNestedPath.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.schema, this.path, options);
+  schematype.validators = this.validators.slice();
+  schematype.caster.discriminators = Object.assign({}, this.caster.discriminators);
+  return schematype;
+};
+
+},{"../error/cast":265,"../error/objectExpected":272,"../helpers/discriminator/getConstructor":282,"../helpers/get":286,"../helpers/model/discriminator":289,"../options":303,"../schematype":336,"../types/subdocument":347,"./operators/exists":329,"./operators/geospatial":330,"./operators/helpers":331,"events":242}],317:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79259,18 +81059,9 @@ exports.ObjectId = MongooseTypes.ObjectId;
 const $exists = require('./operators/exists');
 const $type = require('./operators/type');
 const MongooseError = require('../error/mongooseError');
+const SchemaArrayOptions = require('../options/SchemaArrayOptions');
 const SchemaType = require('../schematype');
 const CastError = SchemaType.CastError;
-const Types = {
-  Array: SchemaArray,
-  Boolean: require('./boolean'),
-  Date: require('./date'),
-  Number: require('./number'),
-  String: require('./string'),
-  ObjectId: require('./objectid'),
-  Buffer: require('./buffer'),
-  Map: require('./map')
-};
 const Mixed = require('./mixed');
 const cast = require('../cast');
 const get = require('../helpers/get');
@@ -79301,6 +81092,7 @@ function SchemaArray(key, cast, options, schemaOptions) {
   if (schemaOptions && schemaOptions.typeKey) {
     typeKey = schemaOptions.typeKey;
   }
+  this.schemaOptions = schemaOptions;
 
   if (cast) {
     let castOptions = {};
@@ -79325,9 +81117,8 @@ function SchemaArray(key, cast, options, schemaOptions) {
       ? cast
       : utils.getFunctionName(cast);
 
-    const caster = name in Types
-      ? Types[name]
-      : cast;
+    const Types = require('./index.js');
+    const caster = Types.hasOwnProperty(name) ? Types[name] : cast;
 
     this.casterConstructor = caster;
 
@@ -79396,6 +81187,57 @@ SchemaArray.options = { castNonArrays: true };
  */
 SchemaArray.prototype = Object.create(SchemaType.prototype);
 SchemaArray.prototype.constructor = SchemaArray;
+SchemaArray.prototype.OptionsConstructor = SchemaArrayOptions;
+
+/*!
+ * ignore
+ */
+
+SchemaArray._checkRequired = SchemaType.prototype.checkRequired;
+
+/**
+ * Override the function the required validator uses to check whether an array
+ * passes the `required` check.
+ *
+ * ####Example:
+ *
+ *     // Require non-empty array to pass `required` check
+ *     mongoose.Schema.Types.Array.checkRequired(v => Array.isArray(v) && v.length);
+ *
+ *     const M = mongoose.model({ arr: { type: Array, required: true } });
+ *     new M({ arr: [] }).validateSync(); // `null`, validation fails!
+ *
+ * @param {Function} fn
+ * @return {Function}
+ * @function checkRequired
+ * @static
+ * @api public
+ */
+
+SchemaArray.checkRequired = SchemaType.checkRequired;
+
+/**
+ * Check if the given value satisfies the `required` validator.
+ *
+ * @param {Any} value
+ * @param {Document} doc
+ * @return {Boolean}
+ * @api public
+ */
+
+SchemaArray.prototype.checkRequired = function checkRequired(value, doc) {
+  if (SchemaType._isRef(this, value, doc, true)) {
+    return !!value;
+  }
+
+  // `require('util').inherits()` does **not** copy static properties, and
+  // plugins like mongoose-float use `inherits()` for pre-ES6.
+  const _checkRequired = typeof this.constructor.checkRequired == 'function' ?
+    this.constructor.checkRequired() :
+    SchemaArray.checkRequired();
+
+  return _checkRequired(value);
+};
 
 /**
  * Adds an enum validator if this is an array of strings. Equivalent to
@@ -79406,11 +81248,19 @@ SchemaArray.prototype.constructor = SchemaArray;
  */
 
 SchemaArray.prototype.enum = function() {
-  const instance = get(this, 'caster.instance');
-  if (instance !== 'String') {
-    throw new Error('`enum` can only be set on an array of strings, not ' + instance);
+  let arr = this; /* eslint consistent-this: 0 */
+  while (true) { /* eslint no-constant-condition: 0 */
+    const instance = get(arr, 'caster.instance');
+    if (instance === 'Array') {
+      arr = arr.caster;
+      continue;
+    }
+    if (instance !== 'String') {
+      throw new Error('`enum` can only be set on an array of strings, not ' + instance);
+    }
+    break;
   }
-  this.caster.enum.apply(this.caster, arguments);
+  arr.caster.enum.apply(arr.caster, arguments);
   return this;
 };
 
@@ -79451,10 +81301,24 @@ SchemaArray.prototype.cast = function(value, doc, init) {
     if (!value.length && doc) {
       const indexes = doc.schema.indexedPaths();
 
+      const arrayPath = this.path;
       for (i = 0, l = indexes.length; i < l; ++i) {
-        const pathIndex = indexes[i][0][this.path];
+        const pathIndex = indexes[i][0][arrayPath];
         if (pathIndex === '2dsphere' || pathIndex === '2d') {
           return;
+        }
+      }
+
+      // Special case: if this index is on the parent of what looks like
+      // GeoJSON, skip setting the default to empty array re: #1668, #3233
+      const arrayGeojsonPath = this.path.endsWith('.coordinates') ?
+        this.path.substr(0, this.path.lastIndexOf('.')) : null;
+      if (arrayGeojsonPath != null) {
+        for (i = 0, l = indexes.length; i < l; ++i) {
+          const pathIndex = indexes[i][0][arrayGeojsonPath];
+          if (pathIndex === '2dsphere') {
+            return;
+          }
         }
       }
     }
@@ -79465,6 +81329,11 @@ SchemaArray.prototype.cast = function(value, doc, init) {
       // We need to create a new array, otherwise change tracking will
       // update the old doc (gh-4449)
       value = new MongooseArray(value, this.path, doc);
+    }
+
+    const isPopulated = doc != null && doc.$__ != null && doc.populated(this.path);
+    if (isPopulated) {
+      return value;
     }
 
     if (this.caster && this.casterConstructor !== Mixed) {
@@ -79507,6 +81376,17 @@ SchemaArray.prototype.discriminator = function(name, schema) {
     }
   }
   return arr.discriminator(name, schema);
+};
+
+/*!
+ * ignore
+ */
+
+SchemaArray.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, this.caster, options, this.schemaOptions);
+  schematype.validators = this.validators.slice();
+  return schematype;
 };
 
 /**
@@ -79607,7 +81487,7 @@ function cast$elemMatch(val) {
   for (let i = 0; i < numKeys; ++i) {
     const key = keys[i];
     const value = val[key];
-    if (key.indexOf('$') === 0 && value) {
+    if (key.startsWith('$') && value) {
       val[key] = this.castForQuery(key, value);
     }
   }
@@ -79664,11 +81544,11 @@ handle.$gte =
 handle.$lt =
 handle.$lte =
 handle.$ne =
-handle.$nin =
 handle.$regex = SchemaArray.prototype.castForQuery;
 
 // `$in` is special because you can also include an empty array in the query
 // like `$in: [1, []]`, see gh-5913
+handle.$nin = SchemaType.prototype.$conditionalHandlers.$nin;
 handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
 
 /*!
@@ -79677,7 +81557,7 @@ handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
 
 module.exports = SchemaArray;
 
-},{"../cast":251,"../error/mongooseError":271,"../helpers/get":285,"../queryhelpers":303,"../schematype":325,"../types":332,"../utils":336,"./boolean":306,"./buffer":307,"./date":308,"./map":313,"./mixed":314,"./number":315,"./objectid":316,"./operators/exists":318,"./operators/geospatial":319,"./operators/helpers":320,"./operators/type":322,"./string":323,"util":365}],306:[function(require,module,exports){
+},{"../cast":250,"../error/mongooseError":270,"../helpers/get":286,"../options/SchemaArrayOptions":305,"../queryhelpers":314,"../schematype":336,"../types":344,"../utils":348,"./index.js":323,"./mixed":325,"./operators/exists":329,"./operators/geospatial":330,"./operators/helpers":331,"./operators/type":333,"util":380}],318:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79887,7 +81767,7 @@ SchemaBoolean.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaBoolean;
 
-},{"../cast/boolean":252,"../error/cast":266,"../schematype":325,"../utils":336}],307:[function(require,module,exports){
+},{"../cast/boolean":251,"../error/cast":265,"../schematype":336,"../utils":348}],319:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -79895,11 +81775,13 @@ module.exports = SchemaBoolean;
 
 'use strict';
 
+const MongooseBuffer = require('../types/buffer');
+const SchemaBufferOptions = require('../options/SchemaBufferOptions');
+const SchemaType = require('../schematype');
 const handleBitwiseOperator = require('./operators/bitwise');
 const utils = require('../utils');
 
-const MongooseBuffer = require('../types/buffer');
-const SchemaType = require('../schematype');
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const Binary = MongooseBuffer.Binary;
 const CastError = SchemaType.CastError;
@@ -79931,6 +81813,7 @@ SchemaBuffer.schemaName = 'Buffer';
  */
 SchemaBuffer.prototype = Object.create(SchemaType.prototype);
 SchemaBuffer.prototype.constructor = SchemaBuffer;
+SchemaBuffer.prototype.OptionsConstructor = SchemaBufferOptions;
 
 /*!
  * ignore
@@ -80016,7 +81899,7 @@ SchemaBuffer.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    ret = new pop.options.model(value);
+    ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -80141,18 +82024,18 @@ SchemaBuffer.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaBuffer;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../schematype":325,"../types/buffer":328,"../utils":336,"./../document":258,"./operators/bitwise":317}],308:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../helpers/symbols":299,"../options/SchemaBufferOptions":306,"../schematype":336,"../types/buffer":339,"../utils":348,"./../document":257,"./operators/bitwise":328}],320:[function(require,module,exports){
 /*!
  * Module requirements.
  */
 
 'use strict';
 
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaDateOptions = require('../options/SchemaDateOptions');
+const SchemaType = require('../schematype');
 const castDate = require('../cast/date');
 const utils = require('../utils');
-
-const SchemaType = require('../schematype');
 
 const CastError = SchemaType.CastError;
 
@@ -80182,6 +82065,7 @@ SchemaDate.schemaName = 'Date';
  */
 SchemaDate.prototype = Object.create(SchemaType.prototype);
 SchemaDate.prototype.constructor = SchemaDate;
+SchemaDate.prototype.OptionsConstructor = SchemaDateOptions;
 
 /*!
  * ignore
@@ -80360,11 +82244,15 @@ SchemaDate.prototype.min = function(value, message) {
 
   if (value) {
     let msg = message || MongooseError.messages.Date.min;
-    msg = msg.replace(/{MIN}/, (value === Date.now ? 'Date.now()' : this.cast(value).toString()));
+    msg = msg.replace(/{MIN}/, (value === Date.now ? 'Date.now()' : value.toString()));
     const _this = this;
     this.validators.push({
       validator: this.minValidator = function(val) {
-        const min = (value === Date.now ? value() : _this.cast(value));
+        let _value = value;
+        if (typeof value === 'function' && value !== Date.now) {
+          _value = _value.call(this);
+        }
+        const min = (_value === Date.now ? _value() : _this.cast(_value));
         return val === null || val.valueOf() >= min.valueOf();
       },
       message: msg,
@@ -80416,11 +82304,15 @@ SchemaDate.prototype.max = function(value, message) {
 
   if (value) {
     let msg = message || MongooseError.messages.Date.max;
-    msg = msg.replace(/{MAX}/, (value === Date.now ? 'Date.now()' : this.cast(value).toString()));
+    msg = msg.replace(/{MAX}/, (value === Date.now ? 'Date.now()' : value.toString()));
     const _this = this;
     this.validators.push({
       validator: this.maxValidator = function(val) {
-        const max = (value === Date.now ? value() : _this.cast(value));
+        let _value = value;
+        if (typeof _value === 'function' && _value !== Date.now) {
+          _value = _value.call(this);
+        }
+        const max = (_value === Date.now ? _value() : _this.cast(_value));
         return val === null || val.valueOf() <= max.valueOf();
       },
       message: msg,
@@ -80497,7 +82389,7 @@ SchemaDate.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaDate;
 
-},{"../cast/date":253,"../error":268,"../schematype":325,"../utils":336}],309:[function(require,module,exports){
+},{"../cast/date":252,"../error/index":267,"../options/SchemaDateOptions":307,"../schematype":336,"../utils":348}],321:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -80510,6 +82402,8 @@ const CastError = SchemaType.CastError;
 const Decimal128Type = require('../types/decimal128');
 const castDecimal128 = require('../cast/decimal128');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 let Document;
 
@@ -80671,7 +82565,7 @@ Decimal128.prototype.cast = function(value, doc, init) {
         !doc.$__.populated[path].options ||
         !doc.$__.populated[path].options.options ||
         !doc.$__.populated[path].options.options.lean) {
-      ret = new pop.options.model(value);
+      ret = new pop.options[populateModelSymbol](value);
       ret.$__.wasPopulated = true;
     }
 
@@ -80711,7 +82605,7 @@ Decimal128.prototype.$conditionalHandlers =
 module.exports = Decimal128;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../cast/decimal128":254,"../schematype":325,"../types/decimal128":329,"../utils":336,"./../document":258}],310:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../cast/decimal128":253,"../helpers/symbols":299,"../schematype":336,"../types/decimal128":341,"../utils":348,"./../document":257}],322:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -80725,7 +82619,10 @@ const SchemaType = require('../schematype');
 const discriminator = require('../helpers/model/discriminator');
 const util = require('util');
 const utils = require('../utils');
-const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
+const getConstructor = require('../helpers/discriminator/getConstructor');
+
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
 
 let MongooseDocumentArray;
 let Subdocument;
@@ -80796,7 +82693,7 @@ DocumentArray.prototype.constructor = DocumentArray;
  * Ignore
  */
 
-function _createConstructor(schema, options) {
+function _createConstructor(schema, options, baseClass) {
   Subdocument || (Subdocument = require('../types/embedded'));
 
   // compile an embedded document for this schema
@@ -80806,7 +82703,8 @@ function _createConstructor(schema, options) {
     this.$session(this.ownerDocument().$session());
   }
 
-  EmbeddedDocument.prototype = Object.create(Subdocument.prototype);
+  const proto = baseClass != null ? baseClass.prototype : Subdocument.prototype;
+  EmbeddedDocument.prototype = Object.create(proto);
   EmbeddedDocument.prototype.$__setSchema(schema);
   EmbeddedDocument.schema = schema;
   EmbeddedDocument.prototype.constructor = EmbeddedDocument;
@@ -80836,14 +82734,14 @@ function _createConstructor(schema, options) {
  * Ignore
  */
 
-DocumentArray.prototype.discriminator = function(name, schema) {
+DocumentArray.prototype.discriminator = function(name, schema, tiedValue) {
   if (typeof name === 'function') {
     name = utils.getFunctionName(name);
   }
 
-  schema = discriminator(this.casterConstructor, name, schema);
+  schema = discriminator(this.casterConstructor, name, schema, tiedValue);
 
-  const EmbeddedDocument = _createConstructor(schema);
+  const EmbeddedDocument = _createConstructor(schema, null, this.casterConstructor);
   EmbeddedDocument.baseCasterConstructor = this.casterConstructor;
 
   try {
@@ -80921,8 +82819,8 @@ DocumentArray.prototype.doValidate = function(array, fn, scope, options) {
       // If you set the array index directly, the doc might not yet be
       // a full fledged mongoose subdoc, so make it into one.
       if (!(doc instanceof Subdocument)) {
-        doc = array[i] = new _this.casterConstructor(doc, array, undefined,
-          undefined, i);
+        const Constructor = getConstructor(_this.casterConstructor, array[i]);
+        doc = array[i] = new Constructor(doc, array, undefined, undefined, i);
       }
 
       doc.$__validate(callback);
@@ -80969,8 +82867,8 @@ DocumentArray.prototype.doValidateSync = function(array, scope) {
     // If you set the array index directly, the doc might not yet be
     // a full fledged mongoose subdoc, so make it into one.
     if (!(doc instanceof Subdocument)) {
-      doc = array[i] = new this.casterConstructor(doc, array, undefined,
-        undefined, i);
+      const Constructor = getConstructor(this.casterConstructor, array[i]);
+      doc = array[i] = new Constructor(doc, array, undefined, undefined, i);
     }
 
     const subdocValidateError = doc.validateSync();
@@ -81004,15 +82902,16 @@ DocumentArray.prototype.getDefault = function(scope) {
   }
 
   ret = new MongooseDocumentArray(ret, this.path, scope);
-  const _parent = ret._parent;
-  ret._parent = null;
+  const _parent = ret[arrayParentSymbol];
+  ret[arrayParentSymbol] = null;
 
   for (let i = 0; i < ret.length; ++i) {
-    ret[i] = new this.Constructor(ret[i], ret, undefined,
+    const Constructor = getConstructor(this.casterConstructor, ret[i]);
+    ret[i] = new Constructor(ret[i], ret, undefined,
       undefined, i);
   }
 
-  ret._parent = _parent;
+  ret[arrayParentSymbol] = _parent;
 
   return ret;
 };
@@ -81049,7 +82948,6 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
   if (!(value && value.isMongooseDocumentArray) &&
       (!options || !options.skipDocumentArrayCast)) {
     value = new MongooseDocumentArray(value, this.path, doc);
-    _clearListeners(prev);
   } else if (value && value.isMongooseDocumentArray) {
     // We need to create a new array, otherwise change tracking will
     // update the old doc (gh-4449)
@@ -81063,30 +82961,24 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
       continue;
     }
 
-    let Constructor = this.casterConstructor;
-    if (Constructor.discriminators &&
-        Constructor.schema &&
-        Constructor.schema.options &&
-        typeof value[i][Constructor.schema.options.discriminatorKey] === 'string') {
-      if (Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]]) {
-        Constructor = Constructor.discriminators[value[i][Constructor.schema.options.discriminatorKey]];
-      } else {
-        const constructorByValue = getDiscriminatorByValue(Constructor, value[i][Constructor.schema.options.discriminatorKey]);
-        if (constructorByValue) {
-          Constructor = constructorByValue;
-        }
-      }
-    }
+    const Constructor = getConstructor(this.casterConstructor, value[i]);
 
     // Check if the document has a different schema (re gh-3701)
     if ((value[i].$__) &&
-        value[i].schema !== Constructor.schema) {
-      value[i] = value[i].toObject({ transform: false, virtuals: false });
+        !(value[i] instanceof Constructor)) {
+      value[i] = value[i].toObject({
+        transform: false,
+        // Special case: if different model, but same schema, apply virtuals
+        // re: gh-7898
+        virtuals: value[i].schema === Constructor.schema
+      });
     }
 
     if (value[i] instanceof Subdocument) {
       // Might not have the correct index yet, so ensure it does.
-      value[i].$setIndex(i);
+      if (value[i].__index == null) {
+        value[i].$setIndex(i);
+      }
     } else if (value[i] != null) {
       if (init) {
         if (doc) {
@@ -81098,7 +82990,7 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
         subdoc = new Constructor(null, value, true, selected, i);
         value[i] = subdoc.init(value[i]);
       } else {
-        if (prev && (subdoc = prev.id(value[i]._id))) {
+        if (prev && typeof prev.id === 'function') {
           subdoc = prev.id(value[i]._id);
         }
 
@@ -81116,12 +83008,9 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
             // see gh-746
             value[i] = subdoc;
           } catch (error) {
-            // Make sure we don't leave listeners dangling because `value`
-            // won't get back up to the schema type. See gh-6723
-            _clearListeners(value);
             const valueInErrorMessage = util.inspect(value[i]);
             throw new CastError('embedded', valueInErrorMessage,
-              value._path, error);
+              value[arrayPathSymbol], error);
           }
         }
       }
@@ -81132,18 +83021,17 @@ DocumentArray.prototype.cast = function(value, doc, init, prev, options) {
 };
 
 /*!
- * Removes listeners from parent
+ * ignore
  */
 
-function _clearListeners(arr) {
-  if (arr == null || arr._parent == null) {
-    return;
-  }
-
-  for (const key in arr._handlers) {
-    arr._parent.removeListener(key, arr._handlers[key]);
-  }
-}
+DocumentArray.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, this.schema, options, this.schemaOptions);
+  schematype.validators = this.validators.slice();
+  schematype.Constructor.discriminators = Object.assign({},
+    this.Constructor.discriminators);
+  return schematype;
+};
 
 /*!
  * Scopes paths selected in a query to this array.
@@ -81169,12 +83057,12 @@ function scopePaths(array, fields, init) {
 
   while (i--) {
     key = keys[i];
-    if (key.indexOf(path) === 0) {
+    if (key.startsWith(path)) {
       sub = key.substring(path.length);
       if (sub === '$') {
         continue;
       }
-      if (sub.indexOf('$.') === 0) {
+      if (sub.startsWith('$.')) {
         sub = sub.substr(2);
       }
       hasKeys || (hasKeys = true);
@@ -81191,329 +83079,7 @@ function scopePaths(array, fields, init) {
 
 module.exports = DocumentArray;
 
-},{"../error/cast":266,"../helpers/model/discriminator":288,"../queryhelpers":303,"../schematype":325,"../types/documentarray":330,"../types/embedded":331,"../utils":336,"./array":305,"events":242,"util":365}],311:[function(require,module,exports){
-'use strict';
-
-/*!
- * Module dependencies.
- */
-
-const CastError = require('../error/cast');
-const EventEmitter = require('events').EventEmitter;
-const ObjectExpectedError = require('../error/objectExpected');
-const SchemaType = require('../schematype');
-const $exists = require('./operators/exists');
-const castToNumber = require('./operators/helpers').castToNumber;
-const discriminator = require('../helpers/model/discriminator');
-const geospatial = require('./operators/geospatial');
-const get = require('../helpers/get');
-const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
-const internalToObjectOptions = require('../options').internalToObjectOptions;
-
-let Subdocument;
-
-module.exports = Embedded;
-
-/**
- * Sub-schema schematype constructor
- *
- * @param {Schema} schema
- * @param {String} key
- * @param {Object} options
- * @inherits SchemaType
- * @api public
- */
-
-function Embedded(schema, path, options) {
-  this.caster = _createConstructor(schema);
-  this.caster.path = path;
-  this.caster.prototype.$basePath = path;
-  this.schema = schema;
-  this.$isSingleNested = true;
-  SchemaType.call(this, path, options, 'Embedded');
-}
-
-/*!
- * ignore
- */
-
-Embedded.prototype = Object.create(SchemaType.prototype);
-
-/*!
- * ignore
- */
-
-function _createConstructor(schema) {
-  // lazy load
-  Subdocument || (Subdocument = require('../types/subdocument'));
-
-  const _embedded = function SingleNested(value, path, parent) {
-    const _this = this;
-
-    this.$parent = parent;
-    Subdocument.apply(this, arguments);
-
-    this.$session(this.ownerDocument().$session());
-
-    if (parent) {
-      parent.on('save', function() {
-        _this.emit('save', _this);
-        _this.constructor.emit('save', _this);
-      });
-
-      parent.on('isNew', function(val) {
-        _this.isNew = val;
-        _this.emit('isNew', val);
-        _this.constructor.emit('isNew', val);
-      });
-    }
-  };
-  _embedded.prototype = Object.create(Subdocument.prototype);
-  _embedded.prototype.$__setSchema(schema);
-  _embedded.prototype.constructor = _embedded;
-  _embedded.schema = schema;
-  _embedded.$isSingleNested = true;
-  _embedded.events = new EventEmitter();
-  _embedded.prototype.toBSON = function() {
-    return this.toObject(internalToObjectOptions);
-  };
-
-  // apply methods
-  for (const i in schema.methods) {
-    _embedded.prototype[i] = schema.methods[i];
-  }
-
-  // apply statics
-  for (const i in schema.statics) {
-    _embedded[i] = schema.statics[i];
-  }
-
-  for (const i in EventEmitter.prototype) {
-    _embedded[i] = EventEmitter.prototype[i];
-  }
-
-  return _embedded;
-}
-
-/*!
- * Special case for when users use a common location schema to represent
- * locations for use with $geoWithin.
- * https://docs.mongodb.org/manual/reference/operator/query/geoWithin/
- *
- * @param {Object} val
- * @api private
- */
-
-Embedded.prototype.$conditionalHandlers.$geoWithin = function handle$geoWithin(val) {
-  return { $geometry: this.castForQuery(val.$geometry) };
-};
-
-/*!
- * ignore
- */
-
-Embedded.prototype.$conditionalHandlers.$near =
-Embedded.prototype.$conditionalHandlers.$nearSphere = geospatial.cast$near;
-
-Embedded.prototype.$conditionalHandlers.$within =
-Embedded.prototype.$conditionalHandlers.$geoWithin = geospatial.cast$within;
-
-Embedded.prototype.$conditionalHandlers.$geoIntersects =
-  geospatial.cast$geoIntersects;
-
-Embedded.prototype.$conditionalHandlers.$minDistance = castToNumber;
-Embedded.prototype.$conditionalHandlers.$maxDistance = castToNumber;
-
-Embedded.prototype.$conditionalHandlers.$exists = $exists;
-
-/**
- * Casts contents
- *
- * @param {Object} value
- * @api private
- */
-
-Embedded.prototype.cast = function(val, doc, init, priorVal) {
-  if (val && val.$isSingleNested) {
-    return val;
-  }
-
-  if (val != null && (typeof val !== 'object' || Array.isArray(val))) {
-    throw new ObjectExpectedError(this.path, val);
-  }
-
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (val != null &&
-      Constructor.discriminators &&
-      typeof val[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[val[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[val[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, val[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  let subdoc;
-
-  // Only pull relevant selected paths and pull out the base path
-  const parentSelected = get(doc, '$__.selected', {});
-  const path = this.path;
-  const selected = Object.keys(parentSelected).reduce((obj, key) => {
-    if (key.startsWith(path + '.')) {
-      obj[key.substr(path.length + 1)] = parentSelected[key];
-    }
-    return obj;
-  }, {});
-
-  if (init) {
-    subdoc = new Constructor(void 0, selected, doc);
-    subdoc.init(val);
-  } else {
-    if (Object.keys(val).length === 0) {
-      return new Constructor({}, selected, doc);
-    }
-
-    return new Constructor(val, selected, doc, undefined, { priorDoc: priorVal });
-  }
-
-  return subdoc;
-};
-
-/**
- * Casts contents for query
- *
- * @param {string} [$conditional] optional query operator (like `$eq` or `$in`)
- * @param {any} value
- * @api private
- */
-
-Embedded.prototype.castForQuery = function($conditional, val) {
-  let handler;
-  if (arguments.length === 2) {
-    handler = this.$conditionalHandlers[$conditional];
-    if (!handler) {
-      throw new Error('Can\'t use ' + $conditional);
-    }
-    return handler.call(this, val);
-  }
-  val = $conditional;
-  if (val == null) {
-    return val;
-  }
-
-  if (this.options.runSetters) {
-    val = this._applySetters(val);
-  }
-
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (val != null &&
-      Constructor.discriminators &&
-      typeof val[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[val[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[val[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, val[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  try {
-    val = new Constructor(val);
-  } catch (error) {
-    // Make sure we always wrap in a CastError (gh-6803)
-    if (!(error instanceof CastError)) {
-      throw new CastError('Embedded', val, this.path, error);
-    }
-    throw error;
-  }
-  return val;
-};
-
-/**
- * Async validation on this single nested doc.
- *
- * @api private
- */
-
-Embedded.prototype.doValidate = function(value, fn, scope, options) {
-  let Constructor = this.caster;
-  const discriminatorKey = Constructor.schema.options.discriminatorKey;
-  if (value != null &&
-      Constructor.discriminators &&
-      typeof value[discriminatorKey] === 'string') {
-    if (Constructor.discriminators[value[discriminatorKey]]) {
-      Constructor = Constructor.discriminators[value[discriminatorKey]];
-    } else {
-      const constructorByValue = getDiscriminatorByValue(Constructor, value[discriminatorKey]);
-      if (constructorByValue) {
-        Constructor = constructorByValue;
-      }
-    }
-  }
-
-  if (options && options.skipSchemaValidators) {
-    if (!(value instanceof Constructor)) {
-      value = new Constructor(value, null, scope);
-    }
-
-    return value.validate(fn);
-  }
-
-  SchemaType.prototype.doValidate.call(this, value, function(error) {
-    if (error) {
-      return fn(error);
-    }
-    if (!value) {
-      return fn(null);
-    }
-
-    value.validate(fn);
-  }, scope);
-};
-
-/**
- * Synchronously validate this single nested doc
- *
- * @api private
- */
-
-Embedded.prototype.doValidateSync = function(value, scope, options) {
-  if (!options || !options.skipSchemaValidators) {
-    const schemaTypeError = SchemaType.prototype.doValidateSync.call(this, value, scope);
-    if (schemaTypeError) {
-      return schemaTypeError;
-    }
-  }
-  if (!value) {
-    return;
-  }
-  return value.validateSync();
-};
-
-/**
- * Adds a discriminator to this property
- *
- * @param {String} name
- * @param {Schema} schema fields to add to the schema for instances of this sub-class
- * @api public
- */
-
-Embedded.prototype.discriminator = function(name, schema) {
-  discriminator(this.caster, name, schema);
-
-  this.caster.discriminators[name] = _createConstructor(schema);
-
-  return this.caster.discriminators[name];
-};
-
-},{"../error/cast":266,"../error/objectExpected":273,"../helpers/get":285,"../helpers/model/discriminator":288,"../options":300,"../queryhelpers":303,"../schematype":325,"../types/subdocument":335,"./operators/exists":318,"./operators/geospatial":319,"./operators/helpers":320,"events":242}],312:[function(require,module,exports){
+},{"../error/cast":265,"../helpers/discriminator/getConstructor":282,"../helpers/model/discriminator":289,"../helpers/symbols":299,"../schematype":336,"../types/documentarray":342,"../types/embedded":343,"../utils":348,"./array":317,"events":242,"util":380}],323:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -81529,7 +83095,7 @@ exports.Boolean = require('./boolean');
 
 exports.DocumentArray = require('./documentarray');
 
-exports.Embedded = require('./embedded');
+exports.Embedded = require('./SingleNestedPath');
 
 exports.Array = require('./array');
 
@@ -81550,8 +83116,10 @@ exports.Map = require('./map');
 exports.Oid = exports.ObjectId;
 exports.Object = exports.Mixed;
 exports.Bool = exports.Boolean;
+exports.ObjectID = exports.ObjectId;
 
-},{"./array":305,"./boolean":306,"./buffer":307,"./date":308,"./decimal128":309,"./documentarray":310,"./embedded":311,"./map":313,"./mixed":314,"./number":315,"./objectid":316,"./string":323}],313:[function(require,module,exports){
+},{"./SingleNestedPath":316,"./array":317,"./boolean":318,"./buffer":319,"./date":320,"./decimal128":321,"./documentarray":322,"./map":324,"./mixed":325,"./number":326,"./objectid":327,"./string":334}],324:[function(require,module,exports){
+(function (global){
 'use strict';
 
 /*!
@@ -81579,8 +83147,14 @@ class Map extends SchemaType {
     if (init) {
       const map = new MongooseMap({}, this.path, doc, this.$__schemaType);
 
-      for (const key of Object.keys(val)) {
-        map.$init(key, this.$__schemaType.cast(val[key], doc, true));
+      if (val instanceof global.Map) {
+        for (const key of val.keys()) {
+          map.$init(key, map.$__schemaType.cast(val.get(key), doc, true));
+        }
+      } else {
+        for (const key of Object.keys(val)) {
+          map.$init(key, map.$__schemaType.cast(val[key], doc, true));
+        }
       }
 
       return map;
@@ -81592,7 +83166,8 @@ class Map extends SchemaType {
 
 module.exports = Map;
 
-},{"../schematype":325,"../types/map":333}],314:[function(require,module,exports){
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"../schematype":336,"../types/map":345}],325:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -81699,7 +83274,7 @@ Mixed.prototype.castForQuery = function($cond, val) {
 
 module.exports = Mixed;
 
-},{"../schematype":325,"../utils":336,"./symbols":324}],315:[function(require,module,exports){
+},{"../schematype":336,"../utils":348,"./symbols":335}],326:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -81707,11 +83282,14 @@ module.exports = Mixed;
  * Module requirements.
  */
 
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaNumberOptions = require('../options/SchemaNumberOptions');
 const SchemaType = require('../schematype');
 const castNumber = require('../cast/number');
 const handleBitwiseOperator = require('./operators/bitwise');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const CastError = SchemaType.CastError;
 let Document;
@@ -81807,6 +83385,7 @@ SchemaNumber.schemaName = 'Number';
  */
 SchemaNumber.prototype = Object.create(SchemaType.prototype);
 SchemaNumber.prototype.constructor = SchemaNumber;
+SchemaNumber.prototype.OptionsConstructor = SchemaNumberOptions;
 
 /*!
  * ignore
@@ -81996,7 +83575,7 @@ SchemaNumber.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    const ret = new pop.options.model(value);
+    const ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -82074,7 +83653,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaNumber;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../cast/number":255,"../error":268,"../schematype":325,"../utils":336,"./../document":258,"./operators/bitwise":317}],316:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../cast/number":254,"../error/index":267,"../helpers/symbols":299,"../options/SchemaNumberOptions":308,"../schematype":336,"../utils":348,"./../document":257,"./operators/bitwise":328}],327:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module dependencies.
@@ -82082,10 +83661,13 @@ module.exports = SchemaNumber;
 
 'use strict';
 
-const castObjectId = require('../cast/objectid');
+const SchemaObjectIdOptions = require('../options/SchemaObjectIdOptions');
 const SchemaType = require('../schematype');
+const castObjectId = require('../cast/objectid');
 const oid = require('../types/objectid');
 const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 const CastError = SchemaType.CastError;
 let Document;
@@ -82125,6 +83707,7 @@ ObjectId.schemaName = 'ObjectId';
  */
 ObjectId.prototype = Object.create(SchemaType.prototype);
 ObjectId.prototype.constructor = ObjectId;
+ObjectId.prototype.OptionsConstructor = SchemaObjectIdOptions;
 
 /**
  * Attaches a getter for all ObjectId instances
@@ -82304,7 +83887,7 @@ ObjectId.prototype.cast = function(value, doc, init) {
         !doc.$__.populated[path].options ||
         !doc.$__.populated[path].options.options ||
         !doc.$__.populated[path].options.options.lean) {
-      ret = new pop.options.model(value);
+      ret = new pop.options[populateModelSymbol](value);
       ret.$__.wasPopulated = true;
     }
 
@@ -82370,7 +83953,7 @@ function resetId(v) {
 module.exports = ObjectId;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../cast/objectid":256,"../schematype":325,"../types/objectid":334,"../utils":336,"./../document":258}],317:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../cast/objectid":255,"../helpers/symbols":299,"../options/SchemaObjectIdOptions":309,"../schematype":336,"../types/objectid":346,"../utils":348,"./../document":257}],328:[function(require,module,exports){
 (function (Buffer){
 /*!
  * Module requirements.
@@ -82412,7 +83995,7 @@ function _castNumber(path, num) {
 module.exports = handleBitwiseOperator;
 
 }).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":245,"../../error/cast":266}],318:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":244,"../../error/cast":265}],329:[function(require,module,exports){
 'use strict';
 
 const castBoolean = require('../../cast/boolean');
@@ -82426,7 +84009,7 @@ module.exports = function(val) {
   return castBoolean(val, path);
 };
 
-},{"../../cast/boolean":252}],319:[function(require,module,exports){
+},{"../../cast/boolean":251}],330:[function(require,module,exports){
 /*!
  * Module requirements.
  */
@@ -82530,7 +84113,7 @@ function _castMinMaxDistance(self, val) {
   }
 }
 
-},{"../array":305,"./helpers":320}],320:[function(require,module,exports){
+},{"../array":317,"./helpers":331}],331:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -82564,7 +84147,7 @@ function castArraysOfNumbers(arr, self) {
   });
 }
 
-},{"../number":315}],321:[function(require,module,exports){
+},{"../number":326}],332:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../../error/cast');
@@ -82605,7 +84188,7 @@ module.exports = function(val, path) {
   return val;
 };
 
-},{"../../cast/boolean":252,"../../cast/string":257,"../../error/cast":266}],322:[function(require,module,exports){
+},{"../../cast/boolean":251,"../../cast/string":256,"../../error/cast":265}],333:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -82620,7 +84203,7 @@ module.exports = function(val) {
   return val;
 };
 
-},{}],323:[function(require,module,exports){
+},{}],334:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -82629,11 +84212,14 @@ module.exports = function(val) {
  */
 
 const SchemaType = require('../schematype');
-const CastError = SchemaType.CastError;
-const MongooseError = require('../error');
+const MongooseError = require('../error/index');
+const SchemaStringOptions = require('../options/SchemaStringOptions');
 const castString = require('../cast/string');
 const utils = require('../utils');
 
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
+
+const CastError = SchemaType.CastError;
 let Document;
 
 /**
@@ -82664,6 +84250,7 @@ SchemaString.schemaName = 'String';
  */
 SchemaString.prototype = Object.create(SchemaType.prototype);
 SchemaString.prototype.constructor = SchemaString;
+SchemaString.prototype.OptionsConstructor = SchemaStringOptions;
 
 /*!
  * ignore
@@ -83161,7 +84748,7 @@ SchemaString.prototype.cast = function(value, doc, init) {
     const path = doc.$__fullPath(this.path);
     const owner = doc.ownerDocument ? doc.ownerDocument() : doc;
     const pop = owner.populated(path, true);
-    const ret = new pop.options.model(value);
+    const ret = new pop.options[populateModelSymbol](value);
     ret.$__.wasPopulated = true;
     return ret;
   }
@@ -83201,7 +84788,7 @@ SchemaString.prototype.$conditionalHandlers =
       $gte: handleSingle,
       $lt: handleSingle,
       $lte: handleSingle,
-      $options: handleSingle,
+      $options: String,
       $regex: handleSingle,
       $not: handleSingle
     });
@@ -83238,13 +84825,13 @@ SchemaString.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaString;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../cast/string":257,"../error":268,"../schematype":325,"../utils":336,"./../document":258}],324:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../cast/string":256,"../error/index":267,"../helpers/symbols":299,"../options/SchemaStringOptions":310,"../schematype":336,"../utils":348,"./../document":257}],335:[function(require,module,exports){
 'use strict';
 
 exports.schemaMixedSymbol = Symbol.for('mongoose:schema_mixed');
 
 exports.builtInMiddleware = Symbol.for('mongoose:built-in-middleware');
-},{}],325:[function(require,module,exports){
+},{}],336:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -83252,11 +84839,15 @@ exports.builtInMiddleware = Symbol.for('mongoose:built-in-middleware');
  * Module dependencies.
  */
 
-const MongooseError = require('./error');
+const MongooseError = require('./error/index');
+const SchemaTypeOptions = require('./options/SchemaTypeOptions');
 const $exists = require('./schema/operators/exists');
 const $type = require('./schema/operators/type');
 const get = require('./helpers/get');
+const handleImmutable = require('./helpers/schematype/handleImmutable');
 const immediate = require('./helpers/immediate');
+const schemaTypeSymbol = require('./helpers/symbols').schemaTypeSymbol;
+const util = require('util');
 const utils = require('./utils');
 const validatorErrorSymbol = require('./helpers/symbols').validatorErrorSymbol;
 
@@ -83273,12 +84864,13 @@ const ValidatorError = MongooseError.ValidatorError;
  *     schema.path('name') instanceof SchemaType; // true
  *
  * @param {String} path
- * @param {Object} [options]
+ * @param {SchemaTypeOptions} [options] See [SchemaTypeOptions docs](/docs/api/schematypeoptions.html)
  * @param {String} [instance]
  * @api public
  */
 
 function SchemaType(path, options, instance) {
+  this[schemaTypeSymbol] = true;
   this.path = path;
   this.instance = instance;
   this.validators = [];
@@ -83286,14 +84878,37 @@ function SchemaType(path, options, instance) {
     this.constructor.getters.slice() :
     [];
   this.setters = [];
-  this.options = options;
+
+  const Options = this.OptionsConstructor || SchemaTypeOptions;
+  this.options = new Options(options);
   this._index = null;
   this.selected;
+  if (utils.hasUserDefinedProperty(this.options, 'immutable')) {
+    this.$immutable = this.options.immutable;
 
-  for (const prop in options) {
-    if (this[prop] && typeof this[prop] === 'function') {
+    handleImmutable(this);
+  }
+
+  const keys = Object.keys(this.options);
+  for (const prop of keys) {
+    if (utils.hasUserDefinedProperty(this.options, prop) && typeof this[prop] === 'function') {
       // { unique: true, index: true }
       if (prop === 'index' && this._index) {
+        if (options.index === false) {
+          const index = this._index;
+          if (typeof index === 'object' && index != null) {
+            if (index.unique) {
+              throw new Error('Path "' + this.path + '" may not have `index` ' +
+                'set to false and `unique` set to true');
+            }
+            if (index.sparse) {
+              throw new Error('Path "' + this.path + '" may not have `index` ' +
+                'set to false and `sparse` set to true');
+            }
+          }
+
+          this._index = false;
+        }
         continue;
       }
 
@@ -83317,6 +84932,12 @@ function SchemaType(path, options, instance) {
     value: null
   });
 }
+
+/*!
+ * ignore
+ */
+
+SchemaType.prototype.OptionsConstructor = SchemaTypeOptions;
 
 /**
  * Get/set the function used to cast arbitrary values to this type.
@@ -83438,9 +85059,9 @@ SchemaType.prototype.default = function(val) {
  *     var s = new Schema({ loc: { type: [Number], index: '2d', sparse: true })
  *     var s = new Schema({ loc: { type: [Number], index: { type: '2dsphere', sparse: true }})
  *     var s = new Schema({ date: { type: Date, index: { unique: true, expires: '1d' }})
- *     Schema.path('my.path').index(true);
- *     Schema.path('my.date').index({ expires: 60 });
- *     Schema.path('my.path').index({ unique: true, sparse: true });
+ *     s.path('my.path').index(true);
+ *     s.path('my.date').index({ expires: 60 });
+ *     s.path('my.path').index({ unique: true, sparse: true });
  *
  * ####NOTE:
  *
@@ -83466,7 +85087,7 @@ SchemaType.prototype.index = function(options) {
  * ####Example:
  *
  *     var s = new Schema({ name: { type: String, unique: true }});
- *     Schema.path('name').index({ unique: true });
+ *     s.path('name').index({ unique: true });
  *
  * _NOTE: violating the constraint returns an `E11000` error from MongoDB when saving, not a Mongoose validation error._
  *
@@ -83499,13 +85120,21 @@ SchemaType.prototype.unique = function(bool) {
  * ###Example:
  *
  *      var s = new Schema({name : {type: String, text : true })
- *      Schema.path('name').index({text : true});
+ *      s.path('name').index({text : true});
  * @param {Boolean} bool
  * @return {SchemaType} this
  * @api public
  */
 
 SchemaType.prototype.text = function(bool) {
+  if (this._index === false) {
+    if (!bool) {
+      return;
+    }
+    throw new Error('Path "' + this.path + '" may not have `index` set to ' +
+      'false and `text` set to true');
+  }
+
   if (this._index === null || this._index === undefined ||
     typeof this._index === 'boolean') {
     this._index = {};
@@ -83522,8 +85151,8 @@ SchemaType.prototype.text = function(bool) {
  *
  * ####Example:
  *
- *     var s = new Schema({ name: { type: String, sparse: true })
- *     Schema.path('name').index({ sparse: true });
+ *     var s = new Schema({ name: { type: String, sparse: true } });
+ *     s.path('name').index({ sparse: true });
  *
  * @param {Boolean} bool
  * @return {SchemaType} this
@@ -83531,14 +85160,71 @@ SchemaType.prototype.text = function(bool) {
  */
 
 SchemaType.prototype.sparse = function(bool) {
-  if (this._index === null || this._index === undefined ||
-    typeof this._index === 'boolean') {
+  if (this._index === false) {
+    if (!bool) {
+      return;
+    }
+    throw new Error('Path "' + this.path + '" may not have `index` set to ' +
+      'false and `sparse` set to true');
+  }
+
+  if (this._index == null || typeof this._index === 'boolean') {
     this._index = {};
   } else if (typeof this._index === 'string') {
     this._index = {type: this._index};
   }
 
   this._index.sparse = bool;
+  return this;
+};
+
+/**
+ * Defines this path as immutable. Mongoose prevents you from changing
+ * immutable paths unless the parent document has [`isNew: true`](/docs/api.html#document_Document-isNew).
+ *
+ * ####Example:
+ *
+ *     const schema = new Schema({
+ *       name: { type: String, immutable: true },
+ *       age: Number
+ *     });
+ *     const Model = mongoose.model('Test', schema);
+ *
+ *     await Model.create({ name: 'test' });
+ *     const doc = await Model.findOne();
+ *
+ *     doc.isNew; // false
+ *     doc.name = 'new name';
+ *     doc.name; // 'test', because `name` is immutable
+ *
+ * Mongoose also prevents changing immutable properties using `updateOne()`
+ * and `updateMany()` based on [strict mode](/docs/guide.html#strict).
+ *
+ * ####Example:
+ *
+ *     // Mongoose will strip out the `name` update, because `name` is immutable
+ *     Model.updateOne({}, { $set: { name: 'test2' }, $inc: { age: 1 } });
+ *
+ *     // If `strict` is set to 'throw', Mongoose will throw an error if you
+ *     // update `name`
+ *     const err = await Model.updateOne({}, { name: 'test2' }, { strict: 'throw' }).
+ *       then(() => null, err => err);
+ *     err.name; // StrictModeError
+ *
+ *     // If `strict` is `false`, Mongoose allows updating `name` even though
+ *     // the property is immutable.
+ *     Model.updateOne({}, { name: 'test2' }, { strict: false });
+ *
+ * @param {Boolean} bool
+ * @return {SchemaType} this
+ * @see isNew /docs/api.html#document_Document-isNew
+ * @api public
+ */
+
+SchemaType.prototype.immutable = function(bool) {
+  this.$immutable = bool;
+  handleImmutable(this);
+
   return this;
 };
 
@@ -83841,6 +85527,11 @@ SchemaType.prototype.validate = function(obj, message, type) {
       }
       properties = {message: message, type: type, validator: obj};
     }
+
+    if (properties.isAsync) {
+      handleIsAsync();
+    }
+
     this.validators.push(properties);
     return this;
   }
@@ -83863,6 +85554,15 @@ SchemaType.prototype.validate = function(obj, message, type) {
 
   return this;
 };
+
+/*!
+ * ignore
+ */
+
+const handleIsAsync = util.deprecate(function handleIsAsync() {},
+  'Mongoose: the `isAsync` option for custom validators is deprecated. Make ' +
+  'your async validators return a promise instead: ' +
+  'https://mongoosejs.com/docs/validation.html#async-custom-validators');
 
 /**
  * Adds a required validator to this SchemaType. The validator gets added
@@ -83900,15 +85600,15 @@ SchemaType.prototype.validate = function(obj, message, type) {
  *
  *     // or through the path API
  *
- *     Schema.path('name').required(true);
+ *     s.path('name').required(true);
  *
  *     // with custom error messaging
  *
- *     Schema.path('name').required(true, 'grrr :( ');
+ *     s.path('name').required(true, 'grrr :( ');
  *
  *     // or make a path conditionally required based on a function
  *     var isOver18 = function() { return this.age >= 18; };
- *     Schema.path('voterRegistrationId').required(isOver18);
+ *     s.path('voterRegistrationId').required(isOver18);
  *
  * The required validator uses the SchemaType's `checkRequired` function to
  * determine whether a given value satisfies the required validator. By default,
@@ -83933,6 +85633,17 @@ SchemaType.prototype.validate = function(obj, message, type) {
 
 SchemaType.prototype.required = function(required, message) {
   let customOptions = {};
+
+  if (arguments.length > 0 && required == null) {
+    this.validators = this.validators.filter(function(v) {
+      return v.validator !== this.requiredValidator;
+    }, this);
+
+    this.isRequired = false;
+    delete this.originalRequiredValue;
+    return this;
+  }
+
   if (typeof required === 'object') {
     customOptions = required;
     message = customOptions.message || message;
@@ -84037,7 +85748,7 @@ SchemaType.prototype.getDefault = function(scope, init) {
       ret = utils.clone(ret);
     }
 
-    const casted = this.cast(ret, scope, init);
+    const casted = this.applySetters(ret, scope, init);
     if (casted && casted.$isSingleNested) {
       casted.$parent = scope;
     }
@@ -84150,10 +85861,15 @@ SchemaType.prototype.select = function select(val) {
  * @api private
  */
 
-SchemaType.prototype.doValidate = function(value, fn, scope) {
+SchemaType.prototype.doValidate = function(value, fn, scope, options) {
   let err = false;
   const path = this.path;
-  let count = this.validators.length;
+
+  // Avoid non-object `validators`
+  const validators = this.validators.
+    filter(v => v != null && typeof v === 'object');
+
+  let count = validators.length;
 
   if (!count) {
     return fn(null);
@@ -84180,7 +85896,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
   };
 
   const _this = this;
-  this.validators.forEach(function(v) {
+  validators.forEach(function(v) {
     if (err) {
       return;
     }
@@ -84189,7 +85905,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
     let ok;
 
     const validatorProperties = utils.clone(v);
-    validatorProperties.path = path;
+    validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.value = value;
 
     if (validator instanceof RegExp) {
@@ -84220,6 +85936,7 @@ SchemaType.prototype.doValidate = function(value, fn, scope) {
             function(ok) { validate(ok, validatorProperties); },
             function(error) {
               validatorProperties.reason = error;
+              validatorProperties.message = error.message;
               ok = false;
               validate(ok, validatorProperties);
             });
@@ -84267,6 +85984,7 @@ function asyncValidate(validator, scope, value, props, cb) {
         called = true;
 
         props.reason = error;
+        props.message = error.message;
         cb(false, props);
       });
   }
@@ -84285,7 +86003,7 @@ function asyncValidate(validator, scope, value, props, cb) {
  * @api private
  */
 
-SchemaType.prototype.doValidateSync = function(value, scope) {
+SchemaType.prototype.doValidateSync = function(value, scope, options) {
   let err = null;
   const path = this.path;
   const count = this.validators.length;
@@ -84319,9 +86037,13 @@ SchemaType.prototype.doValidateSync = function(value, scope) {
       return;
     }
 
+    if (v == null || typeof v !== 'object') {
+      return;
+    }
+
     const validator = v.validator;
     const validatorProperties = utils.clone(v);
-    validatorProperties.path = path;
+    validatorProperties.path = options && options.path ? options.path : path;
     validatorProperties.value = value;
     let ok;
 
@@ -84445,7 +86167,7 @@ SchemaType.prototype.$conditionalHandlers = {
   $eq: handleSingle,
   $in: handle$in,
   $ne: handleSingle,
-  $nin: handleArray,
+  $nin: handle$in,
   $exists: $exists,
   $type: $type
 };
@@ -84533,6 +86255,20 @@ SchemaType.prototype.checkRequired = function(val) {
 };
 
 /*!
+ * ignore
+ */
+
+SchemaType.prototype.clone = function() {
+  const options = Object.assign({}, this.options);
+  const schematype = new this.constructor(this.path, options, this.instance);
+  schematype.validators = this.validators.slice();
+  schematype.requiredValidator = this.requiredValidator;
+  schematype.getters = this.getters.slice();
+  schematype.setters = this.setters.slice();
+  return schematype;
+};
+
+/*!
  * Module exports.
  */
 
@@ -84543,7 +86279,7 @@ exports.CastError = CastError;
 exports.ValidatorError = ValidatorError;
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":245,"./error":268,"./helpers/get":285,"./helpers/immediate":286,"./helpers/symbols":296,"./schema/operators/exists":318,"./schema/operators/type":322,"./utils":336}],326:[function(require,module,exports){
+},{"../../is-buffer/index.js":244,"./error/index":267,"./helpers/get":286,"./helpers/immediate":287,"./helpers/schematype/handleImmutable":298,"./helpers/symbols":299,"./options/SchemaTypeOptions":311,"./schema/operators/exists":329,"./schema/operators/type":333,"./utils":348,"util":380}],337:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -84725,24 +86461,22 @@ StateMachine.prototype.map = function map() {
   return this.map.apply(this, arguments);
 };
 
-},{"./utils":336}],327:[function(require,module,exports){
-(function (Buffer){
+},{"./utils":348}],338:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
 
 'use strict';
 
-const EmbeddedDocument = require('./embedded');
+const CoreMongooseArray = require('./core_array');
 const Document = require('../document');
-const ObjectId = require('./objectid');
-const cleanModifiedSubpaths = require('../helpers/document/cleanModifiedSubpaths');
-const get = require('../helpers/get');
-const internalToObjectOptions = require('../options').internalToObjectOptions;
-const utils = require('../utils');
-const util = require('util');
 
-const isMongooseObject = utils.isMongooseObject;
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
+
+const _basePush = Array.prototype.push;
 
 /**
  * Mongoose Array constructor.
@@ -84760,814 +86494,33 @@ const isMongooseObject = utils.isMongooseObject;
  */
 
 function MongooseArray(values, path, doc) {
-  const arr = [].concat(values);
+  // TODO: replace this with `new CoreMongooseArray().concat()` when we remove
+  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
+  const arr = new CoreMongooseArray();
+  arr[arrayAtomicsSymbol] = {};
 
-  const keysMA = Object.keys(MongooseArray.mixin);
-  const numKeys = keysMA.length;
-  for (let i = 0; i < numKeys; ++i) {
-    arr[keysMA[i]] = MongooseArray.mixin[keysMA[i]];
+  if (Array.isArray(values)) {
+    const len = values.length;
+    for (let i = 0; i < len; ++i) {
+      _basePush.call(arr, values[i]);
+    }
+
+    arr[arrayAtomicsSymbol] = values[arrayAtomicsSymbol] || {};
   }
 
-  arr._path = path;
-  arr.isMongooseArray = true;
-  arr.validators = [];
-  arr._atomics = {};
-  arr._schema = void 0;
-  if (util.inspect.custom) {
-    arr[util.inspect.custom] = arr.inspect;
-  }
+  arr[arrayPathSymbol] = path;
+  arr[arraySchemaSymbol] = void 0;
 
   // Because doc comes from the context of another function, doc === global
   // can happen if there was a null somewhere up the chain (see #3020)
   // RB Jun 17, 2015 updated to check for presence of expected paths instead
   // to make more proof against unusual node environments
   if (doc && doc instanceof Document) {
-    arr._parent = doc;
-    arr._schema = doc.schema.path(path);
+    arr[arrayParentSymbol] = doc;
+    arr[arraySchemaSymbol] = doc.schema.path(path);
   }
 
   return arr;
-}
-
-MongooseArray.mixin = {
-  /*!
-   * ignore
-   */
-  toBSON: function() {
-    return this.toObject(internalToObjectOptions);
-  },
-
-  /**
-   * Stores a queue of atomic operations to perform
-   *
-   * @property _atomics
-   * @api private
-   */
-
-  _atomics: undefined,
-
-  /**
-   * Parent owner document
-   *
-   * @property _parent
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _parent: undefined,
-
-  /**
-   * Casts a member based on this arrays schema.
-   *
-   * @param {any} value
-   * @return value the casted value
-   * @method _cast
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _cast: function(value) {
-    let populated = false;
-    let Model;
-
-    if (this._parent) {
-      populated = this._parent.populated(this._path, true);
-    }
-
-    if (populated && value !== null && value !== undefined) {
-      // cast to the populated Models schema
-      Model = populated.options.model || populated.options.Model;
-
-      // only objects are permitted so we can safely assume that
-      // non-objects are to be interpreted as _id
-      if (Buffer.isBuffer(value) ||
-          value instanceof ObjectId || !utils.isObject(value)) {
-        value = {_id: value};
-      }
-
-      // gh-2399
-      // we should cast model only when it's not a discriminator
-      const isDisc = value.schema && value.schema.discriminatorMapping &&
-          value.schema.discriminatorMapping.key !== undefined;
-      if (!isDisc) {
-        value = new Model(value);
-      }
-      return this._schema.caster.applySetters(value, this._parent, true);
-    }
-
-    return this._schema.caster.applySetters(value, this._parent, false);
-  },
-
-  /**
-   * Marks this array as modified.
-   *
-   * If it bubbles up from an embedded document change, then it takes the following arguments (otherwise, takes 0 arguments)
-   *
-   * @param {EmbeddedDocument} embeddedDoc the embedded doc that invoked this method on the Array
-   * @param {String} embeddedPath the path which changed in the embeddedDoc
-   * @method _markModified
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _markModified: function(elem, embeddedPath) {
-    const parent = this._parent;
-    let dirtyPath;
-
-    if (parent) {
-      dirtyPath = this._path;
-
-      if (arguments.length) {
-        if (embeddedPath != null) {
-          // an embedded doc bubbled up the change
-          dirtyPath = dirtyPath + '.' + this.indexOf(elem) + '.' + embeddedPath;
-        } else {
-          // directly set an index
-          dirtyPath = dirtyPath + '.' + elem;
-        }
-      }
-
-      parent.markModified(dirtyPath, arguments.length > 0 ? elem : parent);
-    }
-
-    return this;
-  },
-
-  /**
-   * Register an atomic operation with the parent.
-   *
-   * @param {Array} op operation
-   * @param {any} val
-   * @method _registerAtomic
-   * @api private
-   * @memberOf MongooseArray
-   */
-
-  _registerAtomic: function(op, val) {
-    if (op === '$set') {
-      // $set takes precedence over all other ops.
-      // mark entire array modified.
-      this._atomics = {$set: val};
-      return this;
-    }
-
-    const atomics = this._atomics;
-
-    // reset pop/shift after save
-    if (op === '$pop' && !('$pop' in atomics)) {
-      const _this = this;
-      this._parent.once('save', function() {
-        _this._popped = _this._shifted = null;
-      });
-    }
-
-    // check for impossible $atomic combos (Mongo denies more than one
-    // $atomic op on a single path
-    if (this._atomics.$set ||
-        Object.keys(atomics).length && !(op in atomics)) {
-      // a different op was previously registered.
-      // save the entire thing.
-      this._atomics = {$set: this};
-      return this;
-    }
-
-    let selector;
-
-    if (op === '$pullAll' || op === '$addToSet') {
-      atomics[op] || (atomics[op] = []);
-      atomics[op] = atomics[op].concat(val);
-    } else if (op === '$pullDocs') {
-      const pullOp = atomics['$pull'] || (atomics['$pull'] = {});
-      if (val[0] instanceof EmbeddedDocument) {
-        selector = pullOp['$or'] || (pullOp['$or'] = []);
-        Array.prototype.push.apply(selector, val.map(function(v) {
-          return v.toObject({transform: false, virtuals: false});
-        }));
-      } else {
-        selector = pullOp['_id'] || (pullOp['_id'] = {$in: []});
-        selector['$in'] = selector['$in'].concat(val);
-      }
-    } else if (op === '$push') {
-      atomics.$push = atomics.$push || { $each: [] };
-      atomics.$push.$each = atomics.$push.$each.concat(val);
-    } else {
-      atomics[op] = val;
-    }
-
-    return this;
-  },
-
-  /**
-   * Depopulates stored atomic operation values as necessary for direct insertion to MongoDB.
-   *
-   * If no atomics exist, we return all array values after conversion.
-   *
-   * @return {Array}
-   * @method $__getAtomics
-   * @memberOf MongooseArray
-   * @instance
-   * @api private
-   */
-
-  $__getAtomics: function() {
-    const ret = [];
-    const keys = Object.keys(this._atomics);
-    let i = keys.length;
-
-    const opts = Object.assign({}, internalToObjectOptions, { _isNested: true });
-
-    if (i === 0) {
-      ret[0] = ['$set', this.toObject(opts)];
-      return ret;
-    }
-
-    while (i--) {
-      const op = keys[i];
-      let val = this._atomics[op];
-
-      // the atomic values which are arrays are not MongooseArrays. we
-      // need to convert their elements as if they were MongooseArrays
-      // to handle populated arrays versus DocumentArrays properly.
-      if (isMongooseObject(val)) {
-        val = val.toObject(opts);
-      } else if (Array.isArray(val)) {
-        val = this.toObject.call(val, opts);
-      } else if (val != null && Array.isArray(val.$each)) {
-        val.$each = this.toObject.call(val.$each, opts);
-      } else if (val.valueOf) {
-        val = val.valueOf();
-      }
-
-      if (op === '$addToSet') {
-        val = {$each: val};
-      }
-
-      ret.push([op, val]);
-    }
-
-    return ret;
-  },
-
-  /**
-   * Returns the number of pending atomic operations to send to the db for this array.
-   *
-   * @api private
-   * @return {Number}
-   * @method hasAtomics
-   * @memberOf MongooseArray
-   */
-
-  hasAtomics: function hasAtomics() {
-    if (!(this._atomics && this._atomics.constructor.name === 'Object')) {
-      return 0;
-    }
-
-    return Object.keys(this._atomics).length;
-  },
-
-  /**
-   * Internal helper for .map()
-   *
-   * @api private
-   * @return {Number}
-   * @method _mapCast
-   * @memberOf MongooseArray
-   */
-  _mapCast: function(val, index) {
-    return this._cast(val, this.length + index);
-  },
-
-  /**
-   * Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking.
-   *
-   * @param {Object} [args...]
-   * @api public
-   * @method push
-   * @memberOf MongooseArray
-   */
-
-  push: function() {
-    _checkManualPopulation(this, arguments);
-    let values = [].map.call(arguments, this._mapCast, this);
-    values = this._schema.applySetters(values, this._parent, undefined,
-      undefined, { skipDocumentArrayCast: true });
-    const ret = [].push.apply(this, values);
-
-    this._registerAtomic('$push', values);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pushes items to the array non-atomically.
-   *
-   * ####NOTE:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @param {any} [args...]
-   * @api public
-   * @method nonAtomicPush
-   * @memberOf MongooseArray
-   */
-
-  nonAtomicPush: function() {
-    const values = [].map.call(arguments, this._mapCast, this);
-    const ret = [].push.apply(this, values);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pops the array atomically at most one time per document `save()`.
-   *
-   * #### NOTE:
-   *
-   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
-   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
-   *
-   *      doc.array = [1,2,3];
-   *
-   *      var popped = doc.array.$pop();
-   *      console.log(popped); // 3
-   *      console.log(doc.array); // [1,2]
-   *
-   *      // no affect
-   *      popped = doc.array.$pop();
-   *      console.log(doc.array); // [1,2]
-   *
-   *      doc.save(function (err) {
-   *        if (err) return handleError(err);
-   *
-   *        // we saved, now $pop works again
-   *        popped = doc.array.$pop();
-   *        console.log(popped); // 2
-   *        console.log(doc.array); // [1]
-   *      })
-   *
-   * @api public
-   * @method $pop
-   * @memberOf MongooseArray
-   * @instance
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
-   * @method $pop
-   * @memberOf MongooseArray
-   */
-
-  $pop: function() {
-    this._registerAtomic('$pop', 1);
-    this._markModified();
-
-    // only allow popping once
-    if (this._popped) {
-      return;
-    }
-    this._popped = true;
-
-    return [].pop.call(this);
-  },
-
-  /**
-   * Wraps [`Array#pop`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/pop) with proper change tracking.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified which will pass the entire thing to $set potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @see MongooseArray#$pop #types_array_MongooseArray-%24pop
-   * @api public
-   * @method pop
-   * @memberOf MongooseArray
-   */
-
-  pop: function() {
-    const ret = [].pop.call(this);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Atomically shifts the array at most one time per document `save()`.
-   *
-   * ####NOTE:
-   *
-   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
-   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
-   *
-   *      doc.array = [1,2,3];
-   *
-   *      var shifted = doc.array.$shift();
-   *      console.log(shifted); // 1
-   *      console.log(doc.array); // [2,3]
-   *
-   *      // no affect
-   *      shifted = doc.array.$shift();
-   *      console.log(doc.array); // [2,3]
-   *
-   *      doc.save(function (err) {
-   *        if (err) return handleError(err);
-   *
-   *        // we saved, now $shift works again
-   *        shifted = doc.array.$shift();
-   *        console.log(shifted ); // 2
-   *        console.log(doc.array); // [3]
-   *      })
-   *
-   * @api public
-   * @memberOf MongooseArray
-   * @instance
-   * @method $shift
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
-   */
-
-  $shift: function $shift() {
-    this._registerAtomic('$pop', -1);
-    this._markModified();
-
-    // only allow shifting once
-    if (this._shifted) {
-      return;
-    }
-    this._shifted = true;
-
-    return [].shift.call(this);
-  },
-
-  /**
-   * Wraps [`Array#shift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
-   *
-   * ####Example:
-   *
-   *     doc.array = [2,3];
-   *     var res = doc.array.shift();
-   *     console.log(res) // 2
-   *     console.log(doc.array) // [3]
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method shift
-   * @memberOf MongooseArray
-   */
-
-  shift: function() {
-    const ret = [].shift.call(this);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Pulls items from the array atomically. Equality is determined by casting
-   * the provided value to an embedded document and comparing using
-   * [the `Document.equals()` function.](./api.html#document_Document-equals)
-   *
-   * ####Examples:
-   *
-   *     doc.array.pull(ObjectId)
-   *     doc.array.pull({ _id: 'someId' })
-   *     doc.array.pull(36)
-   *     doc.array.pull('tag 1', 'tag 2')
-   *
-   * To remove a document from a subdocument array we may pass an object with a matching `_id`.
-   *
-   *     doc.subdocs.push({ _id: 4815162342 })
-   *     doc.subdocs.pull({ _id: 4815162342 }) // removed
-   *
-   * Or we may passing the _id directly and let mongoose take care of it.
-   *
-   *     doc.subdocs.push({ _id: 4815162342 })
-   *     doc.subdocs.pull(4815162342); // works
-   *
-   * The first pull call will result in a atomic operation on the database, if pull is called repeatedly without saving the document, a $set operation is used on the complete array instead, overwriting possible changes that happened on the database in the meantime.
-   *
-   * @param {any} [args...]
-   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
-   * @api public
-   * @method pull
-   * @memberOf MongooseArray
-   */
-
-  pull: function() {
-    const values = [].map.call(arguments, this._cast, this);
-    const cur = this._parent.get(this._path);
-    let i = cur.length;
-    let mem;
-
-    while (i--) {
-      mem = cur[i];
-      if (mem instanceof Document) {
-        const some = values.some(function(v) {
-          return mem.equals(v);
-        });
-        if (some) {
-          [].splice.call(cur, i, 1);
-        }
-      } else if (~cur.indexOf.call(values, mem)) {
-        [].splice.call(cur, i, 1);
-      }
-    }
-
-    if (values[0] instanceof EmbeddedDocument) {
-      this._registerAtomic('$pullDocs', values.map(function(v) {
-        return v._id || v;
-      }));
-    } else {
-      this._registerAtomic('$pullAll', values);
-    }
-
-    this._markModified();
-
-    // Might have modified child paths and then pulled, like
-    // `doc.children[1].name = 'test';` followed by
-    // `doc.children.remove(doc.children[0]);`. In this case we fall back
-    // to a `$set` on the whole array. See #3511
-    if (cleanModifiedSubpaths(this._parent, this._path) > 0) {
-      this._registerAtomic('$set', this);
-    }
-
-    return this;
-  },
-
-  /**
-   * Wraps [`Array#splice`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/splice) with proper change tracking and casting.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method splice
-   * @memberOf MongooseArray
-   */
-
-  splice: function splice() {
-    let ret;
-
-    _checkManualPopulation(this, Array.prototype.slice.call(arguments, 2));
-
-    if (arguments.length) {
-      const vals = [];
-      for (let i = 0; i < arguments.length; ++i) {
-        vals[i] = i < 2 ?
-          arguments[i] :
-          this._cast(arguments[i], arguments[0] + (i - 2));
-      }
-      ret = [].splice.apply(this, vals);
-      this._registerAtomic('$set', this);
-      this._markModified();
-      cleanModifiedSubpaths(this._parent, this._path);
-    }
-
-    return ret;
-  },
-
-  /**
-   * Wraps [`Array#unshift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
-   *
-   * ####Note:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method unshift
-   * @memberOf MongooseArray
-   */
-
-  unshift: function() {
-    _checkManualPopulation(this, arguments);
-
-    let values = [].map.call(arguments, this._cast, this);
-    values = this._schema.applySetters(values, this._parent);
-    [].unshift.apply(this, values);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return this.length;
-  },
-
-  /**
-   * Wraps [`Array#sort`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort) with proper change tracking.
-   *
-   * ####NOTE:
-   *
-   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
-   *
-   * @api public
-   * @method sort
-   * @memberOf MongooseArray
-   */
-
-  sort: function() {
-    const ret = [].sort.apply(this, arguments);
-    this._registerAtomic('$set', this);
-    this._markModified();
-    return ret;
-  },
-
-  /**
-   * Adds values to the array if not already present.
-   *
-   * ####Example:
-   *
-   *     console.log(doc.array) // [2,3,4]
-   *     var added = doc.array.addToSet(4,5);
-   *     console.log(doc.array) // [2,3,4,5]
-   *     console.log(added)     // [5]
-   *
-   * @param {any} [args...]
-   * @return {Array} the values that were added
-   * @memberOf MongooseArray
-   * @api public
-   * @method addToSet
-   */
-
-  addToSet: function addToSet() {
-    _checkManualPopulation(this, arguments);
-
-    let values = [].map.call(arguments, this._mapCast, this);
-    values = this._schema.applySetters(values, this._parent);
-    const added = [];
-    let type = '';
-    if (values[0] instanceof EmbeddedDocument) {
-      type = 'doc';
-    } else if (values[0] instanceof Date) {
-      type = 'date';
-    }
-
-    values.forEach(function(v) {
-      let found;
-      const val = +v;
-      switch (type) {
-        case 'doc':
-          found = this.some(function(doc) {
-            return doc.equals(v);
-          });
-          break;
-        case 'date':
-          found = this.some(function(d) {
-            return +d === val;
-          });
-          break;
-        default:
-          found = ~this.indexOf(v);
-      }
-
-      if (!found) {
-        [].push.call(this, v);
-        this._registerAtomic('$addToSet', v);
-        this._markModified();
-        [].push.call(added, v);
-      }
-    }, this);
-
-    return added;
-  },
-
-  /**
-   * Sets the casted `val` at index `i` and marks the array modified.
-   *
-   * ####Example:
-   *
-   *     // given documents based on the following
-   *     var Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
-   *
-   *     var doc = new Doc({ array: [2,3,4] })
-   *
-   *     console.log(doc.array) // [2,3,4]
-   *
-   *     doc.array.set(1,"5");
-   *     console.log(doc.array); // [2,5,4] // properly cast to number
-   *     doc.save() // the change is saved
-   *
-   *     // VS not using array#set
-   *     doc.array[1] = "5";
-   *     console.log(doc.array); // [2,"5",4] // no casting
-   *     doc.save() // change is not saved
-   *
-   * @return {Array} this
-   * @api public
-   * @method set
-   * @memberOf MongooseArray
-   */
-
-  set: function set(i, val) {
-    const value = this._cast(val, i);
-    this[i] = value;
-    this._markModified(i);
-    return this;
-  },
-
-  /**
-   * Returns a native js Array.
-   *
-   * @param {Object} options
-   * @return {Array}
-   * @api public
-   * @method toObject
-   * @memberOf MongooseArray
-   */
-
-  toObject: function(options) {
-    if (options && options.depopulate) {
-      options = utils.clone(options);
-      options._isNested = true;
-      return this.map(function(doc) {
-        return doc instanceof Document
-          ? doc.toObject(options)
-          : doc;
-      });
-    }
-
-    return this.slice();
-  },
-
-  /**
-   * Helper for console.log
-   *
-   * @api public
-   * @method inspect
-   * @memberOf MongooseArray
-   */
-
-  inspect: function() {
-    return JSON.stringify(this);
-  },
-
-  /**
-   * Return the index of `obj` or `-1` if not found.
-   *
-   * @param {Object} obj the item to look for
-   * @return {Number}
-   * @api public
-   * @method indexOf
-   * @memberOf MongooseArray
-   */
-
-  indexOf: function indexOf(obj) {
-    if (obj instanceof ObjectId) {
-      obj = obj.toString();
-    }
-    for (let i = 0, len = this.length; i < len; ++i) {
-      if (obj == this[i]) {
-        return i;
-      }
-    }
-    return -1;
-  }
-};
-
-/**
- * Alias of [pull](#types_array_MongooseArray-pull)
- *
- * @see MongooseArray#pull #types_array_MongooseArray-pull
- * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
- * @api public
- * @memberOf MongooseArray
- * @instance
- * @method remove
- */
-
-MongooseArray.mixin.remove = MongooseArray.mixin.pull;
-
-/*!
- * ignore
- */
-
-function _isAllSubdocs(docs, ref) {
-  if (!ref) {
-    return false;
-  }
-  for (let i = 0; i < docs.length; ++i) {
-    const arg = docs[i];
-    if (arg == null) {
-      return false;
-    }
-    const model = arg.constructor;
-    if (!(arg instanceof Document) ||
-      (model.modelName !== ref && model.baseModelName !== ref)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/*!
- * ignore
- */
-
-function _checkManualPopulation(arr, docs) {
-  const ref = get(arr, '_schema.caster.options.ref', null);
-  if (arr.length === 0 &&
-      docs.length > 0) {
-    if (_isAllSubdocs(docs, ref)) {
-      arr._parent.populated(arr._path, [], { model: docs[0].constructor });
-    }
-  }
 }
 
 /*!
@@ -85576,8 +86529,7 @@ function _checkManualPopulation(arr, docs) {
 
 module.exports = exports = MongooseArray;
 
-}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../document":258,"../helpers/document/cleanModifiedSubpaths":282,"../helpers/get":285,"../options":300,"../utils":336,"./embedded":331,"./objectid":334,"util":365}],328:[function(require,module,exports){
+},{"../document":257,"../helpers/symbols":299,"./core_array":340}],339:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -85636,48 +86588,22 @@ function MongooseBuffer(value, encode, offset) {
   buf.isMongooseBuffer = true;
 
   // make sure these internal props don't show up in Object.keys()
-  Object.defineProperties(buf, {
-    validators: {
-      value: [],
-      enumerable: false
-    },
-    _path: {
-      value: path,
-      enumerable: false
-    },
-    _parent: {
-      value: doc,
-      enumerable: false
-    }
-  });
-
-  if (doc && typeof path === 'string') {
-    Object.defineProperty(buf, '_schema', {
-      value: doc.schema.path(path)
-    });
-  }
+  buf[MongooseBuffer.pathSymbol] = path;
+  buf[parentSymbol] = doc;
 
   buf._subtype = 0;
   return buf;
 }
 
+const pathSymbol = Symbol.for('mongoose#Buffer#_path');
+const parentSymbol = Symbol.for('mongoose#Buffer#_parent');
+MongooseBuffer.pathSymbol = pathSymbol;
+
 /*!
  * Inherit from Buffer.
  */
 
-// MongooseBuffer.prototype = Buffer.alloc(0);
-
 MongooseBuffer.mixin = {
-
-  /**
-   * Parent owner document
-   *
-   * @api private
-   * @property _parent
-   * @receiver MongooseBuffer
-   */
-
-  _parent: undefined,
 
   /**
    * Default subtype for the Binary representing this Buffer
@@ -85698,10 +86624,10 @@ MongooseBuffer.mixin = {
    */
 
   _markModified: function() {
-    const parent = this._parent;
+    const parent = this[parentSymbol];
 
     if (parent) {
-      parent.markModified(this._path);
+      parent.markModified(this[MongooseBuffer.pathSymbol]);
     }
     return this;
   },
@@ -85799,7 +86725,7 @@ MongooseBuffer.mixin.toObject = function(options) {
   const subtype = typeof options === 'number'
     ? options
     : (this._subtype || 0);
-  return new Binary(this, subtype);
+  return new Binary(Buffer.from(this), subtype);
 };
 
 /**
@@ -85884,7 +86810,877 @@ MongooseBuffer.Binary = Binary;
 
 module.exports = MongooseBuffer;
 
-},{"../driver":260,"../utils":336,"safe-buffer":353}],329:[function(require,module,exports){
+},{"../driver":259,"../utils":348,"safe-buffer":351}],340:[function(require,module,exports){
+(function (Buffer){
+'use strict';
+
+const Document = require('../document');
+const EmbeddedDocument = require('./embedded');
+const ObjectId = require('./objectid');
+const cleanModifiedSubpaths = require('../helpers/document/cleanModifiedSubpaths');
+const get = require('../helpers/get');
+const internalToObjectOptions = require('../options').internalToObjectOptions;
+const utils = require('../utils');
+const util = require('util');
+
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
+
+const _basePush = Array.prototype.push;
+
+const validatorsSymbol = Symbol('mongoose#MongooseCoreArray#validators');
+
+/*!
+ * ignore
+ */
+
+class CoreMongooseArray extends Array {
+  get isMongooseArray() {
+    return true;
+  }
+
+  get validators() {
+    return this[validatorsSymbol];
+  }
+
+  set validators(v) {
+    this[validatorsSymbol] = v;
+  }
+
+  /**
+   * Depopulates stored atomic operation values as necessary for direct insertion to MongoDB.
+   *
+   * If no atomics exist, we return all array values after conversion.
+   *
+   * @return {Array}
+   * @method $__getAtomics
+   * @memberOf MongooseArray
+   * @instance
+   * @api private
+   */
+
+  $__getAtomics() {
+    const ret = [];
+    const keys = Object.keys(this[arrayAtomicsSymbol]);
+    let i = keys.length;
+
+    const opts = Object.assign({}, internalToObjectOptions, { _isNested: true });
+
+    if (i === 0) {
+      ret[0] = ['$set', this.toObject(opts)];
+      return ret;
+    }
+
+    while (i--) {
+      const op = keys[i];
+      let val = this[arrayAtomicsSymbol][op];
+
+      // the atomic values which are arrays are not MongooseArrays. we
+      // need to convert their elements as if they were MongooseArrays
+      // to handle populated arrays versus DocumentArrays properly.
+      if (utils.isMongooseObject(val)) {
+        val = val.toObject(opts);
+      } else if (Array.isArray(val)) {
+        val = this.toObject.call(val, opts);
+      } else if (val != null && Array.isArray(val.$each)) {
+        val.$each = this.toObject.call(val.$each, opts);
+      } else if (val != null && typeof val.valueOf === 'function') {
+        val = val.valueOf();
+      }
+
+      if (op === '$addToSet') {
+        val = {$each: val};
+      }
+
+      ret.push([op, val]);
+    }
+
+    return ret;
+  }
+
+  /*!
+   * ignore
+   */
+
+  $atomics() {
+    return this[arrayAtomicsSymbol];
+  }
+
+  /*!
+   * ignore
+   */
+
+  $parent() {
+    return this[arrayParentSymbol];
+  }
+
+  /*!
+   * ignore
+   */
+
+  $path() {
+    return this[arrayPathSymbol];
+  }
+
+  /**
+   * Atomically shifts the array at most one time per document `save()`.
+   *
+   * ####NOTE:
+   *
+   * _Calling this multiple times on an array before saving sends the same command as calling it once._
+   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
+   *
+   *      doc.array = [1,2,3];
+   *
+   *      var shifted = doc.array.$shift();
+   *      console.log(shifted); // 1
+   *      console.log(doc.array); // [2,3]
+   *
+   *      // no affect
+   *      shifted = doc.array.$shift();
+   *      console.log(doc.array); // [2,3]
+   *
+   *      doc.save(function (err) {
+   *        if (err) return handleError(err);
+   *
+   *        // we saved, now $shift works again
+   *        shifted = doc.array.$shift();
+   *        console.log(shifted ); // 2
+   *        console.log(doc.array); // [3]
+   *      })
+   *
+   * @api public
+   * @memberOf MongooseArray
+   * @instance
+   * @method $shift
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
+   */
+
+  $shift() {
+    this._registerAtomic('$pop', -1);
+    this._markModified();
+
+    // only allow shifting once
+    if (this._shifted) {
+      return;
+    }
+    this._shifted = true;
+
+    return [].shift.call(this);
+  }
+
+  /**
+   * Pops the array atomically at most one time per document `save()`.
+   *
+   * #### NOTE:
+   *
+   * _Calling this mulitple times on an array before saving sends the same command as calling it once._
+   * _This update is implemented using the MongoDB [$pop](http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop) method which enforces this restriction._
+   *
+   *      doc.array = [1,2,3];
+   *
+   *      var popped = doc.array.$pop();
+   *      console.log(popped); // 3
+   *      console.log(doc.array); // [1,2]
+   *
+   *      // no affect
+   *      popped = doc.array.$pop();
+   *      console.log(doc.array); // [1,2]
+   *
+   *      doc.save(function (err) {
+   *        if (err) return handleError(err);
+   *
+   *        // we saved, now $pop works again
+   *        popped = doc.array.$pop();
+   *        console.log(popped); // 2
+   *        console.log(doc.array); // [1]
+   *      })
+   *
+   * @api public
+   * @method $pop
+   * @memberOf MongooseArray
+   * @instance
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pop
+   * @method $pop
+   * @memberOf MongooseArray
+   */
+
+  $pop() {
+    this._registerAtomic('$pop', 1);
+    this._markModified();
+
+    // only allow popping once
+    if (this._popped) {
+      return;
+    }
+    this._popped = true;
+
+    return [].pop.call(this);
+  }
+
+  /*!
+   * ignore
+   */
+
+  $schema() {
+    return this[arraySchemaSymbol];
+  }
+
+  /**
+   * Casts a member based on this arrays schema.
+   *
+   * @param {any} value
+   * @return value the casted value
+   * @method _cast
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _cast(value) {
+    let populated = false;
+    let Model;
+
+    if (this[arrayParentSymbol]) {
+      populated = this[arrayParentSymbol].populated(this[arrayPathSymbol], true);
+    }
+
+    if (populated && value !== null && value !== undefined) {
+      // cast to the populated Models schema
+      Model = populated.options[populateModelSymbol];
+
+      // only objects are permitted so we can safely assume that
+      // non-objects are to be interpreted as _id
+      if (Buffer.isBuffer(value) ||
+          value instanceof ObjectId || !utils.isObject(value)) {
+        value = {_id: value};
+      }
+
+      // gh-2399
+      // we should cast model only when it's not a discriminator
+      const isDisc = value.schema && value.schema.discriminatorMapping &&
+          value.schema.discriminatorMapping.key !== undefined;
+      if (!isDisc) {
+        value = new Model(value);
+      }
+      return this[arraySchemaSymbol].caster.applySetters(value, this[arrayParentSymbol], true);
+    }
+
+    return this[arraySchemaSymbol].caster.applySetters(value, this[arrayParentSymbol], false);
+  }
+
+  /**
+   * Internal helper for .map()
+   *
+   * @api private
+   * @return {Number}
+   * @method _mapCast
+   * @memberOf MongooseArray
+   */
+
+  _mapCast(val, index) {
+    return this._cast(val, this.length + index);
+  }
+
+  /**
+   * Marks this array as modified.
+   *
+   * If it bubbles up from an embedded document change, then it takes the following arguments (otherwise, takes 0 arguments)
+   *
+   * @param {EmbeddedDocument} embeddedDoc the embedded doc that invoked this method on the Array
+   * @param {String} embeddedPath the path which changed in the embeddedDoc
+   * @method _markModified
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _markModified(elem, embeddedPath) {
+    const parent = this[arrayParentSymbol];
+    let dirtyPath;
+
+    if (parent) {
+      dirtyPath = this[arrayPathSymbol];
+
+      if (arguments.length) {
+        if (embeddedPath != null) {
+          // an embedded doc bubbled up the change
+          dirtyPath = dirtyPath + '.' + this.indexOf(elem) + '.' + embeddedPath;
+        } else {
+          // directly set an index
+          dirtyPath = dirtyPath + '.' + elem;
+        }
+      }
+
+      parent.markModified(dirtyPath, arguments.length > 0 ? elem : parent);
+    }
+
+    return this;
+  }
+
+  /**
+   * Register an atomic operation with the parent.
+   *
+   * @param {Array} op operation
+   * @param {any} val
+   * @method _registerAtomic
+   * @api private
+   * @memberOf MongooseArray
+   */
+
+  _registerAtomic(op, val) {
+    if (op === '$set') {
+      // $set takes precedence over all other ops.
+      // mark entire array modified.
+      this[arrayAtomicsSymbol] = {$set: val};
+      cleanModifiedSubpaths(this[arrayParentSymbol], this[arrayPathSymbol]);
+      this._markModified();
+      return this;
+    }
+
+    const atomics = this[arrayAtomicsSymbol];
+
+    // reset pop/shift after save
+    if (op === '$pop' && !('$pop' in atomics)) {
+      const _this = this;
+      this[arrayParentSymbol].once('save', function() {
+        _this._popped = _this._shifted = null;
+      });
+    }
+
+    // check for impossible $atomic combos (Mongo denies more than one
+    // $atomic op on a single path
+    if (this[arrayAtomicsSymbol].$set ||
+        Object.keys(atomics).length && !(op in atomics)) {
+      // a different op was previously registered.
+      // save the entire thing.
+      this[arrayAtomicsSymbol] = {$set: this};
+      return this;
+    }
+
+    let selector;
+
+    if (op === '$pullAll' || op === '$addToSet') {
+      atomics[op] || (atomics[op] = []);
+      atomics[op] = atomics[op].concat(val);
+    } else if (op === '$pullDocs') {
+      const pullOp = atomics['$pull'] || (atomics['$pull'] = {});
+      if (val[0] instanceof EmbeddedDocument) {
+        selector = pullOp['$or'] || (pullOp['$or'] = []);
+        Array.prototype.push.apply(selector, val.map(function(v) {
+          return v.toObject({transform: false, virtuals: false});
+        }));
+      } else {
+        selector = pullOp['_id'] || (pullOp['_id'] = {$in: []});
+        selector['$in'] = selector['$in'].concat(val);
+      }
+    } else if (op === '$push') {
+      atomics.$push = atomics.$push || { $each: [] };
+      atomics.$push.$each = atomics.$push.$each.concat(val);
+    } else {
+      atomics[op] = val;
+    }
+
+    return this;
+  }
+
+  /**
+   * Adds values to the array if not already present.
+   *
+   * ####Example:
+   *
+   *     console.log(doc.array) // [2,3,4]
+   *     var added = doc.array.addToSet(4,5);
+   *     console.log(doc.array) // [2,3,4,5]
+   *     console.log(added)     // [5]
+   *
+   * @param {any} [args...]
+   * @return {Array} the values that were added
+   * @memberOf MongooseArray
+   * @api public
+   * @method addToSet
+   */
+
+  addToSet() {
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._mapCast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
+    const added = [];
+    let type = '';
+    if (values[0] instanceof EmbeddedDocument) {
+      type = 'doc';
+    } else if (values[0] instanceof Date) {
+      type = 'date';
+    }
+
+    values.forEach(function(v) {
+      let found;
+      const val = +v;
+      switch (type) {
+        case 'doc':
+          found = this.some(function(doc) {
+            return doc.equals(v);
+          });
+          break;
+        case 'date':
+          found = this.some(function(d) {
+            return +d === val;
+          });
+          break;
+        default:
+          found = ~this.indexOf(v);
+      }
+
+      if (!found) {
+        [].push.call(this, v);
+        this._registerAtomic('$addToSet', v);
+        this._markModified();
+        [].push.call(added, v);
+      }
+    }, this);
+
+    return added;
+  }
+
+  /**
+   * Returns the number of pending atomic operations to send to the db for this array.
+   *
+   * @api private
+   * @return {Number}
+   * @method hasAtomics
+   * @memberOf MongooseArray
+   */
+
+  hasAtomics() {
+    if (!utils.isPOJO(this[arrayAtomicsSymbol])) {
+      return 0;
+    }
+
+    return Object.keys(this[arrayAtomicsSymbol]).length;
+  }
+
+  /**
+   * Return whether or not the `obj` is included in the array.
+   *
+   * @param {Object} obj the item to check
+   * @return {Boolean}
+   * @api public
+   * @method includes
+   * @memberOf MongooseArray
+   */
+
+  includes(obj, fromIndex) {
+    const ret = this.indexOf(obj, fromIndex);
+    return ret !== -1;
+  }
+
+  /**
+   * Return the index of `obj` or `-1` if not found.
+   *
+   * @param {Object} obj the item to look for
+   * @return {Number}
+   * @api public
+   * @method indexOf
+   * @memberOf MongooseArray
+   */
+
+  indexOf(obj, fromIndex) {
+    if (obj instanceof ObjectId) {
+      obj = obj.toString();
+    }
+
+    fromIndex = fromIndex == null ? 0 : fromIndex;
+    const len = this.length;
+    for (let i = fromIndex; i < len; ++i) {
+      if (obj == this[i]) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Helper for console.log
+   *
+   * @api public
+   * @method inspect
+   * @memberOf MongooseArray
+   */
+
+  inspect() {
+    return JSON.stringify(this);
+  }
+
+  /**
+   * Pushes items to the array non-atomically.
+   *
+   * ####NOTE:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @param {any} [args...]
+   * @api public
+   * @method nonAtomicPush
+   * @memberOf MongooseArray
+   */
+
+  nonAtomicPush() {
+    const values = [].map.call(arguments, this._mapCast, this);
+    const ret = [].push.apply(this, values);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#pop`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/pop) with proper change tracking.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified which will pass the entire thing to $set potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @see MongooseArray#$pop #types_array_MongooseArray-%24pop
+   * @api public
+   * @method pop
+   * @memberOf MongooseArray
+   */
+
+  pop() {
+    const ret = [].pop.call(this);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Pulls items from the array atomically. Equality is determined by casting
+   * the provided value to an embedded document and comparing using
+   * [the `Document.equals()` function.](./api.html#document_Document-equals)
+   *
+   * ####Examples:
+   *
+   *     doc.array.pull(ObjectId)
+   *     doc.array.pull({ _id: 'someId' })
+   *     doc.array.pull(36)
+   *     doc.array.pull('tag 1', 'tag 2')
+   *
+   * To remove a document from a subdocument array we may pass an object with a matching `_id`.
+   *
+   *     doc.subdocs.push({ _id: 4815162342 })
+   *     doc.subdocs.pull({ _id: 4815162342 }) // removed
+   *
+   * Or we may passing the _id directly and let mongoose take care of it.
+   *
+   *     doc.subdocs.push({ _id: 4815162342 })
+   *     doc.subdocs.pull(4815162342); // works
+   *
+   * The first pull call will result in a atomic operation on the database, if pull is called repeatedly without saving the document, a $set operation is used on the complete array instead, overwriting possible changes that happened on the database in the meantime.
+   *
+   * @param {any} [args...]
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
+   * @api public
+   * @method pull
+   * @memberOf MongooseArray
+   */
+
+  pull() {
+    const values = [].map.call(arguments, this._cast, this);
+    const cur = this[arrayParentSymbol].get(this[arrayPathSymbol]);
+    let i = cur.length;
+    let mem;
+
+    while (i--) {
+      mem = cur[i];
+      if (mem instanceof Document) {
+        const some = values.some(function(v) {
+          return mem.equals(v);
+        });
+        if (some) {
+          [].splice.call(cur, i, 1);
+        }
+      } else if (~cur.indexOf.call(values, mem)) {
+        [].splice.call(cur, i, 1);
+      }
+    }
+
+    if (values[0] instanceof EmbeddedDocument) {
+      this._registerAtomic('$pullDocs', values.map(function(v) {
+        return v._id || v;
+      }));
+    } else {
+      this._registerAtomic('$pullAll', values);
+    }
+
+    this._markModified();
+
+    // Might have modified child paths and then pulled, like
+    // `doc.children[1].name = 'test';` followed by
+    // `doc.children.remove(doc.children[0]);`. In this case we fall back
+    // to a `$set` on the whole array. See #3511
+    if (cleanModifiedSubpaths(this[arrayParentSymbol], this[arrayPathSymbol]) > 0) {
+      this._registerAtomic('$set', this);
+    }
+
+    return this;
+  }
+
+  /**
+   * Wraps [`Array#push`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/push) with proper change tracking.
+   *
+   * @param {Object} [args...]
+   * @api public
+   * @method push
+   * @memberOf MongooseArray
+   */
+
+  push() {
+    if (this[arraySchemaSymbol] == null) {
+      return _basePush.apply(this, arguments);
+    }
+
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._mapCast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol], undefined,
+      undefined, { skipDocumentArrayCast: true });
+    const ret = [].push.apply(this, values);
+
+    this._registerAtomic('$push', values);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Alias of [pull](#types_array_MongooseArray-pull)
+   *
+   * @see MongooseArray#pull #types_array_MongooseArray-pull
+   * @see mongodb http://www.mongodb.org/display/DOCS/Updating/#Updating-%24pull
+   * @api public
+   * @memberOf MongooseArray
+   * @instance
+   * @method remove
+   */
+
+  remove() {
+    return this.pull.apply(this, arguments);
+  }
+
+  /**
+   * Sets the casted `val` at index `i` and marks the array modified.
+   *
+   * ####Example:
+   *
+   *     // given documents based on the following
+   *     var Doc = mongoose.model('Doc', new Schema({ array: [Number] }));
+   *
+   *     var doc = new Doc({ array: [2,3,4] })
+   *
+   *     console.log(doc.array) // [2,3,4]
+   *
+   *     doc.array.set(1,"5");
+   *     console.log(doc.array); // [2,5,4] // properly cast to number
+   *     doc.save() // the change is saved
+   *
+   *     // VS not using array#set
+   *     doc.array[1] = "5";
+   *     console.log(doc.array); // [2,"5",4] // no casting
+   *     doc.save() // change is not saved
+   *
+   * @return {Array} this
+   * @api public
+   * @method set
+   * @memberOf MongooseArray
+   */
+
+  set(i, val) {
+    const value = this._cast(val, i);
+    this[i] = value;
+    this._markModified(i);
+    return this;
+  }
+
+  /**
+   * Wraps [`Array#shift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
+   *
+   * ####Example:
+   *
+   *     doc.array = [2,3];
+   *     var res = doc.array.shift();
+   *     console.log(res) // 2
+   *     console.log(doc.array) // [3]
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method shift
+   * @memberOf MongooseArray
+   */
+
+  shift() {
+    const ret = [].shift.call(this);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#sort`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort) with proper change tracking.
+   *
+   * ####NOTE:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method sort
+   * @memberOf MongooseArray
+   */
+
+  sort() {
+    const ret = [].sort.apply(this, arguments);
+    this._registerAtomic('$set', this);
+    return ret;
+  }
+
+  /**
+   * Wraps [`Array#splice`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/splice) with proper change tracking and casting.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method splice
+   * @memberOf MongooseArray
+   */
+
+  splice() {
+    let ret;
+
+    _checkManualPopulation(this, Array.prototype.slice.call(arguments, 2));
+
+    if (arguments.length) {
+      const vals = [];
+      for (let i = 0; i < arguments.length; ++i) {
+        vals[i] = i < 2 ?
+          arguments[i] :
+          this._cast(arguments[i], arguments[0] + (i - 2));
+      }
+      ret = [].splice.apply(this, vals);
+      this._registerAtomic('$set', this);
+    }
+
+    return ret;
+  }
+
+  /*!
+   * ignore
+   */
+
+  toBSON() {
+    return this.toObject(internalToObjectOptions);
+  }
+
+  /**
+   * Returns a native js Array.
+   *
+   * @param {Object} options
+   * @return {Array}
+   * @api public
+   * @method toObject
+   * @memberOf MongooseArray
+   */
+
+  toObject(options) {
+    if (options && options.depopulate) {
+      options = utils.clone(options);
+      options._isNested = true;
+      return this.map(function(doc) {
+        return doc instanceof Document
+          ? doc.toObject(options)
+          : doc;
+      });
+    }
+
+    return this.slice();
+  }
+
+  /**
+   * Wraps [`Array#unshift`](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/unshift) with proper change tracking.
+   *
+   * ####Note:
+   *
+   * _marks the entire array as modified, which if saved, will store it as a `$set` operation, potentially overwritting any changes that happen between when you retrieved the object and when you save it._
+   *
+   * @api public
+   * @method unshift
+   * @memberOf MongooseArray
+   */
+
+  unshift() {
+    _checkManualPopulation(this, arguments);
+
+    let values = [].map.call(arguments, this._cast, this);
+    values = this[arraySchemaSymbol].applySetters(values, this[arrayParentSymbol]);
+    [].unshift.apply(this, values);
+    this._registerAtomic('$set', this);
+    this._markModified();
+    return this.length;
+  }
+}
+
+if (util.inspect.custom) {
+  CoreMongooseArray.prototype[util.inspect.custom] =
+    CoreMongooseArray.prototype.inspect;
+}
+
+/*!
+ * ignore
+ */
+
+function _isAllSubdocs(docs, ref) {
+  if (!ref) {
+    return false;
+  }
+  for (let i = 0; i < docs.length; ++i) {
+    const arg = docs[i];
+    if (arg == null) {
+      return false;
+    }
+    const model = arg.constructor;
+    if (!(arg instanceof Document) ||
+      (model.modelName !== ref && model.baseModelName !== ref)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*!
+ * ignore
+ */
+
+function _checkManualPopulation(arr, docs) {
+  const ref = arr == null ?
+    null :
+    get(arr[arraySchemaSymbol], 'caster.options.ref', null);
+  if (arr.length === 0 &&
+      docs.length > 0) {
+    if (_isAllSubdocs(docs, ref)) {
+      arr[arrayParentSymbol].populated(arr[arrayPathSymbol], [], {
+        [populateModelSymbol]: docs[0].constructor
+      });
+    }
+  }
+}
+
+module.exports = CoreMongooseArray;
+}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
+},{"../../../is-buffer/index.js":244,"../document":257,"../helpers/document/cleanModifiedSubpaths":283,"../helpers/get":286,"../helpers/symbols":299,"../options":303,"../utils":348,"./embedded":343,"./objectid":346,"util":380}],341:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -85899,7 +87695,7 @@ module.exports = MongooseBuffer;
 
 module.exports = require('../driver').get().Decimal128;
 
-},{"../driver":260}],330:[function(require,module,exports){
+},{"../driver":259}],342:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -85907,136 +87703,35 @@ module.exports = require('../driver').get().Decimal128;
  * Module dependencies.
  */
 
+const CoreMongooseArray = require('./core_array');
 const Document = require('../document');
-const MongooseArray = require('./array');
 const ObjectId = require('./objectid');
 const castObjectId = require('../cast/objectid');
-const get = require('../helpers/get');
 const getDiscriminatorByValue = require('../queryhelpers').getDiscriminatorByValue;
 const internalToObjectOptions = require('../options').internalToObjectOptions;
 const util = require('util');
 const utils = require('../utils');
 
+const arrayAtomicsSymbol = require('../helpers/symbols').arrayAtomicsSymbol;
+const arrayParentSymbol = require('../helpers/symbols').arrayParentSymbol;
+const arrayPathSymbol = require('../helpers/symbols').arrayPathSymbol;
+const arraySchemaSymbol = require('../helpers/symbols').arraySchemaSymbol;
 const documentArrayParent = require('../helpers/symbols').documentArrayParent;
 
-/*!
- * ignore
- */
+const _basePush = Array.prototype.push;
 
-class CoreMongooseArray extends Array {
-  get isMongooseArray() {
+class CoreDocumentArray extends CoreMongooseArray {
+  get isMongooseDocumentArray() {
     return true;
   }
 
-  remove() {}
-}
-
-/**
- * DocumentArray constructor
- *
- * @param {Array} values
- * @param {String} path the path to this array
- * @param {Document} doc parent document
- * @api private
- * @return {MongooseDocumentArray}
- * @inherits MongooseArray
- * @see http://bit.ly/f6CnZU
- */
-
-function MongooseDocumentArray(values, path, doc) {
-  // TODO: replace this with `new CoreMongooseArray().concat()` when we remove
-  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
-  const arr = new CoreMongooseArray();
-
-  const props = {
-    isMongooseDocumentArray: true,
-    validators: [],
-    _atomics: {},
-    _schema: void 0,
-    _handlers: void 0
-  };
-
-  if (Array.isArray(values)) {
-    if (values instanceof CoreMongooseArray &&
-        values._path === path &&
-        values._parent === doc) {
-      props._atomics = Object.assign({}, values._atomics);
-    }
-    values.forEach(v => {
-      arr.push(v);
-    });
-  }
-  arr._path = path;
-
-  // Values always have to be passed to the constructor to initialize, since
-  // otherwise MongooseArray#push will mark the array as modified to the parent.
-  const keysMA = Object.keys(MongooseArray.mixin);
-  let numKeys = keysMA.length;
-  for (let j = 0; j < numKeys; ++j) {
-    arr[keysMA[j]] = MongooseArray.mixin[keysMA[j]];
-  }
-
-  const keysMDA = Object.keys(MongooseDocumentArray.mixin);
-  numKeys = keysMDA.length;
-  for (let i = 0; i < numKeys; ++i) {
-    arr[keysMDA[i]] = MongooseDocumentArray.mixin[keysMDA[i]];
-  }
-  if (util.inspect.custom) {
-    props[util.inspect.custom] = arr.inspect;
-  }
-
-  const keysP = Object.keys(props);
-  numKeys = keysP.length;
-  for (let k = 0; k < numKeys; ++k) {
-    arr[keysP[k]] = props[keysP[k]];
-  }
-
-  // Because doc comes from the context of another function, doc === global
-  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
-  // RB Jun 17, 2015 updated to check for presence of expected paths instead
-  // to make more proof against unusual node environments
-  if (doc && doc instanceof Document) {
-    arr._parent = doc;
-    arr._schema = doc.schema.path(path);
-
-    // `schema.path()` doesn't drill into nested arrays properly yet, see
-    // gh-6398, gh-6602. This is a workaround because nested arrays are
-    // always plain non-document arrays, so once you get to a document array
-    // nesting is done. Matryoshka code.
-    while (get(arr, '_schema.$isMongooseArray') &&
-        !get(arr, '_schema.$isMongooseDocumentArray')) {
-      arr._schema = arr._schema.casterConstructor;
-    }
-
-    // Tricky but this may be a document array embedded in a normal array,
-    // in which case `path` would point to the embedded array. See #6405, #6398
-    if (arr._schema && !arr._schema.$isMongooseDocumentArray) {
-      arr._schema = arr._schema.casterConstructor;
-    }
-
-    arr._handlers = {
-      isNew: arr.notify('isNew'),
-      save: arr.notify('save')
-    };
-
-    doc.on('save', arr._handlers.save);
-    doc.on('isNew', arr._handlers.isNew);
-  }
-
-  return arr;
-}
-
-/*!
- * Inherits from MongooseArray
- */
-
-MongooseDocumentArray.mixin = {
   /*!
    * ignore
    */
-  toBSON: function() {
+
+  toBSON() {
     return this.toObject(internalToObjectOptions);
-  },
+  }
 
   /**
    * Overrides MongooseArray#cast
@@ -86046,8 +87741,8 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  _cast: function(value, index) {
-    let Constructor = this._schema.casterConstructor;
+  _cast(value, index) {
+    let Constructor = this[arraySchemaSymbol].casterConstructor;
     const isInstance = Constructor.$isMongooseDocumentArray ?
       value && value.isMongooseDocumentArray :
       value instanceof Constructor;
@@ -86056,7 +87751,7 @@ MongooseDocumentArray.mixin = {
         (value && value.constructor && value.constructor.baseCasterConstructor === Constructor)) {
       if (!(value[documentArrayParent] && value.__parentArray)) {
         // value may have been created using array.create()
-        value[documentArrayParent] = this._parent;
+        value[documentArrayParent] = this[arrayParentSymbol];
         value.__parentArray = this;
       }
       value.$setIndex(index);
@@ -86095,7 +87790,7 @@ MongooseDocumentArray.mixin = {
       return Constructor.cast(value, this, undefined, undefined, index);
     }
     return new Constructor(value, this, undefined, undefined, index);
-  },
+  }
 
   /**
    * Searches array items for the first document with a matching _id.
@@ -86112,7 +87807,7 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  id: function(id) {
+  id(id) {
     let casted;
     let sid;
     let _id;
@@ -86146,7 +87841,7 @@ MongooseDocumentArray.mixin = {
     }
 
     return null;
-  },
+  }
 
   /**
    * Returns a native js Array of plain js objects
@@ -86162,15 +87857,19 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  toObject: function(options) {
-    return this.map(function(doc) {
-      try {
-        return doc.toObject(options);
-      } catch (e) {
-        return doc || null;
+  toObject(options) {
+    // `[].concat` coerces the return value into a vanilla JS array, rather
+    // than a Mongoose array.
+    return [].concat(this.map(function(doc) {
+      if (doc == null) {
+        return null;
       }
-    });
-  },
+      if (typeof doc.toObject !== 'function') {
+        return doc;
+      }
+      return doc.toObject(options);
+    }));
+  }
 
   /**
    * Helper for console.log
@@ -86180,9 +87879,9 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  inspect: function() {
+  inspect() {
     return this.toObject();
-  },
+  }
 
   /**
    * Creates a subdocument casted to this schema.
@@ -86195,8 +87894,8 @@ MongooseDocumentArray.mixin = {
    * @receiver MongooseDocumentArray
    */
 
-  create: function(obj) {
-    let Constructor = this._schema.casterConstructor;
+  create(obj) {
+    let Constructor = this[arraySchemaSymbol].casterConstructor;
     if (obj &&
         Constructor.discriminators &&
         Constructor.schema &&
@@ -86214,19 +87913,13 @@ MongooseDocumentArray.mixin = {
     }
 
     return new Constructor(obj, this);
-  },
+  }
 
-  /**
-   * Creates a fn that notifies all child docs of `event`.
-   *
-   * @param {String} event
-   * @return {Function}
-   * @method notify
-   * @api private
-   * @receiver MongooseDocumentArray
+  /*!
+   * ignore
    */
 
-  notify: function notify(event) {
+  notify(event) {
     const _this = this;
     return function notify(val, _arr) {
       _arr = _arr || _this;
@@ -86253,8 +87946,72 @@ MongooseDocumentArray.mixin = {
       }
     };
   }
+}
 
-};
+if (util.inspect.custom) {
+  CoreDocumentArray.prototype[util.inspect.custom] =
+    CoreDocumentArray.prototype.inspect;
+}
+
+/**
+ * DocumentArray constructor
+ *
+ * @param {Array} values
+ * @param {String} path the path to this array
+ * @param {Document} doc parent document
+ * @api private
+ * @return {MongooseDocumentArray}
+ * @inherits MongooseArray
+ * @see http://bit.ly/f6CnZU
+ */
+
+function MongooseDocumentArray(values, path, doc) {
+  // TODO: replace this with `new CoreDocumentArray().concat()` when we remove
+  // support for node 4.x and 5.x, see https://i.imgur.com/UAAHk4S.png
+  const arr = new CoreDocumentArray();
+
+  arr[arrayAtomicsSymbol] = {};
+  arr[arraySchemaSymbol] = void 0;
+  if (Array.isArray(values)) {
+    if (values instanceof CoreDocumentArray &&
+        values[arrayPathSymbol] === path &&
+        values[arrayParentSymbol] === doc) {
+      arr[arrayAtomicsSymbol] = Object.assign({}, values[arrayAtomicsSymbol]);
+    }
+    values.forEach(v => {
+      _basePush.call(arr, v);
+    });
+  }
+  arr[arrayPathSymbol] = path;
+
+  // Because doc comes from the context of another function, doc === global
+  // can happen if there was a null somewhere up the chain (see #3020 && #3034)
+  // RB Jun 17, 2015 updated to check for presence of expected paths instead
+  // to make more proof against unusual node environments
+  if (doc && doc instanceof Document) {
+    arr[arrayParentSymbol] = doc;
+    arr[arraySchemaSymbol] = doc.schema.path(path);
+
+    // `schema.path()` doesn't drill into nested arrays properly yet, see
+    // gh-6398, gh-6602. This is a workaround because nested arrays are
+    // always plain non-document arrays, so once you get to a document array
+    // nesting is done. Matryoshka code.
+    while (arr != null &&
+        arr[arraySchemaSymbol] != null &&
+        arr[arraySchemaSymbol].$isMongooseArray &&
+        !arr[arraySchemaSymbol].$isMongooseDocumentArray) {
+      arr[arraySchemaSymbol] = arr[arraySchemaSymbol].casterConstructor;
+    }
+
+    // Tricky but this may be a document array embedded in a normal array,
+    // in which case `path` would point to the embedded array. See #6405, #6398
+    if (arr[arraySchemaSymbol] && !arr[arraySchemaSymbol].$isMongooseDocumentArray) {
+      arr[arraySchemaSymbol] = arr[arraySchemaSymbol].casterConstructor;
+    }
+  }
+
+  return arr;
+}
 
 /*!
  * Module exports.
@@ -86263,7 +88020,7 @@ MongooseDocumentArray.mixin = {
 module.exports = MongooseDocumentArray;
 
 }).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":245,"../cast/objectid":256,"../document":258,"../helpers/get":285,"../helpers/symbols":296,"../options":300,"../queryhelpers":303,"../utils":336,"./array":327,"./objectid":334,"util":365}],331:[function(require,module,exports){
+},{"../../../is-buffer/index.js":244,"../cast/objectid":255,"../document":257,"../helpers/symbols":299,"../options":303,"../queryhelpers":314,"../utils":348,"./core_array":340,"./objectid":346,"util":380}],343:[function(require,module,exports){
 /* eslint no-func-assign: 1 */
 
 /*!
@@ -86296,7 +88053,7 @@ const validatorErrorSymbol = require('../helpers/symbols').validatorErrorSymbol;
 function EmbeddedDocument(obj, parentArr, skipId, fields, index) {
   if (parentArr) {
     this.__parentArray = parentArr;
-    this[documentArrayParent] = parentArr._parent;
+    this[documentArrayParent] = parentArr.$parent();
   } else {
     this.__parentArray = undefined;
     this[documentArrayParent] = undefined;
@@ -86551,7 +88308,7 @@ EmbeddedDocument.prototype.invalidate = function(path, err, val) {
   }
 
   const index = this.__index;
-  const parentPath = this.__parentArray._path;
+  const parentPath = this.__parentArray.$path();
   const fullPath = [parentPath, index, path].join('.');
   this[documentArrayParent].invalidate(fullPath, err, val);
 
@@ -86574,7 +88331,7 @@ EmbeddedDocument.prototype.$markValid = function(path) {
 
   const index = this.__index;
   if (typeof index !== 'undefined') {
-    const parentPath = this.__parentArray._path;
+    const parentPath = this.__parentArray.$path();
     const fullPath = [parentPath, index, path].join('.');
     this[documentArrayParent].$markValid(fullPath);
   }
@@ -86593,7 +88350,7 @@ EmbeddedDocument.prototype.$ignore = function(path) {
 
   const index = this.__index;
   if (typeof index !== 'undefined') {
-    const parentPath = this.__parentArray._path;
+    const parentPath = this.__parentArray.$path();
     const fullPath = [parentPath, index, path].join('.');
     this[documentArrayParent].$ignore(fullPath);
   }
@@ -86663,7 +88420,7 @@ EmbeddedDocument.prototype.$__fullPath = function(path) {
     const paths = [];
     while (parent[documentArrayParent] || parent.$parent) {
       if (parent[documentArrayParent]) {
-        paths.unshift(parent.__parentArray._path);
+        paths.unshift(parent.__parentArray.$path());
       } else {
         paths.unshift(parent.$basePath);
       }
@@ -86709,7 +88466,7 @@ EmbeddedDocument.prototype.parentArray = function() {
 
 module.exports = EmbeddedDocument;
 
-},{"../document_provider":259,"../helpers/get":285,"../helpers/immediate":286,"../helpers/symbols":296,"../options":300,"../utils":336,"events":242,"util":365}],332:[function(require,module,exports){
+},{"../document_provider":258,"../helpers/get":286,"../helpers/immediate":287,"../helpers/symbols":299,"../options":303,"../utils":348,"events":242,"util":380}],344:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -86731,12 +88488,15 @@ exports.Map = require('./map');
 
 exports.Subdocument = require('./subdocument');
 
-},{"./array":327,"./buffer":328,"./decimal128":329,"./documentarray":330,"./embedded":331,"./map":333,"./objectid":334,"./subdocument":335}],333:[function(require,module,exports){
+},{"./array":338,"./buffer":339,"./decimal128":341,"./documentarray":342,"./embedded":343,"./map":345,"./objectid":346,"./subdocument":347}],345:[function(require,module,exports){
 'use strict';
 
 const Mixed = require('../schema/mixed');
 const get = require('../helpers/get');
 const util = require('util');
+const utils = require('../utils');
+
+const populateModelSymbol = require('../helpers/symbols').populateModelSymbol;
 
 /*!
  * ignore
@@ -86790,7 +88550,7 @@ class MongooseMap extends Map {
 
     if (populated != null) {
       if (value.$__ == null) {
-        value = new populated.options.model(value);
+        value = new populated.options[populateModelSymbol](value);
       }
       value.$__.wasPopulated = true;
     } else {
@@ -86815,6 +88575,11 @@ class MongooseMap extends Map {
     if (this.$__parent != null && this.$__parent.$__) {
       this.$__parent.markModified(this.$__path + '.' + key);
     }
+  }
+
+  delete(key) {
+    this.set(key, undefined);
+    super.delete(key);
   }
 
   toBSON() {
@@ -86921,11 +88686,14 @@ function checkValidKey(key) {
   if (key.includes('.')) {
     throw new Error(`Mongoose maps do not support keys that contain ".", got "${key}"`);
   }
+  if (utils.specialProperties.has(key)) {
+    throw new Error(`Mongoose maps do not support reserved key name "${key}"`);
+  }
 }
 
 module.exports = MongooseMap;
 
-},{"../helpers/get":285,"../schema/mixed":314,"util":365}],334:[function(require,module,exports){
+},{"../helpers/get":286,"../helpers/symbols":299,"../schema/mixed":325,"../utils":348,"util":380}],346:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -86957,7 +88725,7 @@ ObjectId.prototype[objectIdSymbol] = true;
 
 module.exports = ObjectId;
 
-},{"../driver":260,"../helpers/symbols":296}],335:[function(require,module,exports){
+},{"../driver":259,"../helpers/symbols":299}],347:[function(require,module,exports){
 'use strict';
 
 const Document = require('../document');
@@ -86978,13 +88746,30 @@ module.exports = Subdocument;
 
 function Subdocument(value, fields, parent, skipId, options) {
   this.$isSingleNested = true;
+
+  const hasPriorDoc = options != null && options.priorDoc;
+  let initedPaths = null;
+  if (hasPriorDoc) {
+    this._doc = Object.assign({}, options.priorDoc._doc);
+    delete this._doc[this.schema.options.discriminatorKey];
+    initedPaths = Object.keys(options.priorDoc._doc || {}).
+      filter(key => key !== this.schema.options.discriminatorKey);
+  }
   if (parent != null) {
     // If setting a nested path, should copy isNew from parent re: gh-7048
     options = Object.assign({}, options, { isNew: parent.isNew });
   }
   Document.call(this, value, fields, skipId, options);
 
-  delete this.$__.$options.priorDoc;
+  if (hasPriorDoc) {
+    for (const key of initedPaths) {
+      if (!this.$__.activePaths.states.modify[key] &&
+          !this.$__.activePaths.states.default[key] &&
+          !this.$__.$setCalled.has(key)) {
+        delete this._doc[key];
+      }
+    }
+  }
 }
 
 Subdocument.prototype = Object.create(Document.prototype);
@@ -87057,6 +88842,25 @@ Subdocument.prototype.markModified = function(path) {
     this.$parent.markModified([this.$basePath, path].join('.'), this);
   }
 };
+
+Subdocument.prototype.isModified = function(paths, modifiedPaths) {
+  if (this.$parent && this.$basePath) {
+    paths = (Array.isArray(paths) ? paths : paths.split(' ')).
+      map(p => [this.$basePath, p].join('.'));
+    return this.$parent.isModified(paths, modifiedPaths);
+  }
+
+  return Document.prototype.isModified(paths, modifiedPaths);
+};
+
+/**
+ * Marks a path as valid, removing existing validation errors.
+ *
+ * @param {String} path the field to mark as valid
+ * @api private
+ * @method $markValid
+ * @receiver Subdocument
+ */
 
 Subdocument.prototype.$markValid = function(path) {
   Document.prototype.$markValid.call(this, path);
@@ -87176,7 +88980,7 @@ Subdocument.prototype.populate = function() {
  * Registers remove event listeners for triggering
  * on subdocuments.
  *
- * @param {EmbeddedDocument} sub
+ * @param {Subdocument} sub
  * @api private
  */
 
@@ -87195,7 +88999,7 @@ function registerRemoveListener(sub) {
   owner.on('remove', emitRemove);
 }
 
-},{"../document":258,"../helpers/immediate":286,"../helpers/symbols":296,"../options":300,"../utils":336}],336:[function(require,module,exports){
+},{"../document":257,"../helpers/immediate":287,"../helpers/symbols":299,"../options":303,"../utils":348}],348:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -87205,12 +89009,14 @@ function registerRemoveListener(sub) {
 
 const Decimal = require('./types/decimal128');
 const ObjectId = require('./types/objectid');
+const PopulateOptions = require('./options/PopulateOptions');
 const PromiseProvider = require('./promise_provider');
 const cloneRegExp = require('regexp-clone');
 const get = require('./helpers/get');
 const sliced = require('sliced');
 const mpath = require('mpath');
 const ms = require('ms');
+const symbols = require('./helpers/symbols');
 const Buffer = require('safe-buffer').Buffer;
 
 const emittedSymbol = Symbol.for('mongoose:emitted');
@@ -87425,7 +89231,11 @@ exports.clone = function clone(obj, options, isArrayChild) {
     return cloneObject(obj, options, isArrayChild);
   }
 
-  if (obj.valueOf) {
+  if (obj[symbols.schemaTypeSymbol]) {
+    return obj.clone();
+  }
+
+  if (obj.valueOf != null) {
     return obj.valueOf();
   }
 
@@ -87475,6 +89285,25 @@ exports.promiseOrCallback = function promiseOrCallback(callback, fn, ee) {
       resolve(res);
     });
   });
+};
+
+/*!
+ * ignore
+ */
+
+exports.omit = function omit(obj, keys) {
+  if (keys == null) {
+    return Object.assign({}, obj);
+  }
+  if (!Array.isArray(keys)) {
+    keys = [keys];
+  }
+
+  const ret = Object.assign({}, obj);
+  for (const key of keys) {
+    delete ret[key];
+  }
+  return ret;
 };
 
 /*!
@@ -87585,7 +89414,11 @@ exports.merge = function merge(to, from, options, path) {
       }
       if (from[key] != null) {
         if (from[key].instanceOfSchema) {
-          to[key] = from[key].clone();
+          if (to[key].instanceOfSchema) {
+            to[key].add(from[key].clone());
+          } else {
+            to[key] = from[key].clone();
+          }
           continue;
         } else if (from[key] instanceof ObjectId) {
           to[key] = new ObjectId(from[key]);
@@ -87672,7 +89505,7 @@ exports.isObject = function(arg) {
  * @return {Boolean}
  */
 
-exports.isPOJO = function(arg) {
+exports.isPOJO = function isPOJO(arg) {
   if (arg == null || typeof arg !== 'object') {
     return false;
   }
@@ -87681,6 +89514,47 @@ exports.isPOJO = function(arg) {
   // Checking `proto`'s constructor is safe because `getPrototypeOf()`
   // explicitly crosses the boundary from object data to object metadata
   return !proto || proto.constructor.name === 'Object';
+};
+
+/*!
+ * Determines if `obj` is a built-in object like an array, date, boolean,
+ * etc.
+ */
+
+exports.isNativeObject = function(arg) {
+  return Array.isArray(arg) ||
+    arg instanceof Date ||
+    arg instanceof Boolean ||
+    arg instanceof Number ||
+    arg instanceof String;
+};
+
+/*!
+ * Determines if `val` is an object that has no own keys
+ */
+
+exports.isEmptyObject = function(val) {
+  return val != null &&
+    typeof val === 'object' &&
+    Object.keys(val).length === 0;
+};
+
+/*!
+ * Search if `obj` or any POJOs nested underneath `obj` has a property named
+ * `key`
+ */
+
+exports.hasKey = function hasKey(obj, key) {
+  const props = Object.keys(obj);
+  for (const prop of props) {
+    if (prop === key) {
+      return true;
+    }
+    if (exports.isPOJO(obj[prop]) && exports.hasKey(obj[prop], key)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /*!
@@ -87716,6 +89590,15 @@ exports.tick = function tick(callback) {
       });
     }
   };
+};
+
+/*!
+ * Returns true if `v` is an object that can be serialized as a primitive in
+ * MongoDB
+ */
+
+exports.isMongooseType = function(v) {
+  return v instanceof ObjectId || v instanceof Decimal || v instanceof Buffer;
 };
 
 /*!
@@ -87770,38 +89653,53 @@ exports.expires = function expires(object) {
 };
 
 /*!
- * Populate options constructor
- */
-
-function PopulateOptions(obj) {
-  this.path = obj.path;
-  this.match = obj.match;
-  this.select = obj.select;
-  this.options = obj.options;
-  this.model = obj.model;
-  if (typeof obj.subPopulate === 'object') {
-    this.populate = obj.subPopulate;
-  }
-  if (obj.justOne != null) {
-    this.justOne = obj.justOne;
-  }
-  if (obj.count != null) {
-    this.count = obj.count;
-  }
-  this._docs = {};
-}
-
-// make it compatible with utils.clone
-PopulateOptions.prototype.constructor = Object;
-
-// expose
-exports.PopulateOptions = PopulateOptions;
-
-/*!
  * populate helper
  */
 
 exports.populate = function populate(path, select, model, match, options, subPopulate, justOne, count) {
+  // might have passed an object specifying all arguments
+  let obj = null;
+  if (arguments.length === 1) {
+    if (path instanceof PopulateOptions) {
+      return [path];
+    }
+
+    if (Array.isArray(path)) {
+      const singles = makeSingles(path);
+      return singles.map(o => exports.populate(o)[0]);
+    }
+
+    if (exports.isObject(path)) {
+      obj = Object.assign({}, path);
+    } else {
+      obj = { path: path };
+    }
+  } else if (typeof model === 'object') {
+    obj = {
+      path: path,
+      select: select,
+      match: model,
+      options: match
+    };
+  } else {
+    obj = {
+      path: path,
+      select: select,
+      model: model,
+      match: match,
+      options: options,
+      populate: subPopulate,
+      justOne: justOne,
+      count: count
+    };
+  }
+
+  if (typeof obj.path !== 'string') {
+    throw new TypeError('utils.populate: invalid path. Expected string. Got typeof `' + typeof path + '`');
+  }
+
+  return _populateObj(obj);
+
   // The order of select/conditions args is opposite Model.find but
   // necessary to keep backward compatibility (select could be
   // an array, string, or object literal).
@@ -87822,47 +89720,12 @@ exports.populate = function populate(path, select, model, match, options, subPop
 
     return ret;
   }
+};
 
-  // might have passed an object specifying all arguments
-  if (arguments.length === 1) {
-    if (path instanceof PopulateOptions) {
-      return [path];
-    }
-
-    if (Array.isArray(path)) {
-      const singles = makeSingles(path);
-      return singles.map(function(o) {
-        if (o.populate && !(o.match || o.options)) {
-          return exports.populate(o)[0];
-        } else {
-          return exports.populate(o)[0];
-        }
-      });
-    }
-
-    if (exports.isObject(path)) {
-      match = path.match;
-      options = path.options;
-      select = path.select;
-      model = path.model;
-      subPopulate = path.populate;
-      justOne = path.justOne;
-      path = path.path;
-      count = path.count;
-    }
-  } else if (typeof model === 'object') {
-    options = match;
-    match = model;
-    model = undefined;
-  }
-
-  if (typeof path !== 'string') {
-    throw new TypeError('utils.populate: invalid path. Expected string. Got typeof `' + typeof path + '`');
-  }
-
-  if (Array.isArray(subPopulate)) {
+function _populateObj(obj) {
+  if (Array.isArray(obj.populate)) {
     const ret = [];
-    subPopulate.forEach(function(obj) {
+    obj.populate.forEach(function(obj) {
       if (/[\s]/.test(obj.path)) {
         const copy = Object.assign({}, obj);
         const paths = copy.path.split(' ');
@@ -87874,29 +89737,23 @@ exports.populate = function populate(path, select, model, match, options, subPop
         ret.push(exports.populate(obj)[0]);
       }
     });
-    subPopulate = exports.populate(ret);
-  } else if (typeof subPopulate === 'object') {
-    subPopulate = exports.populate(subPopulate);
+    obj.populate = exports.populate(ret);
+  } else if (obj.populate != null && typeof obj.populate === 'object') {
+    obj.populate = exports.populate(obj.populate);
   }
 
   const ret = [];
-  const paths = path.split(' ');
-  options = exports.clone(options);
+  const paths = obj.path.split(' ');
+  if (obj.options != null) {
+    obj.options = exports.clone(obj.options);
+  }
+
   for (let i = 0; i < paths.length; ++i) {
-    ret.push(new PopulateOptions({
-      path: paths[i],
-      select: select,
-      match: match,
-      options: options,
-      model: model,
-      subPopulate: subPopulate,
-      justOne: justOne,
-      count: count
-    }));
+    ret.push(new PopulateOptions(Object.assign({}, obj, { path: paths[i] })));
   }
 
   return ret;
-};
+}
 
 /*!
  * Return the value of `obj` at the given `path`.
@@ -87982,7 +89839,7 @@ exports.array = {};
  * [ 1, [ 2, 3, [4] ]] -> [1,2,3,4]
  *
  * @param {Array} arr
- * @param {Function} [filter] If passed, will be invoked with each item in the array. If `filter` returns a falsey value, the item will not be included in the results.
+ * @param {Function} [filter] If passed, will be invoked with each item in the array. If `filter` returns a falsy value, the item will not be included in the results.
  * @return {Array}
  * @private
  */
@@ -88001,6 +89858,58 @@ exports.array.flatten = function flatten(arr, filter, ret) {
   });
 
   return ret;
+};
+
+/*!
+ * ignore
+ */
+
+const _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+exports.hasUserDefinedProperty = function(obj, key) {
+  if (obj == null) {
+    return false;
+  }
+
+  if (Array.isArray(key)) {
+    for (const k of key) {
+      if (exports.hasUserDefinedProperty(obj, k)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (_hasOwnProperty.call(obj, key)) {
+    return true;
+  }
+  if (key in obj) {
+    const v = obj[key];
+    return v !== Object.prototype[key] && v !== Array.prototype[key];
+  }
+
+  return false;
+};
+
+/*!
+ * ignore
+ */
+
+const MAX_ARRAY_INDEX = Math.pow(2, 32) - 1;
+
+exports.isArrayIndex = function(val) {
+  if (typeof val === 'number') {
+    return val >= 0 && val <= MAX_ARRAY_INDEX;
+  }
+  if (typeof val === 'string') {
+    if (!/^\d+$/.test(val)) {
+      return false;
+    }
+    val = +val;
+    return val >= 0 && val <= MAX_ARRAY_INDEX;
+  }
+
+  return false;
 };
 
 /*!
@@ -88170,10 +90079,26 @@ exports.each = function(arr, fn) {
  * ignore
  */
 
+exports.getOption = function(name) {
+  const sources = Array.prototype.slice.call(arguments, 1);
+
+  for (const source of sources) {
+    if (source[name] != null) {
+      return source[name];
+    }
+  }
+
+  return null;
+};
+
+/*!
+ * ignore
+ */
+
 exports.noop = function() {};
 
 }).call(this,require('_process'))
-},{"./document":258,"./helpers/get":285,"./promise_provider":302,"./types":332,"./types/decimal128":329,"./types/objectid":334,"_process":351,"mpath":339,"ms":338,"regexp-clone":352,"safe-buffer":353,"sliced":354}],337:[function(require,module,exports){
+},{"./document":257,"./helpers/get":286,"./helpers/symbols":299,"./options/PopulateOptions":304,"./promise_provider":313,"./types":344,"./types/decimal128":341,"./types/objectid":346,"_process":366,"mpath":352,"ms":350,"regexp-clone":367,"safe-buffer":351,"sliced":368}],349:[function(require,module,exports){
 'use strict';
 
 /**
@@ -88238,16 +90163,22 @@ VirtualType.prototype.clone = function() {
 };
 
 /**
- * Defines a getter.
+ * Adds a custom getter to this virtual.
+ *
+ * Mongoose calls the getter function with 3 parameters:
+ *
+ * - `value`: the value returned by the previous getter. If there is only one getter, `value` will be `undefined`.
+ * - `virtual`: the virtual object you called `.get()` on
+ * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * ####Example:
  *
  *     var virtual = schema.virtual('fullname');
- *     virtual.get(function () {
+ *     virtual.get(function(value, virtual, doc) {
  *       return this.name.first + ' ' + this.name.last;
  *     });
  *
- * @param {Function} fn
+ * @param {Function(Any, VirtualType, Document)} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -88258,18 +90189,31 @@ VirtualType.prototype.get = function(fn) {
 };
 
 /**
- * Defines a setter.
+ * Adds a custom setter to this virtual.
+ *
+ * Mongoose calls the setter function with 3 parameters:
+ *
+ * - `value`: the value being set
+ * - `virtual`: the virtual object you're calling `.set()` on
+ * - `doc`: the document this virtual is attached to. Equivalent to `this`.
  *
  * ####Example:
  *
- *     var virtual = schema.virtual('fullname');
- *     virtual.set(function (v) {
- *       var parts = v.split(' ');
+ *     const virtual = schema.virtual('fullname');
+ *     virtual.set(function(value, virtual, doc) {
+ *       var parts = value.split(' ');
  *       this.name.first = parts[0];
  *       this.name.last = parts[1];
  *     });
  *
- * @param {Function} fn
+ *     const Model = mongoose.model('Test', schema);
+ *     const doc = new Model();
+ *     // Calls the setter with `value = 'Jean-Luc Picard'`
+ *     doc.fullname = 'Jean-Luc Picard';
+ *     doc.name.first; // 'Jean-Luc'
+ *     doc.name.last; // 'Picard'
+ *
+ * @param {Function(Any, VirtualType, Document)} fn
  * @return {VirtualType} this
  * @api public
  */
@@ -88280,35 +90224,35 @@ VirtualType.prototype.set = function(fn) {
 };
 
 /**
- * Applies getters to `value` using optional `scope`.
+ * Applies getters to `value`.
  *
  * @param {Object} value
- * @param {Object} scope
+ * @param {Document} doc The document this virtual is attached to
  * @return {any} the value after applying all getters
  * @api public
  */
 
-VirtualType.prototype.applyGetters = function(value, scope) {
+VirtualType.prototype.applyGetters = function(value, doc) {
   let v = value;
   for (let l = this.getters.length - 1; l >= 0; l--) {
-    v = this.getters[l].call(scope, v, this);
+    v = this.getters[l].call(doc, v, this, doc);
   }
   return v;
 };
 
 /**
- * Applies setters to `value` using optional `scope`.
+ * Applies setters to `value`.
  *
  * @param {Object} value
- * @param {Object} scope
+ * @param {Document} doc
  * @return {any} the value after applying all setters
  * @api public
  */
 
-VirtualType.prototype.applySetters = function(value, scope) {
+VirtualType.prototype.applySetters = function(value, doc) {
   let v = value;
   for (let l = this.setters.length - 1; l >= 0; l--) {
-    v = this.setters[l].call(scope, v, this);
+    v = this.setters[l].call(doc, v, this, doc);
   }
   return v;
 };
@@ -88319,7 +90263,7 @@ VirtualType.prototype.applySetters = function(value, scope) {
 
 module.exports = VirtualType;
 
-},{}],338:[function(require,module,exports){
+},{}],350:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -88350,7 +90294,7 @@ module.exports = function(val, options) {
   var type = typeof val;
   if (type === 'string' && val.length > 0) {
     return parse(val);
-  } else if (type === 'number' && isNaN(val) === false) {
+  } else if (type === 'number' && isFinite(val)) {
     return options.long ? fmtLong(val) : fmtShort(val);
   }
   throw new Error(
@@ -88372,7 +90316,7 @@ function parse(str) {
   if (str.length > 100) {
     return;
   }
-  var match = /^((?:\d+)?\-?\d?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+  var match = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
     str
   );
   if (!match) {
@@ -88483,14 +90427,74 @@ function plural(ms, msAbs, n, name) {
   return Math.round(ms / n) + ' ' + name + (isPlural ? 's' : '');
 }
 
-},{}],339:[function(require,module,exports){
+},{}],351:[function(require,module,exports){
+/* eslint-disable node/no-deprecated-api */
+var buffer = require('buffer')
+var Buffer = buffer.Buffer
+
+// alternative to using Object.keys for old browsers
+function copyProps (src, dst) {
+  for (var key in src) {
+    dst[key] = src[key]
+  }
+}
+if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+  module.exports = buffer
+} else {
+  // Copy properties from require('buffer')
+  copyProps(buffer, exports)
+  exports.Buffer = SafeBuffer
+}
+
+function SafeBuffer (arg, encodingOrOffset, length) {
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+// Copy static methods from Buffer
+copyProps(Buffer, SafeBuffer)
+
+SafeBuffer.from = function (arg, encodingOrOffset, length) {
+  if (typeof arg === 'number') {
+    throw new TypeError('Argument must not be a number')
+  }
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+SafeBuffer.alloc = function (size, fill, encoding) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  var buf = Buffer(size)
+  if (fill !== undefined) {
+    if (typeof encoding === 'string') {
+      buf.fill(fill, encoding)
+    } else {
+      buf.fill(fill)
+    }
+  } else {
+    buf.fill(0)
+  }
+  return buf
+}
+
+SafeBuffer.allocUnsafe = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return Buffer(size)
+}
+
+SafeBuffer.allocUnsafeSlow = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return buffer.SlowBuffer(size)
+}
+
+},{"buffer":106}],352:[function(require,module,exports){
 module.exports = exports = require('./lib');
 
-},{"./lib":340}],340:[function(require,module,exports){
-(function (global){
-// Make sure Map exists for old Node.js versions
-var Map = global.Map != null ? global.Map : function() {};
-
+},{"./lib":353}],353:[function(require,module,exports){
 // These properties are special and can open client libraries to security
 // issues
 var ignoreProperties = ['__proto__', 'constructor', 'prototype'];
@@ -88556,7 +90560,9 @@ exports.get = function (path, o, special, map) {
       // reading a property from the array items
       var paths = parts.slice(i);
 
-      return obj.map(function (item) {
+      // Need to `concat()` to avoid `map()` calling a constructor of an array
+      // subclass
+      return [].concat(obj).map(function (item) {
         return item
           ? exports.get(paths, item, special || lookup, map)
           : map(undefined);
@@ -88745,17 +90751,7 @@ exports.set = function (path, val, o, special, map, _copying) {
   // set the value on the last branch
   if (Array.isArray(obj) && !/^\d+$/.test(part)) {
     if (!copy && Array.isArray(val)) {
-      for (var item, j = 0; j < obj.length && j < val.length; ++j) {
-        item = obj[j];
-        if (item) {
-          if (lookup) {
-            lookup(item, part, map(val[j]));
-          } else {
-            if (item[special]) item = item[special];
-            item[part] = map(val[j]);
-          }
-        }
-      }
+      _setArray(obj, val, part, lookup, special, map);
     } else {
       for (var j = 0; j < obj.length; ++j) {
         item = obj[j];
@@ -88781,6 +90777,26 @@ exports.set = function (path, val, o, special, map, _copying) {
 }
 
 /*!
+ * Recursively set nested arrays
+ */
+
+function _setArray(obj, val, part, lookup, special, map) {
+  for (var item, j = 0; j < obj.length && j < val.length; ++j) {
+    item = obj[j];
+    if (Array.isArray(item) && Array.isArray(val[j])) {
+      _setArray(item, val[j], part, lookup, special, map);
+    } else if (item) {
+      if (lookup) {
+        lookup(item, part, map(val[j]));
+      } else {
+        if (item[special]) item = item[special];
+        item[part] = map(val[j]);
+      }
+    }
+  }
+}
+
+/*!
  * Returns the value passed to it.
  */
 
@@ -88788,8 +90804,7 @@ function K (v) {
   return v;
 }
 
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],341:[function(require,module,exports){
+},{}],354:[function(require,module,exports){
 'use strict';
 
 /**
@@ -88837,7 +90852,7 @@ function notImplemented(method) {
   };
 }
 
-},{}],342:[function(require,module,exports){
+},{}],355:[function(require,module,exports){
 'use strict';
 
 var env = require('../env');
@@ -88852,7 +90867,7 @@ module.exports =
       require('./collection');
 
 
-},{"../env":344,"./collection":341,"./node":343}],343:[function(require,module,exports){
+},{"../env":357,"./collection":354,"./node":356}],356:[function(require,module,exports){
 'use strict';
 
 /**
@@ -89005,7 +91020,7 @@ NodeCollection.prototype.findCursor = function(match, findOptions) {
 
 module.exports = exports = NodeCollection;
 
-},{"../utils":347,"./collection":341}],344:[function(require,module,exports){
+},{"../utils":360,"./collection":354}],357:[function(require,module,exports){
 (function (process,global,Buffer){
 'use strict';
 
@@ -89031,7 +91046,7 @@ exports.type = exports.isNode ? 'node'
       : 'unknown';
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"_process":351,"buffer":106}],345:[function(require,module,exports){
+},{"_process":366,"buffer":106}],358:[function(require,module,exports){
 'use strict';
 
 /**
@@ -89068,8 +91083,7 @@ function Query(criteria, options) {
 
   this.op = proto.op || undefined;
 
-  this.options = {};
-  this.setOptions(proto.options);
+  this.options = Object.assign({}, proto.options);
 
   this._conditions = proto._conditions
     ? utils.clone(proto._conditions)
@@ -92286,7 +94300,7 @@ module.exports = exports = Query;
 // TODO
 // test utils
 
-},{"./collection":342,"./collection/collection":341,"./env":344,"./permissions":346,"./utils":347,"assert":80,"bluebird":85,"debug":348,"sliced":354,"util":365}],346:[function(require,module,exports){
+},{"./collection":355,"./collection/collection":354,"./env":357,"./permissions":359,"./utils":360,"assert":80,"bluebird":85,"debug":361,"sliced":368,"util":380}],359:[function(require,module,exports){
 'use strict';
 
 var denied = exports;
@@ -92376,7 +94390,7 @@ denied.count.maxScan =
 denied.count.snapshot =
 denied.count.tailable = true;
 
-},{}],347:[function(require,module,exports){
+},{}],360:[function(require,module,exports){
 (function (process,setImmediate){
 'use strict';
 
@@ -92736,7 +94750,7 @@ exports.isArgumentsObject = function(v) {
 };
 
 }).call(this,require('_process'),require("timers").setImmediate)
-},{"_process":351,"regexp-clone":352,"safe-buffer":353,"timers":355}],348:[function(require,module,exports){
+},{"_process":366,"regexp-clone":367,"safe-buffer":363,"timers":369}],361:[function(require,module,exports){
 (function (process){
 /**
  * This is the web browser implementation of `debug()`.
@@ -92935,7 +94949,7 @@ function localstorage() {
 }
 
 }).call(this,require('_process'))
-},{"./debug":349,"_process":351}],349:[function(require,module,exports){
+},{"./debug":362,"_process":366}],362:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -93162,7 +95176,9 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":350}],350:[function(require,module,exports){
+},{"ms":364}],363:[function(require,module,exports){
+arguments[4][351][0].apply(exports,arguments)
+},{"buffer":106,"dup":351}],364:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -93316,7 +95332,99 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],351:[function(require,module,exports){
+},{}],365:[function(require,module,exports){
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+'use strict';
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+},{}],366:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -93502,9 +95610,9 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],352:[function(require,module,exports){
+},{}],367:[function(require,module,exports){
 
-var toString = Object.prototype.toString;
+const toString = Object.prototype.toString;
 
 function isRegExp (o) {
   return 'object' == typeof o
@@ -93516,79 +95624,22 @@ module.exports = exports = function (regexp) {
     throw new TypeError('Not a RegExp');
   }
 
-  var flags = [];
+  const flags = [];
   if (regexp.global) flags.push('g');
   if (regexp.multiline) flags.push('m');
   if (regexp.ignoreCase) flags.push('i');
-  return new RegExp(regexp.source, flags.join(''));
-}
-
-
-},{}],353:[function(require,module,exports){
-/* eslint-disable node/no-deprecated-api */
-var buffer = require('buffer')
-var Buffer = buffer.Buffer
-
-// alternative to using Object.keys for old browsers
-function copyProps (src, dst) {
-  for (var key in src) {
-    dst[key] = src[key]
+  if (regexp.dotAll) flags.push('s');
+  if (regexp.unicode) flags.push('u');
+  if (regexp.sticky) flags.push('y');
+  const result = new RegExp(regexp.source, flags.join(''));
+  if (typeof regexp.lastIndex === 'number') {
+    result.lastIndex = regexp.lastIndex;
   }
-}
-if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
-  module.exports = buffer
-} else {
-  // Copy properties from require('buffer')
-  copyProps(buffer, exports)
-  exports.Buffer = SafeBuffer
+  return result;
 }
 
-function SafeBuffer (arg, encodingOrOffset, length) {
-  return Buffer(arg, encodingOrOffset, length)
-}
 
-// Copy static methods from Buffer
-copyProps(Buffer, SafeBuffer)
-
-SafeBuffer.from = function (arg, encodingOrOffset, length) {
-  if (typeof arg === 'number') {
-    throw new TypeError('Argument must not be a number')
-  }
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-SafeBuffer.alloc = function (size, fill, encoding) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  var buf = Buffer(size)
-  if (fill !== undefined) {
-    if (typeof encoding === 'string') {
-      buf.fill(fill, encoding)
-    } else {
-      buf.fill(fill)
-    }
-  } else {
-    buf.fill(0)
-  }
-  return buf
-}
-
-SafeBuffer.allocUnsafe = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return Buffer(size)
-}
-
-SafeBuffer.allocUnsafeSlow = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return buffer.SlowBuffer(size)
-}
-
-},{"buffer":106}],354:[function(require,module,exports){
+},{}],368:[function(require,module,exports){
 
 /**
  * An Array.prototype.slice.call(arguments) alternative
@@ -93623,7 +95674,7 @@ module.exports = function (args, slice, sliceEnd) {
 }
 
 
-},{}],355:[function(require,module,exports){
+},{}],369:[function(require,module,exports){
 (function (setImmediate,clearImmediate){
 var nextTick = require('process/browser.js').nextTick;
 var apply = Function.prototype.apply;
@@ -93702,7 +95753,7 @@ exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate :
   delete immediateIds[id];
 };
 }).call(this,require("timers").setImmediate,require("timers").clearImmediate)
-},{"process/browser.js":351,"timers":355}],356:[function(require,module,exports){
+},{"process/browser.js":366,"timers":369}],370:[function(require,module,exports){
 module.exports={
   "10*": {
     "value": 10,
@@ -94906,10 +96957,10 @@ module.exports={
   }
 }
 
-},{}],357:[function(require,module,exports){
+},{}],371:[function(require,module,exports){
 module.exports={"mol":true,"sr":true,"Hz":true,"N":true,"Pa":true,"J":true,"W":true,"A":true,"V":true,"F":true,"Ohm":true,"S":true,"Wb":true,"Cel":true,"T":true,"H":true,"lm":true,"lx":true,"Bq":true,"Gy":true,"Sv":true,"l":true,"L":true,"ar":true,"t":true,"bar":true,"u":true,"eV":true,"pc":true,"[c]":true,"[h]":true,"[k]":true,"[eps_0]":true,"[mu_0]":true,"[e]":true,"[m_e]":true,"[m_p]":true,"[G]":true,"[g]":true,"[ly]":true,"gf":true,"Ky":true,"Gal":true,"dyn":true,"erg":true,"P":true,"Bi":true,"St":true,"Mx":true,"G":true,"Oe":true,"Gb":true,"sb":true,"Lmb":true,"ph":true,"Ci":true,"R":true,"RAD":true,"REM":true,"cal_[15]":true,"cal_[20]":true,"cal_m":true,"cal_IT":true,"cal_th":true,"cal":true,"tex":true,"m[H2O]":true,"m[Hg]":true,"eq":true,"osm":true,"g%":true,"kat":true,"U":true,"[iU]":true,"[IU]":true,"Np":true,"B":true,"B[SPL]":true,"B[V]":true,"B[mV]":true,"B[uV]":true,"B[10.nV]":true,"B[W]":true,"B[kW]":true,"st":true,"mho":true,"bit":true,"By":true,"Bd":true,"m":true,"s":true,"g":true,"rad":true,"K":true,"C":true,"cd":true}
 
-},{}],358:[function(require,module,exports){
+},{}],372:[function(require,module,exports){
 module.exports={
   "Y": {
     "CODE": "YA",
@@ -95273,7 +97324,7 @@ module.exports={
   }
 }
 
-},{}],359:[function(require,module,exports){
+},{}],373:[function(require,module,exports){
 module.exports={
   "Y": 1e+24,
   "Z": 1e+21,
@@ -95301,7 +97352,7 @@ module.exports={
   "Ti": 1099511627776
 }
 
-},{}],360:[function(require,module,exports){
+},{}],374:[function(require,module,exports){
 module.exports = (function() {
   /*
    * Generated by PEG.js 0.8.0.
@@ -96849,7 +98900,7 @@ module.exports = (function() {
   };
 })();
 
-},{"../lib/helpers":362,"./metrics.json":357,"./prefixMetadata.json":358,"./prefixes.json":359,"./unitMetadata.json":361}],361:[function(require,module,exports){
+},{"../lib/helpers":376,"./metrics.json":371,"./prefixMetadata.json":372,"./prefixes.json":373,"./unitMetadata.json":375}],375:[function(require,module,exports){
 module.exports={
   "10*": {
     "isBase": false,
@@ -103036,7 +105087,7 @@ module.exports={
   }
 }
 
-},{}],362:[function(require,module,exports){
+},{}],376:[function(require,module,exports){
 module.exports = {
 
   multiply: function multiply(t, ms) {
@@ -103106,7 +105157,7 @@ module.exports = {
   }
 }
 
-},{}],363:[function(require,module,exports){
+},{}],377:[function(require,module,exports){
 parser = require('./generated/ucum-parser.js');
 equivalents = require('./generated/equivalents.json');
 helpers = require('./lib/helpers.js');
@@ -103336,8 +105387,10 @@ function unitQuery(criteria, resultFields){
     return obj;
   });
 }
-},{"./generated/equivalents.json":356,"./generated/ucum-parser.js":360,"./generated/unitMetadata.json":361,"./lib/helpers.js":362}],364:[function(require,module,exports){
+},{"./generated/equivalents.json":370,"./generated/ucum-parser.js":374,"./generated/unitMetadata.json":375,"./lib/helpers.js":376}],378:[function(require,module,exports){
+arguments[4][81][0].apply(exports,arguments)
+},{"dup":81}],379:[function(require,module,exports){
 arguments[4][82][0].apply(exports,arguments)
-},{"dup":82}],365:[function(require,module,exports){
+},{"dup":82}],380:[function(require,module,exports){
 arguments[4][83][0].apply(exports,arguments)
-},{"./support/isBuffer":364,"_process":351,"dup":83,"inherits":244}]},{},[79]);
+},{"./support/isBuffer":379,"_process":366,"dup":83,"inherits":378}]},{},[79]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {
@@ -16,7 +16,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "cql-execution": "^1.3.3",
+    "cql-execution": "~1.3.3",
     "mongoose": "^5.4.14"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,10 +502,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cql-execution@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.3.tgz#fae49e0dba8e32e10e259257e7377dd7944f06fc"
-  integrity sha512-FihPewB7HeHWZLs/r2qzu60l+bn+CjAaifN34MQHZH9+Xko7sRExp9e48f1qvboWZdKC98N3QV1WUx1NFpt2vA==
+cql-execution@~1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.5.tgz#0036b8ebc4eb6d1fd94810ea9203657625e44a5a"
+  integrity sha512-Gz/EKkjql1jFQcUviU4uvTtyntneOmL9xxsStwkcrKiIb/JPNO3YP5r6ws7iHiTF77WcpJbG0XRa4nRBdelf2w==
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,11 +20,6 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
 
-acorn-dynamic-import@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
-  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
-
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -33,19 +28,18 @@ acorn-jsx@^3.0.0:
     acorn "^3.0.4"
 
 acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.6.2.tgz#b7d7ceca6f22e6417af933a62cad4de01048d5d2"
-  integrity sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
   dependencies:
-    acorn "^6.0.2"
-    acorn-dynamic-import "^4.0.0"
-    acorn-walk "^6.1.0"
-    xtend "^4.0.1"
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
 
-acorn-walk@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
-  integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+acorn-walk@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
+  integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
 
 acorn@^3.0.4:
   version "3.3.0"
@@ -57,10 +51,10 @@ acorn@^5.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.2:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
-  integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -116,20 +110,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-  integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-  integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
-  integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -141,23 +128,17 @@ asn1.js@^4.0.0:
     minimalistic-assert "^1.0.0"
 
 assert@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
-  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   dependencies:
+    object-assign "^4.1.1"
     util "0.10.3"
 
 async@1.x:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
-async@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
-  dependencies:
-    lodash "^4.17.10"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -174,9 +155,9 @@ balanced-match@^1.0.0:
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
-  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 bluebird@3.5.1:
   version "3.5.1"
@@ -280,9 +261,9 @@ browserify-zlib@~0.2.0:
     pako "~1.0.5"
 
 browserify@^16.1.0:
-  version "16.2.3"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.2.3.tgz#7ee6e654ba4f92bce6ab3599c3485b1cc7a0ad0b"
-  integrity sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.5.0.tgz#a1c2bc0431bec11fd29151941582e3f645ede881"
+  integrity sha512-6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==
   dependencies:
     JSONStream "^1.0.3"
     assert "^1.4.0"
@@ -321,7 +302,7 @@ browserify@^16.1.0:
     shasum "^1.0.0"
     shell-quote "^1.6.1"
     stream-browserify "^2.0.0"
-    stream-http "^2.0.0"
+    stream-http "^3.0.0"
     string_decoder "^1.1.1"
     subarg "^1.0.0"
     syntax-error "^1.1.1"
@@ -333,10 +314,10 @@ browserify@^16.1.0:
     vm-browserify "^1.0.0"
     xtend "^4.0.0"
 
-bson@^1.1.0, bson@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
-  integrity sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==
+bson@^1.1.1, bson@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
+  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -349,9 +330,9 @@ buffer-xor@^1.0.3:
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^5.0.2:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
-  integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
+  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -361,7 +342,7 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-cached-path-relative@^1.0.0:
+cached-path-relative@^1.0.0, cached-path-relative@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.2.tgz#a13df4196d26776220cc3356eb147a52dba2c6db"
   integrity sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==
@@ -455,7 +436,7 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
-commander@~2.20.0:
+commander@2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -567,6 +548,11 @@ crypto-browserify@^3.0.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+dash-ast@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dash-ast/-/dash-ast-1.0.0.tgz#12029ba5fb2f8aa6f0a861795b23c1b4b6c27d37"
+  integrity sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -597,6 +583,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+define-properties@^1.1.2, define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -667,9 +660,9 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
     readable-stream "^2.0.2"
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
-  integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
+  integrity sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -685,6 +678,31 @@ error-ex@^1.2.0:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.12.0, es-abstract@^1.7.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.15.0.tgz#8884928ec7e40a79e3c9bc812d37d10c8b24cc57"
+  integrity sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.0"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-inspect "^1.6.0"
+    object-keys "^1.1.1"
+    string.prototype.trimleft "^2.1.0"
+    string.prototype.trimright "^2.1.0"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -718,29 +736,30 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-module-utils@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
-  integrity sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+eslint-module-utils@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz#7b4675875bf96b0dbf1b21977456e5bb1f5e018c"
+  integrity sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
 eslint-plugin-import@^2.8.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
-  integrity sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6"
+  integrity sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==
   dependencies:
+    array-includes "^3.0.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.2"
-    eslint-module-utils "^2.3.0"
+    eslint-module-utils "^2.4.0"
     has "^1.0.3"
-    lodash "^4.17.11"
     minimatch "^3.0.4"
+    object.values "^1.1.0"
     read-pkg-up "^2.0.0"
-    resolve "^1.9.0"
+    resolve "^1.11.0"
 
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
@@ -756,9 +775,9 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^4.17.0:
   version "4.19.1"
@@ -842,14 +861,14 @@ estraverse@^1.9.1:
   integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 events@^2.0.0:
   version "2.1.0"
@@ -957,9 +976,9 @@ glob@^5.0.15:
     path-is-absolute "^1.0.0"
 
 glob@^7.0.6, glob@^7.1.0, glob@^7.1.2, glob@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -974,14 +993,14 @@ globals@^11.0.1:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 graceful-fs@^4.1.2:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 handlebars@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
+  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -1006,7 +1025,12 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has@^1.0.0, has@^1.0.3:
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
+has@^1.0.0, has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -1039,9 +1063,9 @@ hmac-drbg@^1.0.0:
     minimalistic-crypto-utils "^1.0.1"
 
 hosted-git-info@^2.1.4:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 htmlescape@^1.1.0:
   version "1.1.1"
@@ -1061,9 +1085,9 @@ iconv-lite@^0.4.17:
     safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.4:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
-  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ignore@^3.3.3:
   version "3.3.10"
@@ -1083,15 +1107,20 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inline-source-map@~0.6.0:
   version "0.6.2"
@@ -1146,6 +1175,16 @@ is-buffer@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -1156,20 +1195,29 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-isarray@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.4.tgz#38e7bcbb0f3ba1b7933c86ba1894ddfc3781bbb7"
-  integrity sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1250,18 +1298,17 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-kareem@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.0.tgz#ef33c42e9024dce511eeaf440cd684f3af1fc769"
-  integrity sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg==
+kareem@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
+  integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
 
 labeled-stream-splicer@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz#9cffa32fd99e1612fd1d86a8db962416d5292926"
-  integrity sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz#42a41a16abcd46fd046306cf4f2c3576fffb1c21"
+  integrity sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==
   dependencies:
     inherits "^2.0.1"
-    isarray "^2.0.4"
     stream-splicer "^2.0.0"
 
 levn@^0.3.0, levn@~0.3.0:
@@ -1295,10 +1342,10 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -1316,11 +1363,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-memory-pager@^1.0.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
-  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -1375,13 +1417,13 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 module-deps@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.0.tgz#d41a2e790245ce319171e4e7c4d8c73993ba3cd5"
-  integrity sha512-hKPmO06so6bL/ZvqVNVqdTVO8UAYsi3tQWlCa+z9KuWhoN4KDQtb5hcqQQv58qYiDE21wIvnttZEPiDgEbpwbA==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.1.tgz#cfe558784060e926824f474b4e647287837cda50"
+  integrity sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==
   dependencies:
     JSONStream "^1.0.3"
     browser-resolve "^1.7.0"
-    cached-path-relative "^1.0.0"
+    cached-path-relative "^1.0.2"
     concat-stream "~1.6.0"
     defined "^1.0.0"
     detective "^5.0.2"
@@ -1400,23 +1442,13 @@ moment@^2.20.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-mongodb-core@3.1.11:
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.11.tgz#b253038dbb4d7329f3d1c2ee5400bb0c9221fde5"
-  integrity sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==
+mongodb@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.3.2.tgz#ff086b5f552cf07e24ce098694210f3d42d668b2"
+  integrity sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==
   dependencies:
-    bson "^1.1.0"
+    bson "^1.1.1"
     require_optional "^1.0.1"
-    safe-buffer "^5.1.2"
-  optionalDependencies:
-    saslprep "^1.0.0"
-
-mongodb@3.1.13:
-  version "3.1.13"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.13.tgz#f8cdcbb36ad7a08b570bd1271c8525753f75f9f4"
-  integrity sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==
-  dependencies:
-    mongodb-core "3.1.11"
     safe-buffer "^5.1.2"
 
 mongoose-legacy-pluralize@1.0.2:
@@ -1425,36 +1457,35 @@ mongoose-legacy-pluralize@1.0.2:
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
 mongoose@^5.4.14:
-  version "5.4.14"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.4.14.tgz#8cc074c9990db0a26062a779f461abb91c9c483c"
-  integrity sha512-lAISH4xdx0/o0bVWPB4bxApP3bA1b08oHPEjTBq3/mIr4R494hepDJJowByBgpGYf8tj/oe6VkFCx8wbRcOciA==
+  version "5.7.5"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.7.5.tgz#b787b47216edf62036aa358c3ef0f1869c46cdc2"
+  integrity sha512-BZ4FxtnbTurc/wcm/hLltLdI4IDxo4nsE0D9q58YymTdZwreNzwO62CcjVtaHhmr8HmJtOInp2W/T12FZaMf8g==
   dependencies:
-    async "2.6.1"
-    bson "~1.1.0"
-    kareem "2.3.0"
-    mongodb "3.1.13"
-    mongodb-core "3.1.11"
+    bson "~1.1.1"
+    kareem "2.3.1"
+    mongodb "3.3.2"
     mongoose-legacy-pluralize "1.0.2"
-    mpath "0.5.1"
-    mquery "3.2.0"
-    ms "2.1.1"
-    regexp-clone "0.0.1"
+    mpath "0.6.0"
+    mquery "3.2.2"
+    ms "2.1.2"
+    regexp-clone "1.0.0"
     safe-buffer "5.1.2"
+    sift "7.0.1"
     sliced "1.0.1"
 
-mpath@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.5.1.tgz#17131501f1ff9e6e4fbc8ffa875aa7065b5775ab"
-  integrity sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg==
+mpath@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.6.0.tgz#aa922029fca4f0f641f360e74c5c1b6a4c47078e"
+  integrity sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw==
 
-mquery@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.0.tgz#e276472abd5109686a15eb2a8e0761db813c81cc"
-  integrity sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==
+mquery@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.2.tgz#e1383a3951852ce23e37f619a9b350f1fb3664e7"
+  integrity sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==
   dependencies:
     bluebird "3.5.1"
     debug "3.1.0"
-    regexp-clone "0.0.1"
+    regexp-clone "^1.0.0"
     safe-buffer "5.1.2"
     sliced "1.0.1"
 
@@ -1463,10 +1494,10 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.1, ms@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+ms@2.1.2, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -1479,9 +1510,9 @@ natural-compare@^1.4.0:
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 neo-async@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
-  integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 nopt@3.x:
   version "3.0.6"
@@ -1500,10 +1531,30 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.values@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
+  integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 once@1.x, once@^1.3.0:
   version "1.4.0"
@@ -1569,9 +1620,9 @@ p-try@^1.0.0:
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 pako@~1.0.5:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
-  integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
 parents@^1.0.0, parents@^1.0.1:
   version "1.0.1"
@@ -1581,9 +1632,9 @@ parents@^1.0.0, parents@^1.0.1:
     path-platform "~0.11.15"
 
 parse-asn1@^5.0.0:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
-  integrity sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
+  integrity sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -1670,9 +1721,9 @@ prelude-ls@~1.1.2:
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process@~0.11.0:
   version "0.11.10"
@@ -1760,7 +1811,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -1773,10 +1824,19 @@ readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.6, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-regexp-clone@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
-  integrity sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=
+readable-stream@^3.0.6:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+regexp-clone@1.0.0, regexp-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
+  integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
 
 regexpp@^1.0.1:
   version "1.1.0"
@@ -1814,10 +1874,10 @@ resolve@1.1.7, resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.10.0, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
-  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+resolve@^1.1.4, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.4.0, resolve@^1.5.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -1863,32 +1923,25 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-saslprep@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.2.tgz#da5ab936e6ea0bbae911ffec77534be370c9f52d"
-  integrity sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==
-  dependencies:
-    sparse-bitfield "^3.0.3"
-
-"semver@2 || 3 || 4 || 5", semver@^5.1.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@^5.3.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   version "2.4.11"
@@ -1919,14 +1972,14 @@ shebang-regex@^1.0.0:
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shell-quote@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
+sift@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
+  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
 
 signal-exit@^3.0.2:
   version "3.0.2"
@@ -1967,13 +2020,6 @@ source-map@~0.5.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-sparse-bitfield@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
-  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
-  dependencies:
-    memory-pager "^1.0.2"
-
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -1996,9 +2042,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
-  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
+  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2021,21 +2067,20 @@ stream-combiner2@^1.1.1:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
 
-stream-http@^2.0.0:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
+stream-http@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-3.1.0.tgz#22fb33fe9b4056b4eccf58bd8f400c4b993ffe57"
+  integrity sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
-    readable-stream "^2.3.6"
-    to-arraybuffer "^1.0.0"
+    readable-stream "^3.0.6"
     xtend "^4.0.0"
 
 stream-splicer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-2.0.0.tgz#1b63be438a133e4b671cc1935197600175910d83"
-  integrity sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-2.0.1.tgz#0b13b7ee2b5ac7e0609a7463d83899589a363fcd"
+  integrity sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
@@ -2048,12 +2093,28 @@ string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
-  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+string.prototype.trimleft@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
+  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
   dependencies:
-    safe-buffer "~5.1.0"
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string.prototype.trimright@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
+  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -2163,11 +2224,6 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-to-arraybuffer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
-  integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
 tty-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
@@ -2191,11 +2247,11 @@ ucum@0.0.7:
   integrity sha1-zQfv5VmaF+9/syd3i/g46DLf0aQ=
 
 uglify-js@^3.1.4:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.10.tgz#652bef39f86d9dbfd6674407ee05a5e2d372cf2d"
-  integrity sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.2.tgz#fd8048c86d990ddd29fe99d3300e0cb329103f4d"
+  integrity sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==
   dependencies:
-    commander "~2.20.0"
+    commander "2.20.0"
     source-map "~0.6.1"
 
 umd@^3.0.0:
@@ -2204,11 +2260,12 @@ umd@^3.0.0:
   integrity sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==
 
 undeclared-identifiers@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz#7d850a98887cff4bd0bf64999c014d08ed6d1acc"
-  integrity sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz#9254c1d37bdac0ac2b52de4b6722792d2a91e30f"
+  integrity sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==
   dependencies:
     acorn-node "^1.3.0"
+    dash-ast "^1.0.0"
     get-assigned-identifiers "^1.2.0"
     simple-concat "^1.0.0"
     xtend "^4.0.1"
@@ -2221,7 +2278,7 @@ url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -2282,10 +2339,10 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Currently the 2.0.0 relies on ^1.3.3 which will push the version to 1.4.1, not 1.3.5

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
