### PR TITLE
Release 4.2.4 - MAT-8628: Update cqm-models to include calculate_ravs…

### DIFF
--- a/app/assets/javascripts/cqm/Measure.js
+++ b/app/assets/javascripts/cqm/Measure.js
@@ -53,6 +53,7 @@ const MeasureSchema = new mongoose.Schema(
       default: 'PATIENT',
     },
     calculate_sdes: Boolean,
+    calculate_ravs: Boolean,
 
     // ELM/CQL Measure-logic related data encapsulated in CQLLibrarySchema
     // Field name changed from 'cql' to 'cql_libraries' because the semantics of

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -4116,6 +4116,7 @@ const MeasureSchema = new mongoose.Schema(
       default: 'PATIENT',
     },
     calculate_sdes: Boolean,
+    calculate_ravs: Boolean,
 
     // ELM/CQL Measure-logic related data encapsulated in CQLLibrarySchema
     // Field name changed from 'cql' to 'cql_libraries' because the semantics of

--- a/dist/index.js
+++ b/dist/index.js
@@ -4111,6 +4111,7 @@ const MeasureSchema = new mongoose.Schema(
       default: 'PATIENT',
     },
     calculate_sdes: Boolean,
+    calculate_ravs: Boolean,
 
     // ELM/CQL Measure-logic related data encapsulated in CQLLibrarySchema
     // Field name changed from 'cql' to 'cql_libraries' because the semantics of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-models",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "This library contains auto generated Mongo (Mongoose.js) models that correspond to the QDM (Quality Data Model) specification.",
   "license": "ISC",
   "main": "app/assets/javascripts/index.js",


### PR DESCRIPTION
… in Measure.

In cqm-execution, a measure gets converted into a Measure object (https://github.com/projecttacoma/cqm-execution/blob/63e33556881e4d50a7a6e07c410ed573cf16533a/lib/models/calculator.js#L53). `calculate_ravs` controls whether RAV definitions are included in the calculations and highlighting

Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] If applicable, the library version number in `package.json` and `cqm-models.gemspec` has been updated
- [ ] Cqm-execution fixtures have been updated with the update_cqm_execution_fixtures.sh script inside server-scripts using this branch in the cqm-converter

**MADiE Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Cypress Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
