### PR TITLE
Data element initialization issue with class attribute

### DIFF
--- a/app/models/qdm/basetypes/data_element.rb
+++ b/app/models/qdm/basetypes/data_element.rb
@@ -18,9 +18,9 @@ module QDM
 
     def initialize(options = {})
       # class is reserved word. changed to clazz
-      if options[:class]
-        options[:clazz] = options[:class]
-        options.delete(:class)
+      if options['class']
+        options['clazz'] = options['class']
+        options.delete('class')
       end
       super(options)
       # default id to the mongo ObjectId for this DataElement if it isnt already defined

--- a/spec/cqm/encounter_performed_spec.rb
+++ b/spec/cqm/encounter_performed_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe QDM::EncounterPerformed do
       @patient = CQM::Patient.new(givenNames: %w['Example Patient'], familyName: 'C-cee', bundleId: 'C')
       @patient.qdmPatient.birthDatetime = 15.years.ago
       encounter_performed = QDM::EncounterPerformed.new(
-        authorDatetime: '2012-08-21T08:00:00.000+00:00',
-        class: {
-          code: '111297003',
-          system: 'SNOMED-CT'
+        'authorDatetime' => '2012-08-21T08:00:00.000+00:00',
+        'class' => {
+          'code' => '111297003',
+          'system' => 'SNOMED-CT'
         },
-        relevantPeriod: {
-          low: '2012-08-21T08:00:00.000+00:00',
-          high: '2012-12-19T08:15:00.000+00:00',
-          lowClosed: true,
-          highClosed: true
+        'relevantPeriod' => {
+          'low' => '2012-08-21T08:00:00.000+00:00',
+          'high' => '2012-12-19T08:15:00.000+00:00',
+          'lowClosed' => true,
+          'highClosed' => true
         },
-        diagnoses: [
+        'diagnoses' => [
           {
-            code: '111297002',
-            system: 'SNOMED-CT'
+            'code' => '111297002',
+            'system' => 'SNOMED-CT'
           }
         ]
       )


### PR DESCRIPTION
MAT-2993 Failed to initialize Data element with class attribute in Bonnie
- Updated to initialize model using ruby hash

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: MAT-2993 Failed to initialize Data element with class attribute in Bonnie
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
