### PR TITLE
remove codecov

### DIFF
--- a/cqm-models.gemspec
+++ b/cqm-models.gemspec
@@ -21,12 +21,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundle-audit'
   spec.add_development_dependency 'byebug', '~> 11.0.1'
-  spec.add_development_dependency 'codecov'
   spec.add_development_dependency 'mongoid', '~> 8'
   spec.add_development_dependency 'nokogiri', '>= 1.16.2'
   spec.add_development_dependency 'rails', '~> 7.1'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.63.0'
-  spec.add_development_dependency 'simplecov'
 end

--- a/spec/simplecov_init.rb
+++ b/spec/simplecov_init.rb
@@ -1,8 +1,0 @@
-require 'simplecov'
-require 'codecov'
-
-SimpleCov.start do
-  add_filter 'spec/'
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::Codecov


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
