### PR TITLE
Upgrade gitleaks to v4.3.1 and point config to SB repo

### DIFF
--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -10,6 +10,7 @@ jobs:
       REPO: https://github.com/projecttacoma/cqm-models
       REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/semanticbits/bmat-gitleaks-automation/master/cqm-models/gitleaks.toml
       GITLEAKS_VERSION: v4.3.1
+    steps:
     - name: Execute Gitleaks
       run: |
         wget ${REMOTE_EXCLUDES_URL} -O gitleaks.toml

--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPO: https://github.com/projecttacoma/cqm-models
-      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/casey-erdmann/bmat-gitleaks-automation/master/cqm-models/gitleaks.toml
-      GITLEAKS_VERSION: v3.0.3
-    steps:
+      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/semanticbits/bmat-gitleaks-automation/master/cqm-models/gitleaks.toml
+      GITLEAKS_VERSION: v4.3.1
     - name: Execute Gitleaks
       run: |
         wget ${REMOTE_EXCLUDES_URL} -O gitleaks.toml


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

This PR upgrades our gitleaks automation to the latest version and points the config to our new SB bmat gitleaks config repo.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] Internal ticket for this PR: MAT-786
- [X] Internal ticket links to this PR N/A
- [X] Code diff has been done and been reviewed
- [X] Tests are included and test edge cases N/A
- [X] Tests have been run locally and pass N/A
- [X] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated N/A
- [X] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter N/A

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
