### PR TITLE
Release 4.1.5

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - master
+jobs:
+  npm-publish:
+    if: contains(github.event.head_commit.message, 'Release')
+    name: npm-publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Starting with version **2.0.0** released on 6/20/2019, cqm-models versioning has
 For the versions available, see [tags on this repository](https://github.com/projecttacoma/cqm-models/tags).
 
 ## Publish a New Version
-Create a PR to merge into the master branch with the title ‘Release x.y.z’, where x.y.z is the npm version number. This will trigger the npm-publish GitHub workflow.
+Create a PR to merge into the master branch with the title ‘Release x.y.z’, where x.y.z is the new package number. This will trigger the npm-publish GitHub workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Starting with version **2.0.0** released on 6/20/2019, cqm-models versioning has
 For the versions available, see [tags on this repository](https://github.com/projecttacoma/cqm-models/tags).
 
 ## Publish a New Version
-Create a PR for merge to master branch with a Title of "Release x.y.z" where x.y.z is the npm version number and the npm-publish github workflow will be executed.
+Create a PR to merge into the master branch with the title ‘Release x.y.z’, where x.y.z is the npm version number. This will trigger the npm-publish GitHub workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Starting with version **2.0.0** released on 6/20/2019, cqm-models versioning has
 
 For the versions available, see [tags on this repository](https://github.com/projecttacoma/cqm-models/tags).
 
+## Publish a New Version
+Create a PR for merge to master branch with a Title of "Release x.y.z" where x.y.z is the npm version number and the npm-publish github workflow will be executed.
 
 ## License
 

--- a/app/assets/javascripts/basetypes/Any.js
+++ b/app/assets/javascripts/basetypes/Any.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const QDMDate = require('./QDMDate');
 
 function Any(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Any');
@@ -72,7 +73,7 @@ function RecursiveCast(any) {
       return cql.DateTime.fromJSDate(new Date(`1984-01-01T${any}`), 0).getTime();
     }
     // Must be a Date
-    return cql.DateTime.fromJSDate(new Date(any), 0).getDate();
+    return new QDMDate().cast(any);
   }
   return any;
 }

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -3479,6 +3479,7 @@ module.exports.ResultComponent = ResultComponent;
 },{"../basetypes/Any":67,"../basetypes/Code":69,"../basetypes/DateTime":71,"../basetypes/Interval":72,"../basetypes/QDMDate":73,"../basetypes/Quantity":74,"./Component":57,"mongoose/browser":211}],67:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const QDMDate = require('./QDMDate');
 
 function Any(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Any');
@@ -3551,7 +3552,7 @@ function RecursiveCast(any) {
       return cql.DateTime.fromJSDate(new Date(`1984-01-01T${any}`), 0).getTime();
     }
     // Must be a Date
-    return cql.DateTime.fromJSDate(new Date(any), 0).getDate();
+    return new QDMDate().cast(any);
   }
   return any;
 }
@@ -3561,7 +3562,7 @@ Any.prototype.cast = any => RecursiveCast(any);
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;
 
-},{"cql-execution":135,"mongoose/browser":211}],68:[function(require,module,exports){
+},{"./QDMDate":73,"cql-execution":135,"mongoose/browser":211}],68:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { PatientEntity } = require('../attributes/PatientEntity');
 const { Practitioner } = require('../attributes/Practitioner');

--- a/dist/index.js
+++ b/dist/index.js
@@ -3479,6 +3479,7 @@ module.exports.ResultComponent = ResultComponent;
 },{"../basetypes/Any":67,"../basetypes/Code":69,"../basetypes/DateTime":71,"../basetypes/Interval":72,"../basetypes/QDMDate":73,"../basetypes/Quantity":74,"./Component":57,"mongoose/browser":210}],67:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
+const QDMDate = require('./QDMDate');
 
 function Any(key, options) {
   mongoose.SchemaType.call(this, key, options, 'Any');
@@ -3551,7 +3552,7 @@ function RecursiveCast(any) {
       return cql.DateTime.fromJSDate(new Date(`1984-01-01T${any}`), 0).getTime();
     }
     // Must be a Date
-    return cql.DateTime.fromJSDate(new Date(any), 0).getDate();
+    return new QDMDate().cast(any);
   }
   return any;
 }
@@ -3561,7 +3562,7 @@ Any.prototype.cast = any => RecursiveCast(any);
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;
 
-},{"cql-execution":134,"mongoose/browser":210}],68:[function(require,module,exports){
+},{"./QDMDate":73,"cql-execution":134,"mongoose/browser":210}],68:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { PatientEntity } = require('../attributes/PatientEntity');
 const { Practitioner } = require('../attributes/Practitioner');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cqm-models",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cqm-models",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-execution": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "main": "app/assets/javascripts/index.js",
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,6 +2077,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

In order to tackle all instances of Date Field to adhere to previous changes from https://github.com/projecttacoma/cqm-models/pull/219 and have a new constructor name other than just Date, we have to update the baseTypes.Any which accepts Date as a valid Choice Type, and it has to be CqlDate instead of cql.DateTime as there is a conflict with constructor name of Mongoose Date vs Cql-Execution Date Class.

Ticket: https://jira.cms.gov/browse/MAT-7774

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**Bonnie Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
