### PR TITLE
BONNIEMAT-1644 fix CQL equivalent operator(~) issues

### DIFF
--- a/app/assets/javascripts/QDMPatient.js
+++ b/app/assets/javascripts/QDMPatient.js
@@ -3,6 +3,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const AnyEntity = require('./basetypes/AnyEntity');
 const AllDataElements = require('./AllDataElements');
 
 const [Schema, Number, String, Mixed] = [
@@ -94,6 +95,12 @@ QDMPatientSchema.methods.getDataElements = function getDataElements(params) {
   return this.dataElements;
 };
 
+QDMPatientSchema.methods.addMethodsTo = function addMethodsTo(obj, methods) {
+  Object.entries(methods).forEach(([method_name, method]) => {
+    obj[method_name] = method;
+  });
+};
+
 // Returns an array of dataElements that exist on the patient, queried by
 // QDM profile
 // @param {string} profile - the data criteria requested by the execution engine
@@ -103,7 +110,31 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
   // If isNegated == true, only return data elements with a negationRationale that is not null.
   // If isNegated == false, only return data elements with a null negationRationale.
   // If isNegated == null, return all matching data elements by type, regardless of negationRationale.
-  return this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  const results = this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  return results.map((result) => {
+    // we need to convert mongoose document to an object.
+    // This is required for comparing the two objects(in cql-execution) as we can't compare two mongoose documents.
+    const removedMongooseItems = new AllDataElements[profile](result).toObject({ virtuals: true });
+    // toObject() will remove all mongoose functions but also remove the schema methods, so we add them back
+    this.addMethodsTo(removedMongooseItems, result.schema.methods);
+    // add methods to entities
+    Object.entries(result).forEach(([key, values]) => {
+      // entities are always an array
+      if (Array.isArray(values)) {
+        try {
+          // check if the attribute is of Entity
+          if (AnyEntity.prototype.cast(values[0])) {
+            values.forEach((value, index) => {
+              const entity = removedMongooseItems[key][index];
+              this.addMethodsTo(entity, value.schema.methods);
+            });
+          }
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
+      }
+    });
+    return removedMongooseItems;
+  });
 };
 
 // This method is called by the CQL execution engine on a CQLPatient when

--- a/dist/index.js
+++ b/dist/index.js
@@ -2423,6 +2423,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const AnyEntity = require('./basetypes/AnyEntity');
 const AllDataElements = require('./AllDataElements');
 
 const [Schema, Number, String, Mixed] = [
@@ -2514,6 +2515,12 @@ QDMPatientSchema.methods.getDataElements = function getDataElements(params) {
   return this.dataElements;
 };
 
+QDMPatientSchema.methods.addMethodsTo = function addMethodsTo(obj, methods) {
+  Object.entries(methods).forEach(([method_name, method]) => {
+    obj[method_name] = method;
+  });
+};
+
 // Returns an array of dataElements that exist on the patient, queried by
 // QDM profile
 // @param {string} profile - the data criteria requested by the execution engine
@@ -2523,7 +2530,31 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
   // If isNegated == true, only return data elements with a negationRationale that is not null.
   // If isNegated == false, only return data elements with a null negationRationale.
   // If isNegated == null, return all matching data elements by type, regardless of negationRationale.
-  return this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  const results = this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  return results.map((result) => {
+    // we need to convert mongoose document to an object.
+    // This is required for comparing the two objects(in cql-execution) as we can't compare two mongoose documents.
+    const removedMongooseItems = new AllDataElements[profile](result).toObject({ virtuals: true });
+    // toObject() will remove all mongoose functions but also remove the schema methods, so we add them back
+    this.addMethodsTo(removedMongooseItems, result.schema.methods);
+    // add methods to entities
+    Object.entries(result).forEach(([key, values]) => {
+      // entities are always an array
+      if (Array.isArray(values)) {
+        try {
+          // check if the attribute is of Entity
+          if (AnyEntity.prototype.cast(values[0])) {
+            values.forEach((value, index) => {
+              const entity = removedMongooseItems[key][index];
+              this.addMethodsTo(entity, value.schema.methods);
+            });
+          }
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
+      }
+    });
+    return removedMongooseItems;
+  });
 };
 
 // This method is called by the CQL execution engine on a CQLPatient when
@@ -2714,7 +2745,7 @@ class QDMPatient extends mongoose.Document {
 }
 module.exports.QDMPatient = QDMPatient;
 
-},{"./AllDataElements":2,"./basetypes/Code":69,"./basetypes/DateTime":71,"./basetypes/Interval":72,"./basetypes/Quantity":74,"mongoose/browser":190}],50:[function(require,module,exports){
+},{"./AllDataElements":2,"./basetypes/AnyEntity":68,"./basetypes/Code":69,"./basetypes/DateTime":71,"./basetypes/Interval":72,"./basetypes/Quantity":74,"mongoose/browser":190}],50:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {

--- a/spec/javascript/unit/modelsSpec.js
+++ b/spec/javascript/unit/modelsSpec.js
@@ -608,3 +608,43 @@ describe('IndividualResult', () => {
     expect(result.observation_values.length).toBe(0);
   });
 });
