### PR TITLE
MAT-6467 Add Location Type missing entity to AnyEntity instanceof check condition

### DIFF
--- a/app/assets/javascripts/basetypes/AnyEntity.js
+++ b/app/assets/javascripts/basetypes/AnyEntity.js
@@ -15,7 +15,7 @@ AnyEntity.prototype.cast = (entity) => {
     return null;
   }
 
-  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization) {
+  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization || entity instanceof Location) {
     return entity;
   }
 

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3579,7 +3579,7 @@ AnyEntity.prototype.cast = (entity) => {
     return null;
   }
 
-  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization) {
+  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization || entity instanceof Location) {
     return entity;
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3579,7 +3579,7 @@ AnyEntity.prototype.cast = (entity) => {
     return null;
   }
 
-  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization) {
+  if (entity instanceof PatientEntity || entity instanceof Practitioner || entity instanceof CarePartner || entity instanceof Organization || entity instanceof Location) {
     return entity;
   }
 

--- a/spec/javascript/unit/anyEntitySpec.js
+++ b/spec/javascript/unit/anyEntitySpec.js
@@ -5,6 +5,7 @@ const PatientEntity = require('./../../../app/assets/javascripts/attributes/Pati
 const Practitioner = require('./../../../app/assets/javascripts/attributes/Practitioner').Practitioner;
 const CarePartner = require('./../../../app/assets/javascripts/attributes/CarePartner').CarePartner;
 const Organization = require('./../../../app/assets/javascripts/attributes/Organization').Organization;
+const Location = require('./../../../app/assets/javascripts/attributes/Location').Location;
 
 describe('The AnyEntity class', () => {
   describe('Type casting', () => {
@@ -191,6 +192,37 @@ describe('The AnyEntity class', () => {
           value:'testValue'
         },
         type: new cql.Code('T123', '1.2.3.4', null, 'Test Type Code')
+      });
+
+      const returnedObj = AnyEntity.prototype.cast(entity);
+      expect(returnedObj).toBe(entity);
+    });
+
+    it('Should convert a Location entity JS Object to its type', () => {
+      const entityObj = {
+        id: 'test',
+        identifier: {
+          namingSystem: 'testSystem',
+          value: 'testValue',
+        },
+        locationType: { code: 'T123', system: '1.2.3.4', display: 'Test Code' },
+        _type: 'QDM::Location',
+      };
+
+      const returnedObj = AnyEntity.prototype.cast(entityObj);
+      expect(returnedObj instanceof Location).toBe(true);
+      expect(returnedObj.id).toEqual('test');
+      expect(returnedObj.identifier.namingSystem).toEqual('testSystem');
+      expect(returnedObj.identifier.value).toEqual('testValue');
+    });
+
+    it('Should return same instance of Location if it is already a Location entity', () => {
+      const entity = new Location({
+        id: 'test',
+        identifier: {
+          namingSystem: 'testSystem',
+          value:'testValue'
+        },
       });
 
       const returnedObj = AnyEntity.prototype.cast(entity);


### PR DESCRIPTION
**When we added the Location Entity model to cqm-models as part of QDM 5.6 spec, we missed a condition to check instanceof Location when we typecast the entity object. This PR adds the instanceof check on Location so that we can avoid recasting, instead just return same instance.** 

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: [MAT-6467](https://jira.cms.gov/browse/MAT-6467) Add Location Type to AnyEntity in CQM-Models
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