+
+describe('getByProfile', () => {
+  let qdmPatient;
+  beforeEach(() => {
+    qdmPatient = new QDMPatient({
+      birthDatetime: cql.DateTime.fromJSDate(new Date(), 0),
+      qdmVersion: '0.0',
+      dataElements: [
+        new MedicationAdministered({
+          authorDatetime: new DateTime(),
+          dosage: new cql.Quantity('300', 'mg'),
+          performer: [
+            new CarePartner({
+              relationship: new cql.Code('fake', 'code', 'foo'),
+              identifier: new Identifier({ namingSystem: 'fake system', value: 'fake value' }),
+            }),
+            new Location({
+              locationType: new cql.Code('fake', 'code', 'bar'),
+              identifier: new Identifier({ namingSystem: 'some other system', value: 'some other fake value' }),
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it('can return the data elements by profile with schema methods added', () => {
+    const dataElements = qdmPatient.getByProfile('MedicationAdministered', false);
+    expect(dataElements.length).toEqual(1);
+    const dataElement = dataElements[0];
+    expect(dataElement._type).toEqual('QDM::MedicationAdministered');
+    expect(Object.keys(dataElement)).toEqual(expect.arrayContaining(
+      ['getCode', 'code', '_is', '_typeHierarchy']
+    ));
+    const performers = dataElement.performer;
+    expect(Object.keys(performers[0])).toEqual(expect.arrayContaining(
+      ['_is', '_typeHierarchy']
+    ));
+  });
+});

--- a/templates/patient_template.js.erb
+++ b/templates/patient_template.js.erb
@@ -3,6 +3,7 @@ const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
 const Quantity = require('./basetypes/Quantity');
 const DateTime = require('./basetypes/DateTime');
+const AnyEntity = require('./basetypes/AnyEntity');
 const AllDataElements = require('./AllDataElements');
 
 const [Schema, Number, String, Mixed] = [
@@ -94,6 +95,12 @@ QDMPatientSchema.methods.getDataElements = function getDataElements(params) {
   return this.dataElements;
 };
 
+QDMPatientSchema.methods.addMethodsTo = function addMethodsTo(obj, methods) {
+  Object.entries(methods).forEach(([method_name, method]) => {
+    obj[method_name] = method;
+  });
+};
+
 // Returns an array of dataElements that exist on the patient, queried by
 // QDM profile
 // @param {string} profile - the data criteria requested by the execution engine
@@ -103,7 +110,31 @@ QDMPatientSchema.methods.getByProfile = function getByProfile(profile, isNegated
   // If isNegated == true, only return data elements with a negationRationale that is not null.
   // If isNegated == false, only return data elements with a null negationRationale.
   // If isNegated == null, return all matching data elements by type, regardless of negationRationale.
-  return this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  const results = this.dataElements.filter(element => (element._type === `QDM::${profile}` || element._type === profile) && (isNegated === null || !!element.negationRationale === isNegated));
+  return results.map((result) => {
+    // we need to convert mongoose document to an object.
+    // This is required for comparing the two objects(in cql-execution) as we can't compare two mongoose documents.
+    const removedMongooseItems = new AllDataElements[profile](result).toObject({ virtuals: true });
+    // toObject() will remove all mongoose functions but also remove the schema methods, so we add them back
+    this.addMethodsTo(removedMongooseItems, result.schema.methods);
+    // add methods to entities
+    Object.entries(result).forEach(([key, values]) => {
+      // entities are always an array
+      if (Array.isArray(values)) {
+        try {
+          // check if the attribute is of Entity
+          if (AnyEntity.prototype.cast(values[0])) {
+            values.forEach((value, index) => {
+              const entity = removedMongooseItems[key][index];
+              this.addMethodsTo(entity, value.schema.methods);
+            });
+          }
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
+      }
+    });
+    return removedMongooseItems;
+  });
 };
 
 // This method is called by the CQL execution engine on a CQLPatient when


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
